### PR TITLE
Limit unpublished game access to only designer & tester roles

### DIFF
--- a/src/Gameboard.Api/Features/Game/GameController.cs
+++ b/src/Gameboard.Api/Features/Game/GameController.cs
@@ -59,8 +59,9 @@ namespace Gameboard.Api.Controllers
         [AllowAnonymous]
         public async Task<Game> Retrieve([FromRoute] string id)
         {
-            return await GameService.Retrieve(id);
-        }
+            // only designers and testers can retrieve or list unpublished games
+            return await GameService.Retrieve(id, Actor.IsDesigner || Actor.IsTester);
+        } 
 
         [HttpGet("api/game/{id}/specs")]
         [Authorize]

--- a/src/Gameboard.Api/Features/Game/GameService.cs
+++ b/src/Gameboard.Api/Features/Game/GameService.cs
@@ -44,9 +44,12 @@ namespace Gameboard.Api.Services
             return Mapper.Map<Game>(entity);
         }
 
-        public async Task<Game> Retrieve(string id)
+        public async Task<Game> Retrieve(string id, bool accessHidden = true)
         {
-            return Mapper.Map<Game>(await Store.Retrieve(id));
+            var game = await Store.Retrieve(id);
+            if (!accessHidden && !game.IsPublished)
+                throw new ActionForbidden();
+            return Mapper.Map<Game>(game);
         }
 
         public async Task Update(ChangedGame account)


### PR DESCRIPTION
API-only change to throw `ActionForbidden` error when an unauth'd user or user without Designer or Tester status tries to directly retrieve an unpublished game by id. Unpublished games are already filtered out of lists (except for Designer/Tester), but it was possible to view a hidden game page directly by url, if the lengthy game id was somehow discovered.

This minor change adds a check to require either proper user permissions or the game being published to determine whether to return the game object from `/api/game/{id}`.

Related to:
- https://github.com/cmu-sei/Gameboard/pull/34
- https://github.com/cmu-sei/gameboard-ui/pull/31