### PR TITLE
Archive player session and challenge data instead of deleting

### DIFF
--- a/src/Gameboard.Api/Data/Entities/ArchivedChallenge.cs
+++ b/src/Gameboard.Api/Data/Entities/ArchivedChallenge.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace Gameboard.Api.Data
+{
+    public class ArchivedChallenge : IEntity
+    {
+        public string Id { get; set; }
+        public string TeamId { get; set; }
+        public string Name { get; set; }
+        public string Tag { get; set; }
+        public string GameId { get; set; }
+        public string GameName { get; set; }
+        public string PlayerId { get; set; }
+        public string PlayerName { get; set; }
+        public string UserId { get; set; }
+        public DateTimeOffset StartTime { get; set; }
+        public DateTimeOffset EndTime { get; set; }
+        public DateTimeOffset LastScoreTime { get; set; }
+        public DateTimeOffset LastSyncTime { get; set; }
+        public bool HasGamespaceDeployed { get; set; }
+        public int Points { get; set; }
+        public int Score { get; set; }
+        public long Duration { get; set; }
+        public ChallengeResult Result { get; set; }
+        public string Events { get; set; }
+        public string Submissions { get; set; }
+        public string TeamMembers { get; set; }
+    }
+}

--- a/src/Gameboard.Api/Data/GameboardDbContext.cs
+++ b/src/Gameboard.Api/Data/GameboardDbContext.cs
@@ -116,6 +116,21 @@ namespace Gameboard.Api.Data
                 b.Property(u => u.GameId).HasMaxLength(40);
             });
 
+            builder.Entity<ArchivedChallenge>(b => {
+                // Archive is snapshot with no foreign keys; explicitly index Id fields for searching
+                b.HasIndex(p => p.TeamId);
+                b.HasIndex(p => p.GameId);
+                b.HasIndex(p => p.PlayerId);
+                b.HasIndex(p => p.UserId);
+                b.Property(u => u.Id).HasMaxLength(40);
+                b.Property(u => u.TeamId).HasMaxLength(40);
+                b.Property(p => p.GameId).HasMaxLength(40);
+                b.Property(p => p.GameName).HasMaxLength(64);
+                b.Property(u => u.PlayerId).HasMaxLength(40);
+                b.Property(p => p.PlayerName).HasMaxLength(64);
+                b.Property(u => u.UserId).HasMaxLength(40);
+            });
+
         }
 
         public DbSet<User> Users { get; set; }
@@ -127,5 +142,6 @@ namespace Gameboard.Api.Data
         public DbSet<ChallengeGate> ChallengeGates { get; set; }
         public DbSet<Sponsor> Sponsors { get; set; }
         public DbSet<Feedback> Feedback { get; set; }
+        public DbSet<ArchivedChallenge> ArchivedChallenges { get; set; }
     }
 }

--- a/src/Gameboard.Api/Data/Migrations/PostgreSQL/GameboardDb/20220427155403_ArchivedChallenge.Designer.cs
+++ b/src/Gameboard.Api/Data/Migrations/PostgreSQL/GameboardDb/20220427155403_ArchivedChallenge.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Gameboard.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
 {
     [DbContext(typeof(GameboardDbContextPostgreSQL))]
-    partial class GameboardDbContextPostgreSQLModelSnapshot : ModelSnapshot
+    [Migration("20220427155403_ArchivedChallenge")]
+    partial class ArchivedChallenge
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Gameboard.Api/Data/Migrations/PostgreSQL/GameboardDb/20220427155403_ArchivedChallenge.cs
+++ b/src/Gameboard.Api/Data/Migrations/PostgreSQL/GameboardDb/20220427155403_ArchivedChallenge.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
+{
+    public partial class ArchivedChallenge : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ArchivedChallenges",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "character varying(40)", maxLength: 40, nullable: false),
+                    TeamId = table.Column<string>(type: "character varying(40)", maxLength: 40, nullable: true),
+                    Name = table.Column<string>(type: "text", nullable: true),
+                    Tag = table.Column<string>(type: "text", nullable: true),
+                    GameId = table.Column<string>(type: "character varying(40)", maxLength: 40, nullable: true),
+                    GameName = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    PlayerId = table.Column<string>(type: "character varying(40)", maxLength: 40, nullable: true),
+                    PlayerName = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    UserId = table.Column<string>(type: "character varying(40)", maxLength: 40, nullable: true),
+                    StartTime = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    EndTime = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    LastScoreTime = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    LastSyncTime = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    HasGamespaceDeployed = table.Column<bool>(type: "boolean", nullable: false),
+                    Points = table.Column<int>(type: "integer", nullable: false),
+                    Score = table.Column<int>(type: "integer", nullable: false),
+                    Duration = table.Column<long>(type: "bigint", nullable: false),
+                    Result = table.Column<int>(type: "integer", nullable: false),
+                    Events = table.Column<string>(type: "text", nullable: true),
+                    Submissions = table.Column<string>(type: "text", nullable: true),
+                    TeamMembers = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ArchivedChallenges", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ArchivedChallenges_GameId",
+                table: "ArchivedChallenges",
+                column: "GameId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ArchivedChallenges_PlayerId",
+                table: "ArchivedChallenges",
+                column: "PlayerId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ArchivedChallenges_TeamId",
+                table: "ArchivedChallenges",
+                column: "TeamId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ArchivedChallenges_UserId",
+                table: "ArchivedChallenges",
+                column: "UserId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ArchivedChallenges");
+        }
+    }
+}

