### PR TITLE
Enhancements to observe by players and teams with user consoles 

### DIFF
--- a/src/Gameboard.Api/Features/Challenge/Challenge.cs
+++ b/src/Gameboard.Api/Features/Challenge/Challenge.cs
@@ -80,6 +80,7 @@ namespace Gameboard.Api
         public string Id { get; set; }
         public string TeamId { get; set; }
         public string Name { get; set; }
+        public string Tag { get; set; }
         public string PlayerId { get; set; }
         public string PlayerName { get; set; } 
         public long Duration { get; set; }

--- a/src/Gameboard.Api/Features/Challenge/Challenge.cs
+++ b/src/Gameboard.Api/Features/Challenge/Challenge.cs
@@ -75,6 +75,30 @@ namespace Gameboard.Api
         public ChallengeEvent[] Events { get; set; }
     }
 
+    public class ObserveChallenge
+    {
+        public string Id { get; set; }
+        public string TeamId { get; set; }
+        public string Name { get; set; }
+        public string PlayerId { get; set; }
+        public string PlayerName { get; set; } 
+        public long Duration { get; set; }
+        public int ChallengeScore { get; set; }
+        public int GameScore { get; set; }
+        public int GameRank { get; set; }
+        public bool isActive { get; set; }
+        public ObserveVM[] Consoles { get; set; }
+    }
+
+    public class ObserveVM
+    {
+      public string Id { get; set; }
+      public string Name { get; set; }
+      public string ChallengeId { get; set; }
+      public bool IsRunning { get; set; }
+      public bool IsVisible { get; set; }
+    }
+
     public class ConsoleRequest
     {
       public string Name { get; set; }

--- a/src/Gameboard.Api/Features/Challenge/ChallengeController.cs
+++ b/src/Gameboard.Api/Features/Challenge/ChallengeController.cs
@@ -287,7 +287,7 @@ namespace Gameboard.Api.Controllers
 
             if (isTeamMember)
                 ActorMap.Update(
-                    await ChallengeService.SetConsoleActor(model, Actor.Id, Actor.Name)
+                    await ChallengeService.SetConsoleActor(model, Actor.Id, Actor.ApprovedName)
                 );
 
             return result;
@@ -320,18 +320,29 @@ namespace Gameboard.Api.Controllers
               () => Actor.IsDirector,
               () => Actor.IsObserver
             );
-            return await ChallengeService.GetPlayerConsoles(gid);
+            return await ChallengeService.GetChallengeConsoles(gid);
         }
 
         [HttpGet("/api/challenge/consoleactors")]
         [Authorize]
-        public Dictionary<string, List<string>> GetConsoleActors([FromQuery]string gid)
+        public ConsoleActor[] GetConsoleActors([FromQuery]string gid)
         {
             AuthorizeAny(
               () => Actor.IsDirector,
               () => Actor.IsObserver
             );
             return ChallengeService.GetConsoleActors(gid);
+        }
+
+        [HttpGet("/api/challenge/consoleactor")]
+        [Authorize(AppConstants.ConsolePolicy)]
+        public ConsoleActor GetConsoleActor([FromQuery]string uid)
+        {
+            AuthorizeAny(
+              () => Actor.IsDirector,
+              () => Actor.IsObserver
+            );
+            return ChallengeService.GetConsoleActor(uid);
         }
 
         /// <summary>

--- a/src/Gameboard.Api/Features/Challenge/ChallengeController.cs
+++ b/src/Gameboard.Api/Features/Challenge/ChallengeController.cs
@@ -12,6 +12,7 @@ using TopoMojo.Api.Client;
 using Gameboard.Api.Validators;
 using Microsoft.AspNetCore.SignalR;
 using Gameboard.Api.Hubs;
