### PR TITLE
Allow testers to see unpublished games in list

### DIFF
--- a/src/Gameboard.Api/Features/Game/GameController.cs
+++ b/src/Gameboard.Api/Features/Game/GameController.cs
@@ -117,7 +117,7 @@ namespace Gameboard.Api.Controllers
         [AllowAnonymous]
         public async Task<Game[]> List([FromQuery] GameSearchFilter model)
         {
-            return await GameService.List(model, Actor.IsDesigner);
+            return await GameService.List(model, Actor.IsDesigner || Actor.IsTester);
         }
 
         [HttpPost("/api/game/import")]


### PR DESCRIPTION
Small tweak to allow Tester roles, in addition to Designer roles, to view Games that are unpublished and normally don't show up in a list for normal or unauthenticated users.

API-only change. 