--- a/src/Gameboard.Api/Features/Challenge/Challenge.cs
+++ b/src/Gameboard.Api/Features/Challenge/Challenge.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using TopoMojo.Api.Client;
 
 namespace Gameboard.Api
 {
@@ -35,6 +36,7 @@ namespace Gameboard.Api
         public string GameName { get; set; }
         public string PlayerId { get; set; }
         public string PlayerName { get; set; }
+        public string UserId { get; set; }
         public DateTimeOffset StartTime { get; set; }
         public DateTimeOffset EndTime { get; set; }
         public DateTimeOffset LastScoreTime { get; set; }
@@ -45,6 +47,7 @@ namespace Gameboard.Api
         public long Duration { get; set; }
         public ChallengeResult Result { get; set; }
         public ChallengeEvent[] Events { get; set; }
+        public bool IsActive { get; set; }
     }
 
     public class NewChallenge
@@ -116,6 +119,31 @@ namespace Gameboard.Api
         public string TeamId { get; set; }
         public string VmName { get; set; }
         public DateTimeOffset Timestamp { get; set; }
+    }
 
+    public class ArchivedChallenge
+    {
+        public string Id { get; set; }
+        public string TeamId { get; set; }
+        public string Name { get; set; }
+        public string Tag { get; set; }
+        public string GameId { get; set; }
+        public string GameName { get; set; }
+        public string PlayerId { get; set; }
+        public string PlayerName { get; set; }
+        public string UserId { get; set; }
+        public DateTimeOffset StartTime { get; set; }
+        public DateTimeOffset EndTime { get; set; }
+        public DateTimeOffset LastScoreTime { get; set; }
+        public DateTimeOffset LastSyncTime { get; set; }
+        public bool HasGamespaceDeployed { get; set; }
+        public int Points { get; set; }
+        public int Score { get; set; }
+        public long Duration { get; set; }
+        public ChallengeResult Result { get; set; }
+        public ChallengeEvent[] Events { get; set; }
+        public string[] TeamMembers { get; set; } // User Ids of all team members
+        public bool IsActive { get; set; }
+        public SectionSubmission[] Submissions { get; set; }
     }
 }

--- a/src/Gameboard.Api/Features/Challenge/ChallengeController.cs
+++ b/src/Gameboard.Api/Features/Challenge/ChallengeController.cs
@@ -339,6 +339,22 @@ namespace Gameboard.Api.Controllers
             return await ChallengeService.List(model);
         }
 
