### PR TITLE
Make card text searchable for game list

### DIFF
--- a/src/Gameboard.Api/Features/Game/GameStore.cs
+++ b/src/Gameboard.Api/Features/Game/GameStore.cs
@@ -43,7 +43,10 @@ namespace Gameboard.Api.Data
                     t.Sponsor.ToLower().Contains(term) ||
                     t.Key.ToLower().Contains(term) ||
                     t.Mode.ToLower().Contains(term) ||
-                    t.Id.ToLower().StartsWith(term)
+                    t.Id.ToLower().StartsWith(term) ||
+                    t.CardText1.ToLower().Contains(term) ||
+                    t.CardText2.ToLower().Contains(term) ||
+                    t.CardText3.ToLower().Contains(term)
                 );
             }
 


### PR DESCRIPTION
Corresponding UI changes: https://github.com/cmu-sei/gameboard-ui/pull/36

- Add card text (top, middle, bottom) to be insensitive searchable when listing games