### PR TITLE
Save customized HTML templates to generate dynamic certificates

### DIFF
--- a/src/Gameboard.Api/Data/Entities/Game.cs
+++ b/src/Gameboard.Api/Data/Entities/Game.cs
@@ -24,6 +24,7 @@ namespace Gameboard.Api.Data
         public DateTimeOffset GameEnd { get; set; }
         public string GameMarkdown { get; set; }
         public string FeedbackConfig { get; set; }
+        public string CertificateTemplate { get; set; }
         public string RegistrationMarkdown { get; set; }
         public DateTimeOffset RegistrationOpen { get; set; }
         public DateTimeOffset RegistrationClose { get; set; }
@@ -58,6 +59,9 @@ namespace Gameboard.Api.Data
             GameStart != DateTimeOffset.MinValue &&
             GameStart.CompareTo(DateTimeOffset.UtcNow) < 0 &&
             GameEnd.CompareTo(DateTimeOffset.UtcNow) > 0
+        ;
+        [NotMapped] public bool HasEnded =>
+            GameEnd.CompareTo(DateTimeOffset.UtcNow) < 0
         ;
         [NotMapped] public bool RegistrationActive =>
             RegistrationType != GameRegistrationType.None &&

--- a/src/Gameboard.Api/Data/Migrations/PostgreSQL/GameboardDb/20220512142649_CertificateTemplate.Designer.cs
+++ b/src/Gameboard.Api/Data/Migrations/PostgreSQL/GameboardDb/20220512142649_CertificateTemplate.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Gameboard.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
 {
     [DbContext(typeof(GameboardDbContextPostgreSQL))]
-    partial class GameboardDbContextPostgreSQLModelSnapshot : ModelSnapshot
+    [Migration("20220512142649_CertificateTemplate")]
+    partial class CertificateTemplate
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Gameboard.Api/Data/Migrations/PostgreSQL/GameboardDb/20220512142649_CertificateTemplate.cs
+++ b/src/Gameboard.Api/Data/Migrations/PostgreSQL/GameboardDb/20220512142649_CertificateTemplate.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
+{
+    public partial class CertificateTemplate : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "CertificateTemplate",
+                table: "Games",
+                type: "text",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CertificateTemplate",
+                table: "Games");
+        }
+    }
+}

--- a/src/Gameboard.Api/Extensions/DefaultsStartupExtensions.cs
+++ b/src/Gameboard.Api/Extensions/DefaultsStartupExtensions.cs
@@ -16,14 +16,23 @@ namespace Microsoft.Extensions.DependencyInjection
         ) {
             services.AddSingleton<Defaults>(_ => {
                 // if no filename specified, check for presence of 'feedback-template.yaml'
-                var filename = defaults.FeedbackTemplateFile.NotEmpty() ? defaults.FeedbackTemplateFile : "feedback-template.yaml";
-                var file = Path.Combine(contentRootPath, filename);
-                string template = null;
-                if (File.Exists(file))
-                    template = File.ReadAllText(file);
+                var feedbackFilename = defaults.FeedbackTemplateFile.NotEmpty() ? defaults.FeedbackTemplateFile : "feedback-template.yaml";
+                var feedbackFile = Path.Combine(contentRootPath, feedbackFilename);
+                string feedbackTemplate = null;
+                if (File.Exists(feedbackFile))
+                    feedbackTemplate = File.ReadAllText(feedbackFile);
+
+                var certificateFilename = defaults.CertificateTemplateFile.NotEmpty() ? defaults.CertificateTemplateFile : "certificate-template.html";
+                var certificateFile = Path.Combine(contentRootPath, certificateFilename);
+                string certificateTemplate = null;
+                if (File.Exists(certificateFile))
+                    certificateTemplate = File.ReadAllText(certificateFile);
+
                 return new Defaults {
-                    FeedbackTemplate = template,
-                    FeedbackTemplateFile = defaults.FeedbackTemplateFile
+                    FeedbackTemplate = feedbackTemplate,
+                    FeedbackTemplateFile = defaults.FeedbackTemplateFile,
+                    CertificateTemplate = certificateTemplate,
+                    CertificateTemplateFile = defaults.CertificateTemplateFile
                 };
             });
             

--- a/src/Gameboard.Api/Features/Game/Game.cs
+++ b/src/Gameboard.Api/Features/Game/Game.cs
@@ -23,6 +23,7 @@ namespace Gameboard.Api
         public string GameMarkdown { get; set; }
         public string FeedbackConfig { get; set; }
         public GameFeedbackTemplate FeedbackTemplate { get; set; }
+        public string CertificateTemplate { get; set; }
         public string RegistrationMarkdown { get; set; }
         public DateTimeOffset RegistrationOpen { get; set; }
         public DateTimeOffset RegistrationClose { get; set; }
@@ -52,6 +53,7 @@ namespace Gameboard.Api
         public bool RequireTeam { get; set; }
         public bool AllowTeam { get; set; }
         public bool IsLive { get; set; }
+        public bool HasEnded { get; set; }
         public bool RegistrationActive { get; set; }
     }
 