+        /// <summary>
+        /// Find archived challenges
+        /// </summary>
+        /// <param name="model"></param>
+        /// <returns></returns>
+        [HttpGet("/api/challenges/archived")]
+        [Authorize]
+        public async Task<ArchivedChallenge[]> ListArchived([FromQuery] SearchFilter model)
+        {
+            AuthorizeAny(
+                () => Actor.IsDirector
+            );
+
+            return await ChallengeService.ListArchived(model);
+        }
+
         private async Task<bool> IsSelf(string playerId)
         {
           return await PlayerService.MapId(playerId) == Actor.Id;

--- a/src/Gameboard.Api/Features/Challenge/ChallengeMapper.cs
+++ b/src/Gameboard.Api/Features/Challenge/ChallengeMapper.cs
@@ -49,9 +49,48 @@ namespace Gameboard.Api.Services
 
             CreateMap<Data.Challenge, ChallengeSummary>()
                 .ForMember(d => d.Score, opt => opt.MapFrom(s => (int)Math.Floor(s.Score)))
+                .ForMember(d => d.UserId, opt => opt.MapFrom(s => s.Player.UserId))
+                .ForMember(d => d.IsActive, opt => opt.MapFrom(s =>
+                    JsonSerializer.Deserialize<TopoMojo.Api.Client.GameState>(s.State, JsonOptions).IsActive)
+                )
             ;
 
             CreateMap<Data.ChallengeEvent, ChallengeEvent>()
+            ;
+
+            CreateMap<Data.Challenge, ArchivedChallenge>()
+                .ForMember(d => d.PlayerName, opt => opt.MapFrom(s => s.Player.ApprovedName))
+                .ForMember(d => d.GameName, opt => opt.MapFrom(s => s.Game.Name))
+                .ForMember(d => d.UserId, opt => opt.MapFrom(s => s.Player.UserId))
+                .ForMember(d => d.Score, opt => opt.MapFrom(s => (int)Math.Floor(s.Score)))
+                .ForMember(d => d.IsActive, opt => opt.MapFrom(s =>
+                    JsonSerializer.Deserialize<TopoMojo.Api.Client.GameState>(s.State, JsonOptions).IsActive)
+                )
+            ;
+
+            // Squash arrays of challenge events, submissions, and team members into a single record
+            CreateMap<ArchivedChallenge, Data.ArchivedChallenge>()
+                .ForMember(d => d.Events, opt => opt.MapFrom(s =>
+                    JsonSerializer.Serialize(s.Events, JsonOptions))
+                )
+                .ForMember(d => d.Submissions, opt => opt.MapFrom(s =>
+                    JsonSerializer.Serialize(s.Submissions, JsonOptions))
+                )
+                .ForMember(d => d.TeamMembers, opt => opt.MapFrom(s =>
+                    JsonSerializer.Serialize(s.TeamMembers, JsonOptions))
+                )
+            ;
+
+            CreateMap<Data.ArchivedChallenge, ArchivedChallenge>()
+                .ForMember(d => d.Events, opt => opt.MapFrom(s =>
+                    JsonSerializer.Deserialize<ChallengeEvent[]>(s.Events, JsonOptions))
+                )
+                .ForMember(d => d.Submissions, opt => opt.MapFrom(s =>
+                    JsonSerializer.Deserialize<TopoMojo.Api.Client.SectionSubmission[]>(s.Submissions, JsonOptions))
+                )
+                .ForMember(d => d.TeamMembers, opt => opt.MapFrom(s =>
+                    JsonSerializer.Deserialize<string[]>(s.TeamMembers, JsonOptions))
+                )
             ;
 
             CreateMap<TopoMojo.Api.Client.VmConsole, ConsoleSummary>()

--- a/src/Gameboard.Api/Features/Challenge/ChallengeService.cs
+++ b/src/Gameboard.Api/Features/Challenge/ChallengeService.cs
@@ -206,6 +206,32 @@ namespace Gameboard.Api.Services
             return await Mapper.ProjectTo<ChallengeSummary>(q).ToArrayAsync();
         }
 
+        public async Task<ArchivedChallenge[]> ListArchived(SearchFilter model)
+        { 
+            var q = Store.DbContext.ArchivedChallenges.AsQueryable();
+            
+            if (model.Term.NotEmpty())
+            {
+                var term = model.Term.ToLower();
+                q = q.Where(c =>
+                    c.Id.StartsWith(term) || // Challenge Id
+                    c.Tag.ToLower().StartsWith(term) || // Challenge Tag
+                    c.UserId.StartsWith(term) || // User Id
+                    c.Name.ToLower().Contains(term) || // Challenge Title
+                    c.PlayerName.ToLower().Contains(term) // Team Name (or indiv. Player Name)
+                );
+            }
+    
+            q = q.OrderByDescending(p => p.LastSyncTime);
+
+            q = q.Skip(model.Skip);
+
+            if (model.Take > 0)
+                q = q.Take(model.Take);
+
+            return await Mapper.ProjectTo<ArchivedChallenge>(q).ToArrayAsync();
+        }
+
         public async Task<Challenge> Preview(NewChallenge model)
         {
             var entity = await Store.Load(model);

--- a/src/Gameboard.Api/Features/Challenge/ChallengeStore.cs
+++ b/src/Gameboard.Api/Features/Challenge/ChallengeStore.cs
@@ -19,12 +19,20 @@ namespace Gameboard.Api.Data
 
         public override IQueryable<Challenge> List(string term)
         {
-            var q = term.NotEmpty()
-                ? base.List().Where(c =>
-                    c.Id.StartsWith(term) ||
-                    c.Tag.StartsWith(term))
-                : base.List()
-            ;
+            var q = base.List();
+
+            if (term.NotEmpty())
+            {
+                term = term.ToLower();
+                q = q.Include(c => c.Player);
+                q = q.Where(c =>
+                    c.Id.StartsWith(term) || // Challenge Id
+                    c.Tag.ToLower().StartsWith(term) || // Challenge Tag
+                    c.Player.UserId.StartsWith(term) || // User Id
+                    c.Name.ToLower().Contains(term) || // Challenge Title
+                    c.Player.ApprovedName.ToLower().Contains(term) // Team Name (or indiv. Player Name)
+                );
+            }
 
             return q
                 .Include(c => c.Game)


### PR DESCRIPTION
Corresponding UI changes: 

- New table `ArchivedChallenges` that stores copied data from `Players`, `Challenges`, and `ChallengeEvents` plus submission data from TopoMojo 
- Logic during session reset to copy data to new table right before a player record is deleted and cascade deletes other entities  
- New endpoint to query archived challenges
- Changes to challenges query for better searching 

This will prevent losing all record of players completing challenges and then resetting their session. It also enhances the searching for challenges and adds searching for the new archived challenges. 