### PR TITLE
Add game grouping and enhanced game search

### DIFF
--- a/src/Gameboard.Api/Features/Game/Game.cs
+++ b/src/Gameboard.Api/Features/Game/Game.cs
@@ -105,4 +105,11 @@ namespace Gameboard.Api
         public int Available { get; set; }
         public int Reserved { get; set; }
     }
+
+    public class GameGroup
+    {
+        public int Year { get; set; }
+        public int Month { get; set; }
+        public Game[] Games { get; set; }
+    }
 }

--- a/src/Gameboard.Api/Features/Game/GameController.cs
+++ b/src/Gameboard.Api/Features/Game/GameController.cs
@@ -120,6 +120,18 @@ namespace Gameboard.Api.Controllers
             return await GameService.List(model, Actor.IsDesigner || Actor.IsTester);
         }
 
+        /// <summary>
+        /// List games grouped by year and month
+        /// </summary>
+        /// <param name="model"></param>
+        /// <returns></returns>
+        [HttpGet("/api/games/grouped")]
+        [AllowAnonymous]
+        public async Task<GameGroup[]> ListGrouped([FromQuery] GameSearchFilter model)
+        {
+            return await GameService.ListGrouped(model, Actor.IsDesigner || Actor.IsTester);
+        }
+
         [HttpPost("/api/game/import")]
         [Authorize(AppConstants.DesignerPolicy)]
         public async Task<Game> ImportGameSpec([FromBody] GameSpecImport model)

--- a/src/Gameboard.Api/Features/Game/GameService.cs
+++ b/src/Gameboard.Api/Features/Game/GameService.cs
@@ -95,6 +95,48 @@ namespace Gameboard.Api.Services
             return Mapper.Map<Game[]>(await q.ToArrayAsync());
         }
 
+        public async Task<GameGroup[]> ListGrouped(GameSearchFilter model, bool sudo)
+        {
+            DateTimeOffset now = DateTimeOffset.Now;
+
+            var q = Store.List(model.Term);
+
+            if (!sudo)
+                q = q.Where(g => g.IsPublished);
+
+            if (model.WantsPresent)
+                q = q.Where(g => g.GameEnd > now && g.GameStart < now);
+            if (model.WantsFuture)
+                q = q.Where(g => g.GameStart > now);
+            if (model.WantsPast)
+                q = q.Where(g => g.GameEnd < now);
+
+            var games = await q.ToArrayAsync();
+
+            var b = games
+                .GroupBy(g => new 
+                {
+                    g.GameStart.Year,
+                    g.GameStart.Month,
+                })
+                .Select(g => new GameGroup
+                {
+                    Year = g.Key.Year,
+                    Month = g.Key.Month,
+                    Games = g
+                        .OrderBy(c => c.GameStart)
+                        .Select(c =>  Mapper.Map<Game>(c))
+                        .ToArray()
+                });
+            
+            if (model.WantsPast)
+                b = b.OrderByDescending(g => g.Year).ThenByDescending(g => g.Month);
+            else
+                b = b.OrderBy(g => g.Year).ThenBy(g => g.Month);
+
+            return b.ToArray();
+        }
+
         public async Task<ChallengeSpec[]> RetrieveChallenges(string id)
         {
             var entity = await Store.Load(id);

--- a/src/Gameboard.Api/Features/Game/GameStore.cs
+++ b/src/Gameboard.Api/Features/Game/GameStore.cs
@@ -40,7 +40,10 @@ namespace Gameboard.Api.Data
                     t.Track.ToLower().Contains(term) ||
                     t.Division.ToLower().Contains(term) ||
                     t.Competition.ToLower().Contains(term) ||
-                    t.Sponsor.ToLower().Contains(term)
+                    t.Sponsor.ToLower().Contains(term) ||
+                    t.Key.ToLower().Contains(term) ||
+                    t.Mode.ToLower().Contains(term) ||
+                    t.Id.ToLower().StartsWith(term)
                 );
             }
 


### PR DESCRIPTION
Corresponding UI changes: https://github.com/cmu-sei/gameboard-ui/pull/34

Changes:
- New endpoint `/games/grouped` added, similar to endpoint `/games`. Instead of returning `Game[]`, the new endpoint returns `GameGroup[]`. Each game group contains the grouping data (`Month` and `Year`) and records in that group `Game[]`. 
- Search for games by term now supports matching `Key`, `Mode`, and `Id`. This relates to UI changes that utilize searching by term. 