+using System.Collections.Generic;
 
 namespace Gameboard.Api.Controllers
 {
@@ -313,14 +314,24 @@ namespace Gameboard.Api.Controllers
 
         [HttpGet("/api/challenge/consoles")]
         [Authorize]
-        public ConsoleActor[] FindConsoles([FromQuery]string gid)
+        public async Task<List<ObserveChallenge>> FindConsoles([FromQuery]string gid)
         {
             AuthorizeAny(
               () => Actor.IsDirector,
               () => Actor.IsObserver
             );
+            return await ChallengeService.GetPlayerConsoles(gid);
+        }
 
-            return ActorMap.Find(gid);
+        [HttpGet("/api/challenge/consoleactors")]
+        [Authorize]
+        public Dictionary<string, List<string>> GetConsoleActors([FromQuery]string gid)
+        {
+            AuthorizeAny(
+              () => Actor.IsDirector,
+              () => Actor.IsObserver
+            );
+            return ChallengeService.GetConsoleActors(gid);
         }
 
         /// <summary>

--- a/src/Gameboard.Api/Features/Challenge/ChallengeMapper.cs
+++ b/src/Gameboard.Api/Features/Challenge/ChallengeMapper.cs
@@ -92,6 +92,22 @@ namespace Gameboard.Api.Services
                     JsonSerializer.Deserialize<string[]>(s.TeamMembers, JsonOptions))
                 )
             ;
+            
+            CreateMap<Data.Challenge, ObserveChallenge>()
+                .ForMember(d => d.GameRank, opt => opt.MapFrom(s => s.Player.Rank))
+                .ForMember(d => d.GameScore, opt => opt.MapFrom(s => s.Player.Score))
+                .ForMember(d => d.ChallengeScore, opt => opt.MapFrom(s => (int)Math.Floor(s.Score)))
+                .ForMember(d => d.Consoles, opt => opt.MapFrom(s =>
+                    JsonSerializer.Deserialize<TopoMojo.Api.Client.GameState>(s.State, JsonOptions).Vms)
+                )
+                .ForMember(d => d.isActive, opt => opt.MapFrom(s =>
+                    JsonSerializer.Deserialize<TopoMojo.Api.Client.GameState>(s.State, JsonOptions).IsActive)
+                )
+            ;
+
+            CreateMap<TopoMojo.Api.Client.VmState, ObserveVM>()
+                 .ForMember(d => d.ChallengeId, opt => opt.MapFrom(s => s.IsolationId))
+            ;
 
             CreateMap<TopoMojo.Api.Client.VmConsole, ConsoleSummary>()
                 .ForMember(d => d.SessionId, opt => opt.MapFrom(s => s.IsolationId))

--- a/src/Gameboard.Api/Features/Challenge/ChallengeService.cs
+++ b/src/Gameboard.Api/Features/Challenge/ChallengeService.cs
@@ -448,7 +448,7 @@ namespace Gameboard.Api.Services
             throw new InvalidConsoleAction();
         }
 
-        public async Task<List<ObserveChallenge>> GetPlayerConsoles(string gameId)
+        public async Task<List<ObserveChallenge>> GetChallengeConsoles(string gameId)
         {
             var q = Store.DbContext.Challenges
                 .Where(c => c.GameId == gameId &&
@@ -468,9 +468,14 @@ namespace Gameboard.Api.Services
             return result;
         }
 
-        public Dictionary<string, List<string>> GetConsoleActors(string gameId)
+        public ConsoleActor[] GetConsoleActors(string gameId)
         {
-            return _actorMap.ReverseLookup(gameId);
+            return _actorMap.Find(gameId);
+        }
+
+        public ConsoleActor GetConsoleActor(string userId)
+        {
+            return _actorMap.FindActor(userId);
         }
 
         public async Task<string> ResolveApiKey(string key)

--- a/src/Gameboard.Api/Features/Challenge/ChallengeService.cs
+++ b/src/Gameboard.Api/Features/Challenge/ChallengeService.cs
@@ -448,6 +448,31 @@ namespace Gameboard.Api.Services
             throw new InvalidConsoleAction();
         }
 
