### PR TITLE
Minor patches to handle irregular database state

### DIFF
--- a/src/Gameboard.Api/Features/Challenge/ChallengeService.cs
+++ b/src/Gameboard.Api/Features/Challenge/ChallengeService.cs
@@ -196,6 +196,9 @@ namespace Gameboard.Api.Services
         {
             var q = Store.List(model.Term);
 
+            // filter out challenge records with no state used to give starting score to player
+            q = q.Where(p => p.Name != "_initialscore_" && p.State != null);
+
             q = q.OrderByDescending(p => p.LastSyncTime);
 
             q = q.Skip(model.Skip);

--- a/src/Gameboard.Api/Features/Player/PlayerService.cs
+++ b/src/Gameboard.Api/Features/Player/PlayerService.cs
@@ -176,9 +176,10 @@ namespace Gameboard.Api.Services
                     .ToArrayAsync()
                 ;
             }
-            var toArchive = Mapper.Map<ArchivedChallenge[]>(challenges);
-            if (toArchive.Length > 0)
+            
+            if (challenges.Count > 0)
             {
+                var toArchive = Mapper.Map<ArchivedChallenge[]>(challenges);
                 var teamMembers = players.Select(a => a.UserId).ToArray();
                 foreach (var challenge in toArchive)
                 {
@@ -194,6 +195,7 @@ namespace Gameboard.Api.Services
                     challenge.TeamMembers = teamMembers;
                 }
                 Store.DbContext.ArchivedChallenges.AddRange(Mapper.Map<Data.ArchivedChallenge[]>(toArchive));
+                await Store.DbContext.SaveChangesAsync();
             }
 
             // courtesy call; ignore error (gamespace may have already been removed from backend)

--- a/src/Gameboard.Api/Features/Player/PlayerService.cs
+++ b/src/Gameboard.Api/Features/Player/PlayerService.cs
@@ -182,7 +182,15 @@ namespace Gameboard.Api.Services
                 var teamMembers = players.Select(a => a.UserId).ToArray();
                 foreach (var challenge in toArchive)
                 {
-                    challenge.Submissions = (await Mojo.AuditChallengeAsync(challenge.Id)).ToArray();
+                    // gamespace may be deleted in TopoMojo which would cause error and prevent reset
+                    try 
+                    {
+                        challenge.Submissions = (await Mojo.AuditChallengeAsync(challenge.Id)).ToArray();
+                    }  
+                    catch
+                    { 
+                        challenge.Submissions = new SectionSubmission[] {};
+                    }
                     challenge.TeamMembers = teamMembers;
                 }
                 Store.DbContext.ArchivedChallenges.AddRange(Mapper.Map<Data.ArchivedChallenge[]>(toArchive));


### PR DESCRIPTION
API-only change to address 2 minor bugs that were identified recently regarding destroyed TopoMojo gamespaces and `_initialscore_` challenges in the database with no `State` JSON.

Fixes:
1. Safely handle error from TopoMojo API during reset session. If a TopoMojo gamespace is deleted for any reason, there may be errors when Gameboard attempts to contact TopoMojo looking for that specific id. During "Reset Session", it is okay if the Gamespace is no longer there, but it must not fail and prevent the session from being reset. It now catches any errors and puts a default value instead. 
2. Ignore `initialscore` challenges in list function since null `State` may cause errors. When a team advances to another game _with score_ there is a hidden challenge record containing that previous score to be added to the new session score. This challenge record has no `State` JSON and cannot be parsed when trying to access fields from it. These are now filtered out. 