--- a/src/Gameboard.Api/Features/Game/GameService.cs
+++ b/src/Gameboard.Api/Features/Game/GameService.cs
@@ -33,9 +33,13 @@ namespace Gameboard.Api.Services
 
         public async Task<Game> Create(NewGame model)
         {
-            // for "New Game" set feedback template to global default, if defined
-            if (!model.IsClone && Defaults.FeedbackTemplate.NotEmpty())
-                model.FeedbackConfig = Defaults.FeedbackTemplate;
+            // for "New Game" only, set global defaults, if defined
+            if (!model.IsClone)
+            {   if (Defaults.FeedbackTemplate.NotEmpty())
+                    model.FeedbackConfig = Defaults.FeedbackTemplate;
+                if (Defaults.CertificateTemplate.NotEmpty())
+                    model.CertificateTemplate = Defaults.CertificateTemplate;
+            }      
             
             var entity = Mapper.Map<Data.Game>(model);
 

--- a/src/Gameboard.Api/Features/Player/Player.cs
+++ b/src/Gameboard.Api/Features/Player/Player.cs
@@ -211,4 +211,11 @@ namespace Gameboard.Api
         public DateTimeOffset SessionBegin { get; set; }
         public DateTimeOffset SessionEnd { get; set; }
     }
+
+    public class PlayerCertificate 
+    {
+        public Game Game { get; set; }
+        public Player Player { get; set; }
+        public string Html { get; set; }
+    }
 }

--- a/src/Gameboard.Api/Features/Player/PlayerController.cs
+++ b/src/Gameboard.Api/Features/Player/PlayerController.cs
@@ -316,6 +316,35 @@ namespace Gameboard.Api.Controllers
             return await PlayerService.Enlist(model, Actor.IsRegistrar);
         }
 
+        /// <summary>
+        /// Get Player Certificate
+        /// </summary>
+        /// <param name="id">player id</param>
+        /// <returns></returns>
+        [HttpGet("/api/certificate/{id}")]
+        [Authorize]
+        public async Task<PlayerCertificate> GetCertificate([FromRoute] string id)
+        {
+            await Validate(new Entity{ Id = id });
+
+            AuthorizeAny(
+                () => IsSelf(id).Result
+            );
+
+            return await PlayerService.MakeCertificate(id);
+        }
+
+        /// <summary>
+        /// Get List of Player Certificates
+        /// </summary>
+        /// <returns> </returns>
+        [HttpGet("/api/certificates")]
+        [Authorize]
+        public async Task<PlayerCertificate[]> GetCertificates()
+        {
+            return await PlayerService.MakeCertificates(Actor.Id);
+        }
+
         private async Task<bool> IsSelf(string playerId)
         {
           return await PlayerService.MapId(playerId) == Actor.Id;

--- a/src/Gameboard.Api/Structure/AppSettings.cs
+++ b/src/Gameboard.Api/Structure/AppSettings.cs
@@ -144,6 +144,8 @@ namespace Gameboard.Api
     {
         public string FeedbackTemplateFile { get; set; }
         public string FeedbackTemplate { get; set; } = "";
+        public string CertificateTemplateFile { get; set; }
+        public string CertificateTemplate { get; set; } = "";
     }
 
 }

--- a/src/Gameboard.Api/appsettings.conf
+++ b/src/Gameboard.Api/appsettings.conf
@@ -99,8 +99,11 @@
 ## Defaults
 ####################
 
-## Specify a global default template from a yaml file
+## Specify a global default feedback template from a yaml file
 # Defaults__FeedbackTemplateFile = feedback-template.yaml
+
+## Specify a global default certificate template from an html file with only body contents
+# Defaults__CertificateTemplateFile = certificate-template.html
 
 ###################
 ## Example for appsettings.Development.conf


### PR DESCRIPTION
Corresponding UI changes: https://github.com/cmu-sei/gameboard-ui/pull/30

- New database column `CertificateTemplate` on `Games` table to store HTML template as text
- Two new endpoints: for a specific game session `/api/certificate/{id}`, and to list all certificates for a user  `/api/certificates`
- New env var option `Defaults__CertificateTemplateFile` to specify site-wide default certificate template HTML filename to populate new games
- The new db column and optional default html file should only include HTML for inside `<body>...</body>` of the document. This supports storing styles as inline or internal CSS.
- New service functions to handle certificate generation by replacing special keywords in the template like `{{leaderboard_name}}` with dynamic content from the player

The goal is to support a convenient way to create and store HTML designs for each game, so that once a game has completed, a player can view a customized certificate that is specific to the game and their own information. There is an optional app configuration to specify an HTML filename to use as a site default for all new games. 