+        public async Task<List<ObserveChallenge>> GetPlayerConsoles(string gameId)
+        {
+            var q = Store.DbContext.Challenges
+                .Where(c => c.GameId == gameId &&
+                    c.HasDeployedGamespace)
+                .Include(c => c.Player)
+                .OrderBy(c => c.Player.Name)
+                .ThenBy(c => c.Name);
+            var challenges = Mapper.Map<ObserveChallenge[]>(await q.ToArrayAsync());
+            var result = new List<ObserveChallenge>();
+            foreach (var challenge in challenges.Where(c => c.isActive))
+            {
+                challenge.Consoles = challenge.Consoles
+                    .Where(v => v.IsVisible)
+                    .ToArray();
+                result.Add(challenge);
+            }
+            return result;
+        }
+
+        public Dictionary<string, List<string>> GetConsoleActors(string gameId)
+        {
+            return _actorMap.ReverseLookup(gameId);
+        }
+
         public async Task<string> ResolveApiKey(string key)
         {
             if (key.IsEmpty())

--- a/src/Gameboard.Api/Features/Challenge/ConsoleActorMap.cs
+++ b/src/Gameboard.Api/Features/Challenge/ConsoleActorMap.cs
@@ -51,12 +51,7 @@ namespace Gameboard.Api.Services
                 : _cache.Values
             ;
 
-            return q
-                .OrderBy(a => a.GameId)
-                .ThenBy(a => a.PlayerName)
-                .ThenBy(a => a.UserName)
-                .ToArray()
-            ;
+            return q.ToArray();
         }
 
         public Dictionary<string, List<string>> ReverseLookup(string gid)
@@ -72,6 +67,11 @@ namespace Gameboard.Api.Services
                     vmToActor.Add(key, new List<string>{a.UserName});
             }
             return vmToActor;
+        }
+
+        public ConsoleActor FindActor(string uid)
+        {
+            return _cache.GetValueOrDefault(uid, null);
         }
 
         public void Prune()

--- a/src/Gameboard.Api/Features/Challenge/ConsoleActorMap.cs
+++ b/src/Gameboard.Api/Features/Challenge/ConsoleActorMap.cs
@@ -59,6 +59,21 @@ namespace Gameboard.Api.Services
             ;
         }
 
+        public Dictionary<string, List<string>> ReverseLookup(string gid)
+        {
+            var actorMap = _cache.Values.Where(a => a.GameId == gid).ToArray();
+            var vmToActor = new Dictionary<string, List<string>>();
+            foreach (var a in actorMap)
+            {
+                string key = $"{a.ChallengeId}#{a.VmName}";
+                if (vmToActor.ContainsKey(key))
+                    vmToActor[key].Add(a.UserName);
+                else 
+                    vmToActor.Add(key, new List<string>{a.UserName});
+            }
+            return vmToActor;
+        }
+
         public void Prune()
         {
             var ts = DateTimeOffset.UtcNow.AddHours(-4);

--- a/src/Gameboard.Api/Features/Player/Player.cs
+++ b/src/Gameboard.Api/Features/Player/Player.cs
@@ -105,6 +105,7 @@ namespace Gameboard.Api
     public class Team
     {
         public string TeamId { get; set; }
+        public string ApprovedName { get; set; }
         public string GameId { get; set; }
         public string Sponsor { get; set; }
         public DateTimeOffset SessionBegin { get; set; }

--- a/src/Gameboard.Api/Features/Player/Player.cs
+++ b/src/Gameboard.Api/Features/Player/Player.cs
@@ -141,6 +141,7 @@ namespace Gameboard.Api
         public const string NameDisallowedFilter = "disallowed";
         public const string SortRank = "rank";
         public const string SortTime = "time";
+        public const string SortName = "name";
         public string tid { get; set; }
         public string gid { get; set; }
         public string uid { get; set; }
@@ -159,6 +160,7 @@ namespace Gameboard.Api
         public bool WantsDisallowed => Filter.Contains(NameDisallowedFilter);
         public bool WantsSortByTime => Sort == SortTime;
         public bool WantsSortByRank => Sort == SortRank || string.IsNullOrEmpty(Sort);
+        public bool WantsSortByName => Sort == SortName;
     }
 
     public class BoardPlayer

--- a/src/Gameboard.Api/Features/Player/PlayerController.cs
+++ b/src/Gameboard.Api/Features/Player/PlayerController.cs
@@ -234,6 +234,23 @@ namespace Gameboard.Api.Controllers
         }
 
         /// <summary>
+        /// Get a Game's Teams with Members
+        /// </summary>
+        /// <param name="id">Game Id</param>
+        /// <returns>Team[]</returns>
+        [HttpGet("/api/teams/observe/{id}")]
+        [Authorize]
+        public async Task<Team[]> ObserveTeams([FromRoute] string id)
+        {
+            AuthorizeAny(
+                () => Actor.IsDirector,
+                () => Actor.IsObserver
+            );
+
+            return await PlayerService.ObserveTeams(id);
+        }
+
+        /// <summary>
         /// Get Player Team
         /// </summary>
         /// <param name="id">player id</param>

--- a/src/Gameboard.Api/Features/Player/PlayerService.cs
+++ b/src/Gameboard.Api/Features/Player/PlayerService.cs
@@ -409,6 +409,10 @@ namespace Gameboard.Api.Services
 
             if (model.WantsSortByTime)
                 q = q.OrderByDescending(p => p.SessionBegin);
+            
+            if (model.WantsSortByName)
+                q = q.OrderBy(p => p.ApprovedName)
+                    .ThenBy(p => p.User.ApprovedName);
 
             q = q.Skip(model.Skip);
 

--- a/src/Gameboard.Api/Features/Player/PlayerService.cs
+++ b/src/Gameboard.Api/Features/Player/PlayerService.cs
@@ -557,6 +557,44 @@ namespace Gameboard.Api.Services
 
         }
 
+        public async Task<Team[]> ObserveTeams(string id)
+        {
+            var players = await Store.List()
+                .Where(p => p.GameId == id)
+                .Include(p => p.User)
+                .ToArrayAsync()
+            ;
+
+            var teams = players
+                .Where(p => p.IsLive)
+                .GroupBy(p => p.TeamId)
+                .Select(g => new Team {
+                    TeamId = g.Key,
+                    ApprovedName = g.First().ApprovedName,
+                    Sponsor = g.First().Sponsor,
+                    GameId = g.First().GameId,
+                    SessionBegin = g.First().SessionBegin,
+                    SessionEnd = g.First().SessionEnd,
+                    Rank = g.First().Rank,
+                    Score = g.First().Score,
+                    Time = g.First().Time,
+                    CorrectCount = g.First().CorrectCount,
+                    PartialCount = g.First().PartialCount,
+                    Advanced = g.First().Advanced,
+                    Members = g.Select(i => new TeamMember{
+                        Id = i.UserId,
+                        ApprovedName = i.User.ApprovedName,
+                        Role = i.Role
+                    }).OrderBy(t => t.ApprovedName).ToArray()
+                })
+                .OrderBy(g => g.ApprovedName)
+                .ToArray()
+            ;
+
+            return teams;
+
+        }
+
         public async Task AdvanceTeams(TeamAdvancement model)
         {
             var game = await GameStore.Retrieve(model.NextGameId);

--- a/src/Gameboard.Api/Features/User/UserClaimTransformation.cs
+++ b/src/Gameboard.Api/Features/User/UserClaimTransformation.cs
@@ -46,6 +46,7 @@ namespace Gameboard.Api
             var claims = new List<Claim>();
             claims.Add(new Claim(AppConstants.SubjectClaimName, user.Id));
             claims.Add(new Claim(AppConstants.NameClaimName, user.Name ?? ""));
+            claims.Add(new Claim(AppConstants.ApprovedNameClaimName, user.ApprovedName ?? ""));
             claims.Add(new Claim(AppConstants.RoleListClaimName, user.Role.ToString()));
 
             foreach(string role in user.Role.ToString().Replace(" ", "").Split(','))


### PR DESCRIPTION
Corresponding UI changes: https://github.com/cmu-sei/gameboard-ui/pull/27

- Continued use of existing in-memory dictionary to map users to their most recent active console
- Additional endpoints to get user/consoles mappings and full team data

This change adds more functionality to support to "observe by challenge" and "observe by team/player" views in the UI. It also adds more ways to access the information in the user-to-console dictionary.