### PR TITLE
Support Tickets

### DIFF
--- a/src/Gameboard.Api/Data/Entities/Challenge.cs
+++ b/src/Gameboard.Api/Data/Entities/Challenge.cs
@@ -42,7 +42,10 @@ namespace Gameboard.Api.Data
         public Game Game { get; set; }
         public Player Player { get; set; }
         public ICollection<ChallengeEvent> Events { get; set; } = new List<ChallengeEvent>();
+
+        // Control delete behavior with relationships
         public ICollection<Feedback> Feedback { get; set; } = new List<Feedback>();
+        public ICollection<Ticket> Tickets { get; set; } = new List<Ticket>();
     }
 
 }

--- a/src/Gameboard.Api/Data/Entities/Player.cs
+++ b/src/Gameboard.Api/Data/Entities/Player.cs
@@ -32,13 +32,16 @@ namespace Gameboard.Api.Data
         public User User { get; set; }
         public Game Game { get; set; }
         public ICollection<Challenge> Challenges { get; set; } = new List<Challenge>();
-        public ICollection<Feedback> Feedback { get; set; } = new List<Feedback>();
         [NotMapped] public bool IsManager => Role == PlayerRole.Manager;
         [NotMapped] public bool IsLive =>
             SessionBegin > DateTimeOffset.MinValue &&
             SessionBegin < DateTimeOffset.UtcNow &&
             SessionEnd > DateTimeOffset.UtcNow
         ;
+
+        // Control delete behavior with relationships
+        public ICollection<Feedback> Feedback { get; set; } = new List<Feedback>();
+        public ICollection<Ticket> Tickets { get; set; } = new List<Ticket>();
     }
 
 }

--- a/src/Gameboard.Api/Data/Entities/Ticket.cs
+++ b/src/Gameboard.Api/Data/Entities/Ticket.cs
@@ -11,25 +11,21 @@ namespace Gameboard.Api.Data
     public class Ticket : IEntity
     {
         public string Id { get; set; } // PK
-        public int Key { get; set; } // 
+        public int Key { get; set; } // Serial
         public string RequesterId { get; set; } // FK of User.Id
         public string AssigneeId { get; set; } // FK of User.Id
         public string CreatorId { get; set; } // FK of User.Id
-        public string ChallengeId { get; set; } // FK of Challenge.Id (optional based on ticket type)
-        public string PlayerId { get; set; } // ____
-        public string TeamId { get; set; } // Reference to Player.TeamId (optional based on ticket type and team game)
-        public string Summary { get; set; } // Limited to size ___
-        public string Description { get; set; } // Text limited to size ____
-        public string Status { get; set; } // String or enum?
-        public string Label { get; set; } // String, space delimited?
+        public string ChallengeId { get; set; } // FK of Challenge.Id (optional based on ticket context)
+        public string PlayerId { get; set; } // Fk of Player.Id (optional based on ticket context)
+        public string TeamId { get; set; } // Reference to Player.TeamId (optional based on ticket context)
+        public string Summary { get; set; } // Limited to size 128
+        public string Description { get; set; }
+        public string Status { get; set; }
+        public string Label { get; set; } // String, space delimited for multiple
         public bool StaffCreated { get; set; }
-        // public bool SelfCreated { get; set; } 
-        // type?
-            // could you infer this based on what FK references were set
-        public DateTimeOffset Created { get; set; } // When CREATED
-        public DateTimeOffset LastUpdated { get; set; } // When updated last
-        public string Attachments { get; set; } // JSON paths to static files
-        
+        public DateTimeOffset Created { get; set; } // Time ticket was created, does not change
+        public DateTimeOffset LastUpdated { get; set; } // Time ticket was last updated including when activity was added for this ticket
+        public string Attachments { get; set; } // JSON array of string filenames for static files behind the support path
         [ForeignKey("RequesterId")]
         public User Requester { get; set; }
         [ForeignKey("AssigneeId")]
@@ -38,8 +34,7 @@ namespace Gameboard.Api.Data
         public User Creator { get; set; }
         public Challenge Challenge { get; set; }
         public Player Player { get; set; }
-
-        // thread of comments and activity like status or assignee changes
+        // Activity is a thread of comments and activity like status or assignee changes
         public ICollection<TicketActivity> Activity { get; set; } = new List<TicketActivity>();
     }
 

--- a/src/Gameboard.Api/Data/Entities/Ticket.cs
+++ b/src/Gameboard.Api/Data/Entities/Ticket.cs
@@ -1,0 +1,46 @@
+// Copyright 2021 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Gameboard.Api.Data
+{
+    public class Ticket : IEntity
+    {
+        public string Id { get; set; } // PK
+        public int Key { get; set; } // 
+        public string RequesterId { get; set; } // FK of User.Id
+        public string AssigneeId { get; set; } // FK of User.Id
+        public string CreatorId { get; set; } // FK of User.Id
+        public string ChallengeId { get; set; } // FK of Challenge.Id (optional based on ticket type)
+        public string PlayerId { get; set; } // ____
+        public string TeamId { get; set; } // Reference to Player.TeamId (optional based on ticket type and team game)
+        public string Summary { get; set; } // Limited to size ___
+        public string Description { get; set; } // Text limited to size ____
+        public string Status { get; set; } // String or enum?
+        public string Label { get; set; } // String, space delimited?
+        public bool StaffCreated { get; set; }
+        // public bool SelfCreated { get; set; } 
+        // type?
+            // could you infer this based on what FK references were set
+        public DateTimeOffset Created { get; set; } // When CREATED
+        public DateTimeOffset LastUpdated { get; set; } // When updated last
+        public string Attachments { get; set; } // JSON paths to static files
+        
+        [ForeignKey("RequesterId")]
+        public User Requester { get; set; }
+        [ForeignKey("AssigneeId")]
+        public User Assignee { get; set; }
+        [ForeignKey("CreatorId")]
+        public User Creator { get; set; }
+        public Challenge Challenge { get; set; }
+        public Player Player { get; set; }
+
+        // thread of comments and activity like status or assignee changes
+        public ICollection<TicketActivity> Activity { get; set; } = new List<TicketActivity>();
+    }
+
+}

--- a/src/Gameboard.Api/Data/Entities/TicketActivity.cs
+++ b/src/Gameboard.Api/Data/Entities/TicketActivity.cs
@@ -16,10 +16,9 @@ namespace Gameboard.Api.Data
         public string AssigneeId { get; set; }
         public string Message { get; set; }
         public string Status { get; set; }
-        public ActivityType Type { get; set; } // string or enum?
+        public ActivityType Type { get; set; }
         public DateTimeOffset Timestamp { get; set; }
-        public string Attachments { get; set; } // JSON paths to static files
-
+        public string Attachments { get; set; }
         public Ticket Ticket { get; set; }
         public User User { get; set; }
         [ForeignKey("AssigneeId")]

--- a/src/Gameboard.Api/Data/Entities/TicketActivity.cs
+++ b/src/Gameboard.Api/Data/Entities/TicketActivity.cs
@@ -1,0 +1,29 @@
+// Copyright 2021 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Gameboard.Api.Data
+{
+    public class TicketActivity  : IEntity
+    {
+        public string Id { get; set; }
+        public string TicketId { get; set; }
+        public string UserId { get; set; }
+        public string AssigneeId { get; set; }
+        public string Message { get; set; }
+        public string Status { get; set; }
+        public ActivityType Type { get; set; } // string or enum?
+        public DateTimeOffset Timestamp { get; set; }
+        public string Attachments { get; set; } // JSON paths to static files
+
+        public Ticket Ticket { get; set; }
+        public User User { get; set; }
+        [ForeignKey("AssigneeId")]
+        public User Assignee { get; set; }
+    }
+
+}

--- a/src/Gameboard.Api/Data/Entities/User.cs
+++ b/src/Gameboard.Api/Data/Entities/User.cs
@@ -18,6 +18,8 @@ namespace Gameboard.Api.Data
         public string Sponsor { get; set; }
         public UserRole Role { get; set; }
         public ICollection<Player> Enrollments { get; set; } = new List<Player>();
+
+        // Control delete behavior with relationships
         public ICollection<Feedback> Feedback { get; set; } = new List<Feedback>();
     }
 

--- a/src/Gameboard.Api/Data/Enumerations.cs
+++ b/src/Gameboard.Api/Data/Enumerations.cs
@@ -10,12 +10,13 @@ namespace Gameboard.Api
     public enum UserRole
     {
         Member =    0,
-        Observer =  0b00000001,
-        Tester =    0b00000010,
-        Designer =  0b00000100,
-        Registrar = 0b00001000,
-        Director =  0b00010000,
-        Admin =     0b00100000
+        Observer =  0b1,
+        Tester =    0b10,
+        Designer =  0b100,
+        Registrar = 0b1000,
+        Director =  0b10000,
+        Admin =     0b100000,
+        Support =   0b1000000
     }
 
     public enum PlayerRole
@@ -44,5 +45,19 @@ namespace Gameboard.Api
         None,
         Partial,
         Success
+    }
+
+    public enum ActivityType
+    {
+        Comment,
+        StatusChange,
+        AssigneeChange
+    }
+
+    public enum TicketStatus
+    {
+        Open,
+        InProgress,
+        Closed
     }
 }

--- a/src/Gameboard.Api/Data/Enumerations.cs
+++ b/src/Gameboard.Api/Data/Enumerations.cs
@@ -54,10 +54,4 @@ namespace Gameboard.Api
         AssigneeChange
     }
 
-    public enum TicketStatus
-    {
-        Open,
-        InProgress,
-        Closed
-    }
 }

--- a/src/Gameboard.Api/Data/GameboardDbContext.cs
+++ b/src/Gameboard.Api/Data/GameboardDbContext.cs
@@ -132,15 +132,26 @@ namespace Gameboard.Api.Data
             });
 
             builder.Entity<Ticket>(b => {
-                // todo - limits and FK constraints
-                b.Property(u => u.AssigneeId).IsRequired(false);
-                // b.Property(u => u.Key).ValueGeneratedOnAdd();
-                b.Property(u => u.Key).UseSerialColumn();
+                b.HasOne(p => p.Challenge).WithMany(u => u.Tickets).OnDelete(DeleteBehavior.SetNull);
+                b.HasOne(p => p.Player).WithMany(u => u.Tickets).OnDelete(DeleteBehavior.SetNull);
+                b.Property(u => u.Id).HasMaxLength(40);
+                b.Property(u => u.CreatorId).HasMaxLength(40);
+                b.Property(u => u.RequesterId).HasMaxLength(40);
+                b.Property(u => u.AssigneeId).HasMaxLength(40);
+                b.Property(u => u.ChallengeId).HasMaxLength(40);
+                b.Property(u => u.PlayerId).HasMaxLength(40);
+                b.Property(u => u.TeamId).HasMaxLength(40);
+                b.Property(u => u.Status).HasMaxLength(64);
+                b.Property(u => u.Key).UseSerialColumn(); // Serial increment by 1
                 b.Property(u => u.Summary).HasMaxLength(128).IsRequired();
             });
 
             builder.Entity<TicketActivity>(b => {
                 b.HasOne(p => p.Ticket).WithMany(u => u.Activity).OnDelete(DeleteBehavior.Cascade);
+                b.Property(u => u.TicketId).HasMaxLength(40);
+                b.Property(u => u.UserId).HasMaxLength(40);
+                b.Property(u => u.AssigneeId).HasMaxLength(40);
+                b.Property(u => u.Status).HasMaxLength(64);
             });
 
 

--- a/src/Gameboard.Api/Data/GameboardDbContext.cs
+++ b/src/Gameboard.Api/Data/GameboardDbContext.cs
@@ -131,6 +131,19 @@ namespace Gameboard.Api.Data
                 b.Property(u => u.UserId).HasMaxLength(40);
             });
 
+            builder.Entity<Ticket>(b => {
+                // todo - limits and FK constraints
+                b.Property(u => u.AssigneeId).IsRequired(false);
+                // b.Property(u => u.Key).ValueGeneratedOnAdd();
+                b.Property(u => u.Key).UseSerialColumn();
+                b.Property(u => u.Summary).HasMaxLength(128).IsRequired();
+            });
+
+            builder.Entity<TicketActivity>(b => {
+                b.HasOne(p => p.Ticket).WithMany(u => u.Activity).OnDelete(DeleteBehavior.Cascade);
+            });
+
+
         }
 
         public DbSet<User> Users { get; set; }
@@ -143,5 +156,7 @@ namespace Gameboard.Api.Data
         public DbSet<Sponsor> Sponsors { get; set; }
         public DbSet<Feedback> Feedback { get; set; }
         public DbSet<ArchivedChallenge> ArchivedChallenges { get; set; }
+        public DbSet<Ticket> Tickets { get; set; }
+        public DbSet<TicketActivity> TicketActivity { get; set; }
     }
 }

--- a/src/Gameboard.Api/Data/Migrations/PostgreSQL/GameboardDb/20220616224044_SupportTickets.Designer.cs
+++ b/src/Gameboard.Api/Data/Migrations/PostgreSQL/GameboardDb/20220616224044_SupportTickets.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Gameboard.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
 {
     [DbContext(typeof(GameboardDbContextPostgreSQL))]
-    partial class GameboardDbContextPostgreSQLModelSnapshot : ModelSnapshot
+    [Migration("20220616224044_SupportTickets")]
+    partial class SupportTickets
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Gameboard.Api/Data/Migrations/PostgreSQL/GameboardDb/20220616224044_SupportTickets.cs
+++ b/src/Gameboard.Api/Data/Migrations/PostgreSQL/GameboardDb/20220616224044_SupportTickets.cs
@@ -1,0 +1,155 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
+{
+    public partial class SupportTickets : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Tickets",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "text", nullable: false),
+                    Key = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.SerialColumn),
+                    RequesterId = table.Column<string>(type: "character varying(40)", nullable: true),
+                    AssigneeId = table.Column<string>(type: "character varying(40)", nullable: true),
+                    CreatorId = table.Column<string>(type: "character varying(40)", nullable: true),
+                    ChallengeId = table.Column<string>(type: "character varying(40)", nullable: true),
+                    PlayerId = table.Column<string>(type: "character varying(40)", nullable: true),
+                    TeamId = table.Column<string>(type: "text", nullable: true),
+                    Summary = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    Description = table.Column<string>(type: "text", nullable: true),
+                    Status = table.Column<string>(type: "text", nullable: true),
+                    Label = table.Column<string>(type: "text", nullable: true),
+                    StaffCreated = table.Column<bool>(type: "boolean", nullable: false),
+                    Created = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    LastUpdated = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    Attachments = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Tickets", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Tickets_Challenges_ChallengeId",
+                        column: x => x.ChallengeId,
+                        principalTable: "Challenges",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_Tickets_Players_PlayerId",
+                        column: x => x.PlayerId,
+                        principalTable: "Players",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_Tickets_Users_AssigneeId",
+                        column: x => x.AssigneeId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_Tickets_Users_CreatorId",
+                        column: x => x.CreatorId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_Tickets_Users_RequesterId",
+                        column: x => x.RequesterId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "TicketActivity",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "text", nullable: false),
+                    TicketId = table.Column<string>(type: "text", nullable: true),
+                    UserId = table.Column<string>(type: "character varying(40)", nullable: true),
+                    AssigneeId = table.Column<string>(type: "character varying(40)", nullable: true),
+                    Message = table.Column<string>(type: "text", nullable: true),
+                    Status = table.Column<string>(type: "text", nullable: true),
+                    Type = table.Column<int>(type: "integer", nullable: false),
+                    Timestamp = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    Attachments = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TicketActivity", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_TicketActivity_Tickets_TicketId",
+                        column: x => x.TicketId,
+                        principalTable: "Tickets",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_TicketActivity_Users_AssigneeId",
+                        column: x => x.AssigneeId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_TicketActivity_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TicketActivity_AssigneeId",
+                table: "TicketActivity",
+                column: "AssigneeId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TicketActivity_TicketId",
+                table: "TicketActivity",
+                column: "TicketId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TicketActivity_UserId",
+                table: "TicketActivity",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Tickets_AssigneeId",
+                table: "Tickets",
+                column: "AssigneeId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Tickets_ChallengeId",
+                table: "Tickets",
+                column: "ChallengeId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Tickets_CreatorId",
+                table: "Tickets",
+                column: "CreatorId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Tickets_PlayerId",
+                table: "Tickets",
+                column: "PlayerId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Tickets_RequesterId",
+                table: "Tickets",
+                column: "RequesterId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "TicketActivity");
+
+            migrationBuilder.DropTable(
+                name: "Tickets");
+        }
+    }
+}

--- a/src/Gameboard.Api/Data/Migrations/PostgreSQL/GameboardDb/20220617182709_SupportTickets.Designer.cs
+++ b/src/Gameboard.Api/Data/Migrations/PostgreSQL/GameboardDb/20220617182709_SupportTickets.Designer.cs
@@ -10,7 +10,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
 {
     [DbContext(typeof(GameboardDbContextPostgreSQL))]
-    [Migration("20220616224044_SupportTickets")]
+    [Migration("20220617182709_SupportTickets")]
     partial class SupportTickets
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -369,6 +369,9 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
                         .HasMaxLength(64)
                         .HasColumnType("character varying(64)");
 
+                    b.Property<string>("CertificateTemplate")
+                        .HasColumnType("text");
+
                     b.Property<string>("Competition")
                         .HasMaxLength(64)
                         .HasColumnType("character varying(64)");
@@ -568,21 +571,25 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
             modelBuilder.Entity("Gameboard.Api.Data.Ticket", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("text");
+                        .HasMaxLength(40)
+                        .HasColumnType("character varying(40)");
 
                     b.Property<string>("AssigneeId")
+                        .HasMaxLength(40)
                         .HasColumnType("character varying(40)");
 
                     b.Property<string>("Attachments")
                         .HasColumnType("text");
 
                     b.Property<string>("ChallengeId")
+                        .HasMaxLength(40)
                         .HasColumnType("character varying(40)");
 
                     b.Property<DateTimeOffset>("Created")
                         .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("CreatorId")
+                        .HasMaxLength(40)
                         .HasColumnType("character varying(40)");
 
                     b.Property<string>("Description")
@@ -600,16 +607,19 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
                         .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("PlayerId")
+                        .HasMaxLength(40)
                         .HasColumnType("character varying(40)");
 
                     b.Property<string>("RequesterId")
+                        .HasMaxLength(40)
                         .HasColumnType("character varying(40)");
 
                     b.Property<bool>("StaffCreated")
                         .HasColumnType("boolean");
 
                     b.Property<string>("Status")
-                        .HasColumnType("text");
+                        .HasMaxLength(64)
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("Summary")
                         .IsRequired()
@@ -617,7 +627,8 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
                         .HasColumnType("character varying(128)");
 
                     b.Property<string>("TeamId")
-                        .HasColumnType("text");
+                        .HasMaxLength(40)
+                        .HasColumnType("character varying(40)");
 
                     b.HasKey("Id");
 
@@ -640,6 +651,7 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
                         .HasColumnType("text");
 
                     b.Property<string>("AssigneeId")
+                        .HasMaxLength(40)
                         .HasColumnType("character varying(40)");
 
                     b.Property<string>("Attachments")
@@ -649,10 +661,12 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
                         .HasColumnType("text");
 
                     b.Property<string>("Status")
-                        .HasColumnType("text");
+                        .HasMaxLength(64)
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("TicketId")
-                        .HasColumnType("text");
+                        .HasMaxLength(40)
+                        .HasColumnType("character varying(40)");
 
                     b.Property<DateTimeOffset>("Timestamp")
                         .HasColumnType("timestamp with time zone");
@@ -661,6 +675,7 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
                         .HasColumnType("integer");
 
                     b.Property<string>("UserId")
+                        .HasMaxLength(40)
                         .HasColumnType("character varying(40)");
 
                     b.HasKey("Id");
@@ -820,16 +835,18 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
                         .HasForeignKey("AssigneeId");
 
                     b.HasOne("Gameboard.Api.Data.Challenge", "Challenge")
-                        .WithMany()
-                        .HasForeignKey("ChallengeId");
+                        .WithMany("Tickets")
+                        .HasForeignKey("ChallengeId")
+                        .OnDelete(DeleteBehavior.SetNull);
 
                     b.HasOne("Gameboard.Api.Data.User", "Creator")
                         .WithMany()
                         .HasForeignKey("CreatorId");
 
                     b.HasOne("Gameboard.Api.Data.Player", "Player")
-                        .WithMany()
-                        .HasForeignKey("PlayerId");
+                        .WithMany("Tickets")
+                        .HasForeignKey("PlayerId")
+                        .OnDelete(DeleteBehavior.SetNull);
 
                     b.HasOne("Gameboard.Api.Data.User", "Requester")
                         .WithMany()
@@ -873,6 +890,8 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
                     b.Navigation("Events");
 
                     b.Navigation("Feedback");
+
+                    b.Navigation("Tickets");
                 });
 
             modelBuilder.Entity("Gameboard.Api.Data.ChallengeSpec", b =>
@@ -898,6 +917,8 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
                     b.Navigation("Challenges");
 
                     b.Navigation("Feedback");
+
+                    b.Navigation("Tickets");
                 });
 
             modelBuilder.Entity("Gameboard.Api.Data.Ticket", b =>

--- a/src/Gameboard.Api/Data/Migrations/PostgreSQL/GameboardDb/20220617182709_SupportTickets.cs
+++ b/src/Gameboard.Api/Data/Migrations/PostgreSQL/GameboardDb/20220617182709_SupportTickets.cs
@@ -12,18 +12,18 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
                 name: "Tickets",
                 columns: table => new
                 {
-                    Id = table.Column<string>(type: "text", nullable: false),
+                    Id = table.Column<string>(type: "character varying(40)", maxLength: 40, nullable: false),
                     Key = table.Column<int>(type: "integer", nullable: false)
                         .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.SerialColumn),
-                    RequesterId = table.Column<string>(type: "character varying(40)", nullable: true),
-                    AssigneeId = table.Column<string>(type: "character varying(40)", nullable: true),
-                    CreatorId = table.Column<string>(type: "character varying(40)", nullable: true),
-                    ChallengeId = table.Column<string>(type: "character varying(40)", nullable: true),
-                    PlayerId = table.Column<string>(type: "character varying(40)", nullable: true),
-                    TeamId = table.Column<string>(type: "text", nullable: true),
+                    RequesterId = table.Column<string>(type: "character varying(40)", maxLength: 40, nullable: true),
+                    AssigneeId = table.Column<string>(type: "character varying(40)", maxLength: 40, nullable: true),
+                    CreatorId = table.Column<string>(type: "character varying(40)", maxLength: 40, nullable: true),
+                    ChallengeId = table.Column<string>(type: "character varying(40)", maxLength: 40, nullable: true),
+                    PlayerId = table.Column<string>(type: "character varying(40)", maxLength: 40, nullable: true),
+                    TeamId = table.Column<string>(type: "character varying(40)", maxLength: 40, nullable: true),
                     Summary = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
                     Description = table.Column<string>(type: "text", nullable: true),
-                    Status = table.Column<string>(type: "text", nullable: true),
+                    Status = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
                     Label = table.Column<string>(type: "text", nullable: true),
                     StaffCreated = table.Column<bool>(type: "boolean", nullable: false),
                     Created = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
@@ -50,19 +50,19 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
                         column: x => x.AssigneeId,
                         principalTable: "Users",
                         principalColumn: "Id",
-                        onDelete: ReferentialAction.SetNull);
+                        onDelete: ReferentialAction.Restrict);
                     table.ForeignKey(
                         name: "FK_Tickets_Users_CreatorId",
                         column: x => x.CreatorId,
                         principalTable: "Users",
                         principalColumn: "Id",
-                        onDelete: ReferentialAction.SetNull);
+                        onDelete: ReferentialAction.Restrict);
                     table.ForeignKey(
                         name: "FK_Tickets_Users_RequesterId",
                         column: x => x.RequesterId,
                         principalTable: "Users",
                         principalColumn: "Id",
-                        onDelete: ReferentialAction.SetNull);
+                        onDelete: ReferentialAction.Restrict);
                 });
 
             migrationBuilder.CreateTable(
@@ -70,11 +70,11 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "text", nullable: false),
-                    TicketId = table.Column<string>(type: "text", nullable: true),
-                    UserId = table.Column<string>(type: "character varying(40)", nullable: true),
-                    AssigneeId = table.Column<string>(type: "character varying(40)", nullable: true),
+                    TicketId = table.Column<string>(type: "character varying(40)", maxLength: 40, nullable: true),
+                    UserId = table.Column<string>(type: "character varying(40)", maxLength: 40, nullable: true),
+                    AssigneeId = table.Column<string>(type: "character varying(40)", maxLength: 40, nullable: true),
                     Message = table.Column<string>(type: "text", nullable: true),
-                    Status = table.Column<string>(type: "text", nullable: true),
+                    Status = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
                     Type = table.Column<int>(type: "integer", nullable: false),
                     Timestamp = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
                     Attachments = table.Column<string>(type: "text", nullable: true)
@@ -93,13 +93,13 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
                         column: x => x.AssigneeId,
                         principalTable: "Users",
                         principalColumn: "Id",
-                        onDelete: ReferentialAction.SetNull);
+                        onDelete: ReferentialAction.Restrict);
                     table.ForeignKey(
                         name: "FK_TicketActivity_Users_UserId",
                         column: x => x.UserId,
                         principalTable: "Users",
                         principalColumn: "Id",
-                        onDelete: ReferentialAction.SetNull);
+                        onDelete: ReferentialAction.Restrict);
                 });
 
             migrationBuilder.CreateIndex(

--- a/src/Gameboard.Api/Data/Migrations/PostgreSQL/GameboardDb/GameboardDbContextPostgreSQLModelSnapshot.cs
+++ b/src/Gameboard.Api/Data/Migrations/PostgreSQL/GameboardDb/GameboardDbContextPostgreSQLModelSnapshot.cs
@@ -569,21 +569,25 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
             modelBuilder.Entity("Gameboard.Api.Data.Ticket", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("text");
+                        .HasMaxLength(40)
+                        .HasColumnType("character varying(40)");
 
                     b.Property<string>("AssigneeId")
+                        .HasMaxLength(40)
                         .HasColumnType("character varying(40)");
 
                     b.Property<string>("Attachments")
                         .HasColumnType("text");
 
                     b.Property<string>("ChallengeId")
+                        .HasMaxLength(40)
                         .HasColumnType("character varying(40)");
 
                     b.Property<DateTimeOffset>("Created")
                         .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("CreatorId")
+                        .HasMaxLength(40)
                         .HasColumnType("character varying(40)");
 
                     b.Property<string>("Description")
@@ -601,16 +605,19 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
                         .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("PlayerId")
+                        .HasMaxLength(40)
                         .HasColumnType("character varying(40)");
 
                     b.Property<string>("RequesterId")
+                        .HasMaxLength(40)
                         .HasColumnType("character varying(40)");
 
                     b.Property<bool>("StaffCreated")
                         .HasColumnType("boolean");
 
                     b.Property<string>("Status")
-                        .HasColumnType("text");
+                        .HasMaxLength(64)
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("Summary")
                         .IsRequired()
@@ -618,7 +625,8 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
                         .HasColumnType("character varying(128)");
 
                     b.Property<string>("TeamId")
-                        .HasColumnType("text");
+                        .HasMaxLength(40)
+                        .HasColumnType("character varying(40)");
 
                     b.HasKey("Id");
 
@@ -641,6 +649,7 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
                         .HasColumnType("text");
 
                     b.Property<string>("AssigneeId")
+                        .HasMaxLength(40)
                         .HasColumnType("character varying(40)");
 
                     b.Property<string>("Attachments")
@@ -650,10 +659,12 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
                         .HasColumnType("text");
 
                     b.Property<string>("Status")
-                        .HasColumnType("text");
+                        .HasMaxLength(64)
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("TicketId")
-                        .HasColumnType("text");
+                        .HasMaxLength(40)
+                        .HasColumnType("character varying(40)");
 
                     b.Property<DateTimeOffset>("Timestamp")
                         .HasColumnType("timestamp with time zone");
@@ -662,6 +673,7 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
                         .HasColumnType("integer");
 
                     b.Property<string>("UserId")
+                        .HasMaxLength(40)
                         .HasColumnType("character varying(40)");
 
                     b.HasKey("Id");
@@ -821,16 +833,18 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
                         .HasForeignKey("AssigneeId");
 
                     b.HasOne("Gameboard.Api.Data.Challenge", "Challenge")
-                        .WithMany()
-                        .HasForeignKey("ChallengeId");
+                        .WithMany("Tickets")
+                        .HasForeignKey("ChallengeId")
+                        .OnDelete(DeleteBehavior.SetNull);
 
                     b.HasOne("Gameboard.Api.Data.User", "Creator")
                         .WithMany()
                         .HasForeignKey("CreatorId");
 
                     b.HasOne("Gameboard.Api.Data.Player", "Player")
-                        .WithMany()
-                        .HasForeignKey("PlayerId");
+                        .WithMany("Tickets")
+                        .HasForeignKey("PlayerId")
+                        .OnDelete(DeleteBehavior.SetNull);
 
                     b.HasOne("Gameboard.Api.Data.User", "Requester")
                         .WithMany()
@@ -874,6 +888,8 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
                     b.Navigation("Events");
 
                     b.Navigation("Feedback");
+
+                    b.Navigation("Tickets");
                 });
 
             modelBuilder.Entity("Gameboard.Api.Data.ChallengeSpec", b =>
@@ -899,6 +915,8 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
                     b.Navigation("Challenges");
 
                     b.Navigation("Feedback");
+
+                    b.Navigation("Tickets");
                 });
 
             modelBuilder.Entity("Gameboard.Api.Data.Ticket", b =>

--- a/src/Gameboard.Api/Features/Challenge/Challenge.cs
+++ b/src/Gameboard.Api/Features/Challenge/Challenge.cs
@@ -75,6 +75,20 @@ namespace Gameboard.Api
         public ChallengeEvent[] Events { get; set; }
     }
 
+    public class ChallengeOverview
+    {
+        public string Id { get; set; }
+        public string TeamId { get; set; }
+        public string GameId { get; set; }
+        public string GameName { get; set; }
+        public string Name { get; set; }
+        public string Tag { get; set; }
+        public int Points { get; set; }
+        public int Score { get; set; }
+        public long Duration { get; set; }
+        public bool AllowTeam { get; set; }
+    }
+
     public class ObserveChallenge
     {
         public string Id { get; set; }
@@ -170,5 +184,13 @@ namespace Gameboard.Api
         public string[] TeamMembers { get; set; } // User Ids of all team members
         public bool IsActive { get; set; }
         public SectionSubmission[] Submissions { get; set; }
+    }
+
+    public class ChallengeSearchFilter: SearchFilter
+    {
+        // public const string PresentFilter = "present";
+        // public bool WantsPresent => Filter.Contains(PresentFilter);
+
+        public string uid { get; set; }
     }
 }

--- a/src/Gameboard.Api/Features/Challenge/Challenge.cs
+++ b/src/Gameboard.Api/Features/Challenge/Challenge.cs
@@ -188,9 +188,6 @@ namespace Gameboard.Api
 
     public class ChallengeSearchFilter: SearchFilter
     {
-        // public const string PresentFilter = "present";
-        // public bool WantsPresent => Filter.Contains(PresentFilter);
-
-        public string uid { get; set; }
+        public string uid { get; set; } // Used to search for all challenges of a user
     }
 }

--- a/src/Gameboard.Api/Features/Challenge/ChallengeController.cs
+++ b/src/Gameboard.Api/Features/Challenge/ChallengeController.cs
@@ -370,12 +370,8 @@ namespace Gameboard.Api.Controllers
         [Authorize]
         public async Task<ChallengeOverview[]> ListByUser([FromQuery] ChallengeSearchFilter model)
         {
-            // AuthorizeAny(
-            //     () => Actor.IsSupport,
-            //     () => Actor.IsObserver,
-            //     () => Actor.Id == id
-            // );
 
+            // if not sudo or not specified, search use Actor.Id as uid in filtering
             if (!(Actor.IsSupport || Actor.IsObserver) || model.uid.IsEmpty())
                 model.uid = Actor.Id;
 

--- a/src/Gameboard.Api/Features/Challenge/ChallengeController.cs
+++ b/src/Gameboard.Api/Features/Challenge/ChallengeController.cs
@@ -362,6 +362,27 @@ namespace Gameboard.Api.Controllers
         }
 
         /// <summary>
+        /// Find challenges by user
+        /// </summary>
+        /// <param name="model"></param>
+        /// <returns></returns>
+        [HttpGet("/api/userchallenges")]
+        [Authorize]
+        public async Task<ChallengeOverview[]> ListByUser([FromQuery] ChallengeSearchFilter model)
+        {
+            // AuthorizeAny(
+            //     () => Actor.IsSupport,
+            //     () => Actor.IsObserver,
+            //     () => Actor.Id == id
+            // );
+
+            if (!(Actor.IsSupport || Actor.IsObserver) || model.uid.IsEmpty())
+                model.uid = Actor.Id;
+
+            return await ChallengeService.ListByUser(model.uid);
+        }
+
+        /// <summary>
         /// Find archived challenges
         /// </summary>
         /// <param name="model"></param>

--- a/src/Gameboard.Api/Features/Challenge/ChallengeMapper.cs
+++ b/src/Gameboard.Api/Features/Challenge/ChallengeMapper.cs
@@ -17,6 +17,12 @@ namespace Gameboard.Api.Services
 
             CreateMap<Data.Challenge, TeamChallenge>();
 
+            CreateMap<Data.Challenge, ChallengeOverview>()
+                .ForMember(d => d.Score, opt => opt.MapFrom(s => (int)Math.Floor(s.Score)))
+                .ForMember(d => d.GameId, opt => opt.MapFrom(s => s.GameId))
+                .ForMember(d => d.AllowTeam, opt => opt.MapFrom(s => s.Game.AllowTeam))
+            ;
+
             CreateMap<Challenge, Data.Challenge>();
 
             CreateMap<NewChallenge, Data.Challenge>();

--- a/src/Gameboard.Api/Features/Challenge/ChallengeService.cs
+++ b/src/Gameboard.Api/Features/Challenge/ChallengeService.cs
@@ -220,11 +220,11 @@ namespace Gameboard.Api.Services
 
             q = q.Where(t => userTeams.Any(i => i == t.TeamId));
 
-            // todo other filtering
+            // Todo other filtering?
 
             q = q.Include(c => c.Player).Include(c => c.Game);
 
-            DateTimeOffset recent = DateTimeOffset.Now.AddDays(-1);
+            DateTimeOffset recent = DateTimeOffset.UtcNow.AddDays(-1);
 
             q = q.Where(c => c.Game.GameEnd > recent);
 

--- a/src/Gameboard.Api/Features/Challenge/ChallengeService.cs
+++ b/src/Gameboard.Api/Features/Challenge/ChallengeService.cs
@@ -206,6 +206,30 @@ namespace Gameboard.Api.Services
             return await Mapper.ProjectTo<ChallengeSummary>(q).ToArrayAsync();
         }
 
+        public async Task<ChallengeOverview[]> ListByUser(string uid)
+        {
+            var q = Store.List(null);
+
+            var userTeams = await Store.DbContext.Players
+                    .Where(p => p.UserId == uid && p.TeamId != null && p.TeamId != "")
+                    .Select(p => p.TeamId)
+                    .ToListAsync();
+
+            q = q.Where(t => userTeams.Any(i => i == t.TeamId));
+
+            // todo other filtering
+
+            q = q.Include(c => c.Player).Include(c => c.Game);
+
+            DateTimeOffset recent = DateTimeOffset.Now.AddDays(-1);
+
+            q = q.Where(c => c.Game.GameEnd > recent);
+
+            q = q.OrderByDescending(p => p.StartTime);
+
+            return await Mapper.ProjectTo<ChallengeOverview>(q).ToArrayAsync();
+        }
+
         public async Task<ArchivedChallenge[]> ListArchived(SearchFilter model)
         { 
             var q = Store.DbContext.ArchivedChallenges.AsQueryable();

--- a/src/Gameboard.Api/Features/Player/Player.cs
+++ b/src/Gameboard.Api/Features/Player/Player.cs
@@ -15,6 +15,7 @@ namespace Gameboard.Api
         public string UserName { get; set; }
         public string UserApprovedName { get; set; }
         public string GameId { get; set; }
+        public string GameName { get; set; }
         public string ApprovedName { get; set; }
         public string Name { get; set; }
         public string NameStatus { get; set; }
@@ -127,6 +128,16 @@ namespace Gameboard.Api
         public string Name { get; set; }
         public string Sponsor { get; set; }
         public string[] Members { get; set; }
+    }
+
+    public class PlayerOverview
+    {
+        public string Id { get; set; }
+        public string TeamId { get; set; }
+        public string GameId { get; set; }
+        public string GameName { get; set; }
+        public string ApprovedName { get; set; }
+    
     }
 
     public class PlayerDataFilter: SearchFilter

--- a/src/Gameboard.Api/Features/Player/Player.cs
+++ b/src/Gameboard.Api/Features/Player/Player.cs
@@ -137,7 +137,6 @@ namespace Gameboard.Api
         public string GameId { get; set; }
         public string GameName { get; set; }
         public string ApprovedName { get; set; }
-    
     }
 
     public class PlayerDataFilter: SearchFilter

--- a/src/Gameboard.Api/Features/Player/PlayerMapper.cs
+++ b/src/Gameboard.Api/Features/Player/PlayerMapper.cs
@@ -22,6 +22,8 @@ namespace Gameboard.Api.Services
 
             CreateMap<Data.Player, TeamPlayer>();
 
+            CreateMap<Data.Player, PlayerOverview>();
+
             CreateMap<Player, TeamPlayer>();
 
             CreateMap<Player, TeamState>();

--- a/src/Gameboard.Api/Features/Player/PlayerService.cs
+++ b/src/Gameboard.Api/Features/Player/PlayerService.cs
@@ -348,12 +348,12 @@ namespace Gameboard.Api.Services
             {
                 q = q.Where(p => p.GameId == model.gid);
 
-                if (model.WantsUser)
-                    q = q.Where(p => p.UserId == model.uid);
-
                 if (model.WantsOrg)
                     q = q.Where(p => p.Sponsor == model.org);
             }
+
+            if (model.WantsUser)
+                q = q.Where(p => p.UserId == model.uid);
 
             if (model.WantsTeam)
                 q = q.Where(p => p.TeamId == model.tid);

--- a/src/Gameboard.Api/Features/Report/ReportController.cs
+++ b/src/Gameboard.Api/Features/Report/ReportController.cs
@@ -23,19 +23,22 @@ namespace Gameboard.Api.Controllers
             ReportService service,
             GameService gameService,
             ChallengeSpecService challengeSpecService,
-            FeedbackService feedbackService
+            FeedbackService feedbackService,
+            TicketService ticketService
         ): base(logger, cache)
         {
             Service = service;
             GameService = gameService;
             FeedbackService = feedbackService;
             ChallengeSpecService = challengeSpecService;
+            TicketService = ticketService;
         }
 
         ReportService Service { get; }
         GameService GameService { get; }
         FeedbackService FeedbackService { get; }
         ChallengeSpecService ChallengeSpecService { get; }
+        TicketService TicketService { get; }
 
         [HttpGet("/api/report/userstats")]
         [Authorize]
@@ -477,6 +480,45 @@ namespace Gameboard.Api.Controllers
             };
 
             return Ok(fullStats);
+        }
+
+        [HttpGet("/api/report/supportdaystats")]
+        [Authorize]
+        public async Task<ActionResult<object[]>> GetTicketVolumeStats([FromQuery] TicketReportFilter model)
+        {
+            AuthorizeAny(
+                () => Actor.IsObserver
+            );
+
+            var tickets = await Service.GetTicketVolume(model);
+
+            return Ok(tickets);
+        }
+
+        [HttpGet("/api/report/supportlabelstats")]
+        [Authorize]
+        public async Task<ActionResult<object[]>> GetTicketLabelStats([FromQuery] TicketReportFilter model)
+        {
+            AuthorizeAny(
+                () => Actor.IsObserver
+            );
+
+            var tickets = await Service.GetTicketLabels(model);
+
+            return Ok(tickets);
+        }
+
+        [HttpGet("/api/report/supportchallengestats")]
+        [Authorize]
+        public async Task<ActionResult<object[]>> GetTicketChallengeStats([FromQuery] TicketReportFilter model)
+        {
+            AuthorizeAny(
+                () => Actor.IsObserver
+            );
+
+            var tickets = await Service.GetTicketChallenges(model);
+
+            return Ok(tickets);
         }
 
     }

--- a/src/Gameboard.Api/Features/Report/ReportController.cs
+++ b/src/Gameboard.Api/Features/Report/ReportController.cs
@@ -484,7 +484,7 @@ namespace Gameboard.Api.Controllers
 
         [HttpGet("/api/report/supportdaystats")]
         [Authorize]
-        public async Task<ActionResult<object[]>> GetTicketVolumeStats([FromQuery] TicketReportFilter model)
+        public async Task<ActionResult<TicketDayGroup[]>> GetTicketVolumeStats([FromQuery] TicketReportFilter model)
         {
             AuthorizeAny(
                 () => Actor.IsObserver
@@ -497,7 +497,7 @@ namespace Gameboard.Api.Controllers
 
         [HttpGet("/api/report/supportlabelstats")]
         [Authorize]
-        public async Task<ActionResult<object[]>> GetTicketLabelStats([FromQuery] TicketReportFilter model)
+        public async Task<ActionResult<TicketLabelGroup[]>> GetTicketLabelStats([FromQuery] TicketReportFilter model)
         {
             AuthorizeAny(
                 () => Actor.IsObserver
@@ -510,7 +510,7 @@ namespace Gameboard.Api.Controllers
 
         [HttpGet("/api/report/supportchallengestats")]
         [Authorize]
-        public async Task<ActionResult<object[]>> GetTicketChallengeStats([FromQuery] TicketReportFilter model)
+        public async Task<ActionResult<TicketChallengeGroup[]>> GetTicketChallengeStats([FromQuery] TicketReportFilter model)
         {
             AuthorizeAny(
                 () => Actor.IsObserver

--- a/src/Gameboard.Api/Features/Ticket/ITicketStore.cs
+++ b/src/Gameboard.Api/Features/Ticket/ITicketStore.cs
@@ -1,0 +1,17 @@
+// Copyright 2021 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace Gameboard.Api.Data.Abstractions
+{
+
+    public interface ITicketStore : IStore<Ticket>
+    {
+        Task<Data.Ticket> Load(string id);
+        Task<Data.Ticket> Load(Api.Ticket model);
+        Task<Data.Ticket> LoadDetails(string id);
+        Task<Data.Ticket> ResolveApiKey(string key);
+    }
+
+}

--- a/src/Gameboard.Api/Features/Ticket/Ticket.cs
+++ b/src/Gameboard.Api/Features/Ticket/Ticket.cs
@@ -8,7 +8,6 @@ using System.Linq;
 
 namespace Gameboard.Api
 {
-    // same as Data.Ticket
     public class Ticket
     {
         public string Id { get; set; } 
@@ -127,12 +126,6 @@ namespace Gameboard.Api
         public UserSummary Assignee { get; set; }
     }
 
-    // public class AttachmentFile
-    // {
-    //     public string Filename { get; set; }
-    //     public string Extension { get; set; }
-    // }
-
     public class UploadFile 
     {
         public string FileName { get; set; }
@@ -164,28 +157,6 @@ namespace Gameboard.Api
 
         public bool WantsAfterStartTime => StartRange != DateTimeOffset.MinValue;
         public bool WantsBeforeEndTime => EndRange != DateTimeOffset.MinValue;
-    }
-
-
-    public class TicketMeta
-    {
-        public string Id { get; set; } 
-        public int Key { get; set; } 
-        public string FullKey { get; set; } 
-        public string RequesterId { get; set; }
-        public string AssigneeId { get; set; }
-        public string CreatorId { get; set; }
-        public string ChallengeId { get; set; }
-        public string TeamId { get; set; }
-        public string Summary { get; set; }
-        public string Description { get; set; }
-        public string Status { get; set; }
-        public string Label { get; set; }
-        public bool SelfCreated { get; set; }
-
-        public DateTimeOffset Created { get; set; }
-        public DateTimeOffset LastUpdated { get; set; }
-        
     }
 
     public class TicketDayGroup

--- a/src/Gameboard.Api/Features/Ticket/Ticket.cs
+++ b/src/Gameboard.Api/Features/Ticket/Ticket.cs
@@ -1,0 +1,214 @@
+// Copyright 2021 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
+using System.Linq;
+
+namespace Gameboard.Api
+{
+    // same as Data.Ticket
+    public class Ticket
+    {
+        public string Id { get; set; } 
+        public int Key { get; set; } 
+        public string FullKey { get; set; }
+        public string RequesterId { get; set; }
+        public string AssigneeId { get; set; }
+        public string CreatorId { get; set; }
+        public string ChallengeId { get; set; }
+        public string PlayerId { get; set; }
+        public string TeamId { get; set; }
+        public string Summary { get; set; }
+        public string Description { get; set; }
+        public string Status { get; set; }
+        public string Label { get; set; }
+        public bool StaffCreated { get; set; }
+
+        public DateTimeOffset Created { get; set; }
+        public DateTimeOffset LastUpdated { get; set; }
+
+        public string[] Attachments { get; set; }
+        
+        public UserSummary Requester { get; set; }
+        public UserSummary Assignee { get; set; }
+        public UserSummary Creator { get; set; }
+        public ChallengeOverview Challenge { get; set; } 
+        public PlayerOverview Player { get; set; }
+
+        public List<TicketActivity> Activity { get; set; } = new List<TicketActivity>();
+    }
+
+    public class TicketSummary
+    {
+        public string Id { get; set; } 
+        public int Key { get; set; } 
+        public string FullKey { get; set; } 
+        public string RequesterId { get; set; }
+        public string AssigneeId { get; set; }
+        public string CreatorId { get; set; }
+        public string ChallengeId { get; set; }
+        public string TeamId { get; set; }
+        public string Summary { get; set; }
+        public string Description { get; set; }
+        public string Status { get; set; }
+        public string Label { get; set; }
+        public bool StaffCreated { get; set; }
+
+        public DateTimeOffset Created { get; set; }
+        public DateTimeOffset LastUpdated { get; set; }
+        
+        public UserSummary Requester { get; set; }
+        public UserSummary Assignee { get; set; }
+        public UserSummary Creator { get; set; }
+        public ChallengeSummary Challenge { get; set; }
+
+    }
+
+    public class SelfTicketSubmission 
+    {
+        public string ChallengeId { get; set; }
+        public string Summary { get; set; }
+        public string Description { get; set; }
+    }
+
+    public class TicketSubmission
+    {
+        public string RequesterId { get; set; }
+        public string AssigneeId { get; set; }
+        public string ChallengeId { get; set; }
+        public string PlayerId { get; set; }
+        public string GameId { get; set; }
+        public string Summary { get; set; }
+        public string Description { get; set; }
+        public string Status { get; set; }
+        public string Label { get; set; }
+    }
+
+    public class SelfNewTicket : SelfTicketSubmission
+    {
+        public List<IFormFile> Uploads { get; set; }
+    }
+
+    public class NewTicket : TicketSubmission
+    {
+        public List<IFormFile> Uploads { get; set; }
+    }
+    
+    public class SelfChangedTicket : SelfTicketSubmission
+    {
+        public string Id { get; set; }
+    }
+
+    public class ChangedTicket : TicketSubmission
+    {
+        public string Id { get; set; }
+    }
+
+    public class NewTicketComment
+    {
+        public string TicketId { get; set; }
+        public string Message { get; set; }
+        public List<IFormFile> Uploads { get; set; }
+    }
+
+    public class TicketActivity
+    {
+        public string Id { get; set; }
+        public string TicketId { get; set; }
+        public string Message { get; set; }
+        public string Status { get; set; }
+        public string AssigneeId { get; set; }
+        public int Type { get; set; }
+        public DateTimeOffset Timestamp { get; set; }
+        public string[] Attachments { get; set; }
+        public UserSummary User { get; set; }
+        public UserSummary Assignee { get; set; }
+    }
+
+    // public class AttachmentFile
+    // {
+    //     public string Filename { get; set; }
+    //     public string Extension { get; set; }
+    // }
+
+    public class UploadFile 
+    {
+        public string FileName { get; set; }
+        public IFormFile File { get; set; }
+    }
+
+    public class TicketSearchFilter: SearchFilter
+    {
+        public const string OpenFilter = "open";
+        public const string InProgressFilter = "in progress";
+        public const string ClosedFilter = "closed";
+        public const string NotClosedFilter = "not closed";
+        public const string AssignedToMeFilter = "assigned to me";
+        public const string UnassignedFilter = "unassigned";
+        public bool WantsOpen => Filter.Contains(OpenFilter);
+        public bool WantsInProgress => Filter.Contains(InProgressFilter);
+        public bool WantsClosed => Filter.Contains(ClosedFilter);
+        public bool WantsNotClosed => Filter.Contains(NotClosedFilter);
+        public bool WantsAssignedToMe => Filter.Contains(AssignedToMeFilter);
+        public bool WantsUnassigned => Filter.Contains(UnassignedFilter);
+    }
+
+    public class TicketReportFilter: SearchFilter
+    {
+        public string GameId { get; set; }
+        public bool WantsGame => !GameId.IsEmpty();
+        public DateTimeOffset StartRange { get; set; }
+        public DateTimeOffset EndRange { get; set; }
+
+        public bool WantsAfterStartTime => StartRange != DateTimeOffset.MinValue;
+        public bool WantsBeforeEndTime => EndRange != DateTimeOffset.MinValue;
+    }
+
+
+    public class TicketMeta
+    {
+        public string Id { get; set; } 
+        public int Key { get; set; } 
+        public string FullKey { get; set; } 
+        public string RequesterId { get; set; }
+        public string AssigneeId { get; set; }
+        public string CreatorId { get; set; }
+        public string ChallengeId { get; set; }
+        public string TeamId { get; set; }
+        public string Summary { get; set; }
+        public string Description { get; set; }
+        public string Status { get; set; }
+        public string Label { get; set; }
+        public bool SelfCreated { get; set; }
+
+        public DateTimeOffset Created { get; set; }
+        public DateTimeOffset LastUpdated { get; set; }
+        
+    }
+
+    public class TicketDayGroup
+    {
+        public string Date { get; set; }
+        public string DayOfWeek { get; set; }
+        public int Count { get; set; }
+        public int Shift1Count { get; set; }
+        public int Shift2Count { get; set; }
+        public int OutsideShiftCount { get; set; }
+    }
+
+    public class TicketLabelGroup
+    {
+        public string Label { get; set; }
+        public int Count { get; set; }
+    }
+
+    public class TicketChallengeGroup
+    {
+        public string ChallengeSpecId { get; set; }
+        public string ChallengeTag { get; set; }
+        public string ChallengeName { get; set; }
+        public int Count { get; set; }
+    }
+}

--- a/src/Gameboard.Api/Features/Ticket/TicketController.cs
+++ b/src/Gameboard.Api/Features/Ticket/TicketController.cs
@@ -82,7 +82,7 @@ namespace Gameboard.Api.Controllers
 
             if (uploads.Count() > 0 && result != null && !result.Id.IsEmpty())
             {
-                string path = BuildPath("tickets", result.Id);
+                string path = BuildPath(result.Id);
                 await WriteUploadFiles(uploads, path);
             }
 
@@ -152,7 +152,7 @@ namespace Gameboard.Api.Controllers
 
             if (uploads.Count() > 0 && result != null && !result.Id.IsEmpty())
             {
-                string path = BuildPath("tickets", result.TicketId, result.Id);
+                string path = BuildPath(result.TicketId, result.Id);
                 await WriteUploadFiles(uploads, path);
             }
 

--- a/src/Gameboard.Api/Features/Ticket/TicketController.cs
+++ b/src/Gameboard.Api/Features/Ticket/TicketController.cs
@@ -52,11 +52,12 @@ namespace Gameboard.Api.Controllers
 
            await Validate(new Entity { Id = id });
 
+            // Once authenticated, authorized, and validated, cache a file permit for this user id & ticket id
             await Cache.SetStringAsync(
                 $"{"file-permit:"}{Actor.Id}:{id}",
                 "true",
                 new DistributedCacheEntryOptions {
-                    AbsoluteExpirationRelativeToNow = new TimeSpan(0, 30, 0)
+                    AbsoluteExpirationRelativeToNow = new TimeSpan(0, 15, 0)
                 }
             );
 
@@ -111,7 +112,7 @@ namespace Gameboard.Api.Controllers
         }
 
         /// <summary>
-        /// Lists feedback based on search params
+        /// Lists tickets based on search params
         /// </summary>
         /// <param name="model"></param>
         /// <returns></returns>
@@ -119,15 +120,8 @@ namespace Gameboard.Api.Controllers
         [Authorize]
         public async Task<TicketSummary[]> List([FromQuery] TicketSearchFilter model)
         {
-            // AuthorizeAny(
-            //     () => Actor.IsObserver
-            // );
-
-            // todo: filter here or new end point for by user or team 
-            TicketSummary[] result = await TicketService.List(model, Actor.Id, Actor.IsSupport || Actor.IsObserver);
-            return result;
+            return await TicketService.List(model, Actor.Id, Actor.IsSupport || Actor.IsObserver);
         }
-
 
         /// <summary>
         /// Create new ticket comment
@@ -174,9 +168,7 @@ namespace Gameboard.Api.Controllers
                 () => Actor.IsObserver
             );
 
-            // todo: filter here or new end point for by user or team 
-            string[] result = await TicketService.ListLabels(model);
-            return result;
+            return await TicketService.ListLabels(model);
         }
 
         private List<UploadFile> GetUploadFiles(List<IFormFile> uploads)
@@ -210,8 +202,6 @@ namespace Gameboard.Api.Controllers
             }
         }
 
-        // private List<UploadedFile> ProcessFilenames
-
         private string BuildPath(params string[] segments)
         {
             string path = Options.SupportUploadsFolder;
@@ -224,16 +214,6 @@ namespace Gameboard.Api.Controllers
 
             return path;
         }
-
-        /*
-        TODO 
-            - add comment with endpoint
-            - admin edit (more fields can be edited)
-            - either indiv enpoints for different functions:
-                - status change
-                - assignee change
-              OR one put endpoint and it would automatically detect change to key fields 
-        */
 
     }
 }

--- a/src/Gameboard.Api/Features/Ticket/TicketController.cs
+++ b/src/Gameboard.Api/Features/Ticket/TicketController.cs
@@ -1,0 +1,239 @@
+// Copyright 2021 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+using Gameboard.Api.Services;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.AspNetCore.Authorization;
+using Gameboard.Api.Validators;
+using Microsoft.AspNetCore.Http;
+using System;
+using System.IO;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace Gameboard.Api.Controllers
+{
+    [Authorize]
+    public class TicketController : _Controller
+    {
+        TicketService TicketService { get; }
+        public CoreOptions Options { get; }
+        
+
+        public TicketController(
+            ILogger<ChallengeController> logger,
+            IDistributedCache cache,
+            TicketValidator validator,
+            CoreOptions options,
+            TicketService ticketService
+        ): base(logger, cache, validator)
+        {
+            TicketService = ticketService;
+            Options = options;
+        }
+
+        /// <summary>
+        /// Gets ticket details
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        [HttpGet("api/ticket/{id}")]
+        [Authorize]
+        public async Task<Ticket> Retrieve([FromRoute] string id)
+        {
+            AuthorizeAny(
+                () => Actor.IsObserver,
+                () => TicketService.IsOwnerOrTeamMember(id, Actor.Id).Result
+            );
+
+           await Validate(new Entity { Id = id });
+
+            await Cache.SetStringAsync(
+                $"{"file-permit:"}{Actor.Id}:{id}",
+                "true",
+                new DistributedCacheEntryOptions {
+                    AbsoluteExpirationRelativeToNow = new TimeSpan(0, 30, 0)
+                }
+            );
+
+            return await TicketService.Retrieve(id, Actor.Id);
+        }
+
+
+        /// <summary>
+        /// Create new ticket
+        /// </summary>
+        /// <param name="model"></param>
+        /// <returns></returns>
+        [HttpPost("/api/ticket")]
+        [Authorize]
+        public async Task<Ticket> Create([FromForm]NewTicket model)
+        {
+
+            await Validate(model);
+
+            List<UploadFile> uploads = GetUploadFiles(model.Uploads);
+
+            var result = await TicketService.Create(model, Actor.Id, Actor.IsSupport, uploads);
+
+            if (uploads.Count() > 0 && result != null && !result.Id.IsEmpty())
+            {
+                string path = BuildPath("tickets", result.Id);
+                await WriteUploadFiles(uploads, path);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Update ticket
+        /// </summary>
+        /// <param name="model"></param>
+        /// <returns></returns>
+        [HttpPut("/api/ticket")]
+        [Authorize]
+        public async Task<Ticket> Update([FromBody]ChangedTicket model)
+        {
+            AuthorizeAny(
+                () => Actor.IsSupport,
+                () => TicketService.UserCanUpdate(model.Id, Actor.Id).Result
+            );
+
+            await Validate(model);
+
+            var result = await TicketService.Update(model, Actor.Id, Actor.IsSupport);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Lists feedback based on search params
+        /// </summary>
+        /// <param name="model"></param>
+        /// <returns></returns>
+        [HttpGet("/api/ticket/list")]
+        [Authorize]
+        public async Task<TicketSummary[]> List([FromQuery] TicketSearchFilter model)
+        {
+            // AuthorizeAny(
+            //     () => Actor.IsObserver
+            // );
+
+            // todo: filter here or new end point for by user or team 
+            TicketSummary[] result = await TicketService.List(model, Actor.Id, Actor.IsSupport || Actor.IsObserver);
+            return result;
+        }
+
+
+        /// <summary>
+        /// Create new ticket comment
+        /// </summary>
+        /// <param name="model"></param>
+        /// <returns></returns>
+        [HttpPost("/api/ticket/comment")]
+        [Authorize]
+        public async Task<TicketActivity> AddComment([FromForm]NewTicketComment model)
+        {
+            AuthorizeAny(
+                () => Actor.IsObserver,
+                () => Actor.IsSupport,
+                () => TicketService.IsOwnerOrTeamMember(model.TicketId, Actor.Id).Result
+            );
+
+            await Validate(model);
+
+            List<UploadFile> uploads = GetUploadFiles(model.Uploads);
+
+            var result = await TicketService.AddComment(model, Actor.Id, uploads);
+
+            if (uploads.Count() > 0 && result != null && !result.Id.IsEmpty())
+            {
+                string path = BuildPath("tickets", result.TicketId, result.Id);
+                await WriteUploadFiles(uploads, path);
+            }
+
+            return result;
+        }
+
+
+        /// <summary>
+        /// Lists all distinct labels
+        /// </summary>
+        /// <param name="model"></param>
+        /// <returns></returns>
+        [HttpGet("/api/ticket/labels")]
+        [Authorize]
+        public async Task<string[]> ListLabels([FromQuery] SearchFilter model)
+        {
+            AuthorizeAny(
+                () => Actor.IsSupport,
+                () => Actor.IsObserver
+            );
+
+            // todo: filter here or new end point for by user or team 
+            string[] result = await TicketService.ListLabels(model);
+            return result;
+        }
+
+        private List<UploadFile> GetUploadFiles(List<IFormFile> uploads)
+        {
+            List<UploadFile> result = new List<UploadFile>();
+            if (uploads != null)
+            {
+                var fileNum = 1;
+                foreach (var upload in uploads)
+                {
+                    string nameOnly = Path.GetFileNameWithoutExtension(upload.FileName).ToLower();
+                    string extension = Path.GetExtension(upload.FileName);
+                    string filename = $"{nameOnly}_{fileNum}{extension}";
+                    var sanitized = filename.SanitizeFilename();
+                    result.Add(new UploadFile{ FileName = sanitized, File = upload});
+                    fileNum += 1;
+                }
+            }
+            return result;
+        }
+
+        private async Task WriteUploadFiles(List<UploadFile> uploads, string path)
+        {
+            foreach (var upload in uploads)
+            {
+                string filePath = Path.Combine(path, upload.FileName);
+                using (var stream = new FileStream(filePath, FileMode.Create))
+                {
+                    await upload.File.CopyToAsync(stream);
+                }
+            }
+        }
+
+        // private List<UploadedFile> ProcessFilenames
+
+        private string BuildPath(params string[] segments)
+        {
+            string path = Options.SupportUploadsFolder;
+
+            foreach (string s in segments)
+                path = Path.Combine(path, s);
+
+            if (!System.IO.Directory.Exists(path) && !System.IO.File.Exists(path))
+                System.IO.Directory.CreateDirectory(path);
+
+            return path;
+        }
+
+        /*
+        TODO 
+            - add comment with endpoint
+            - admin edit (more fields can be edited)
+            - either indiv enpoints for different functions:
+                - status change
+                - assignee change
+              OR one put endpoint and it would automatically detect change to key fields 
+        */
+
+    }
+}

--- a/src/Gameboard.Api/Features/Ticket/TicketMapper.cs
+++ b/src/Gameboard.Api/Features/Ticket/TicketMapper.cs
@@ -1,0 +1,58 @@
+// Copyright 2021 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using AutoMapper;
+
+
+namespace Gameboard.Api.Services
+{
+    public class TicketMapper : Profile
+    {
+        public TicketMapper()
+        {
+            CreateMap<string[], string>()
+                .ConvertUsing(arr => JsonSerializer.Serialize(arr, JsonOptions));
+
+            CreateMap<Data.Ticket, Ticket>()
+                .ForMember(d => d.Attachments, opt => opt.MapFrom(s =>
+                    JsonSerializer.Deserialize<string[]>(s.Attachments, JsonOptions))
+                )
+            ;
+            CreateMap<Ticket, Data.Ticket>();
+            CreateMap<Data.Ticket, TicketSummary>();
+            CreateMap<Data.Ticket, TicketMeta>();
+
+            CreateMap<NewTicket, SelfNewTicket>();
+
+            CreateMap<NewTicket, Data.Ticket>();
+            CreateMap<NewTicket, SelfNewTicket>();
+            CreateMap<SelfNewTicket, Data.Ticket>();
+            CreateMap<ChangedTicket, Data.Ticket>();
+            CreateMap<ChangedTicket, SelfChangedTicket>();
+            CreateMap<SelfChangedTicket, Data.Ticket>();
+
+            CreateMap<Data.TicketActivity, TicketActivity>()
+                .ForMember(d => d.Attachments, opt => opt.MapFrom(s =>
+                    JsonSerializer.Deserialize<string[]>(s.Attachments, JsonOptions))
+                )
+            ;
+
+            JsonOptions = new JsonSerializerOptions
+            {
+                AllowTrailingCommas = true,
+                WriteIndented = true,
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            };
+            JsonOptions.Converters.Add(
+                new JsonStringEnumConverter(JsonNamingPolicy.CamelCase)
+            );
+
+        }
+
+        public JsonSerializerOptions JsonOptions { get; }
+
+    }
+}

--- a/src/Gameboard.Api/Features/Ticket/TicketMapper.cs
+++ b/src/Gameboard.Api/Features/Ticket/TicketMapper.cs
@@ -23,7 +23,6 @@ namespace Gameboard.Api.Services
             ;
             CreateMap<Ticket, Data.Ticket>();
             CreateMap<Data.Ticket, TicketSummary>();
-            CreateMap<Data.Ticket, TicketMeta>();
 
             CreateMap<NewTicket, SelfNewTicket>();
 

--- a/src/Gameboard.Api/Features/Ticket/TicketService.cs
+++ b/src/Gameboard.Api/Features/Ticket/TicketService.cs
@@ -1,0 +1,359 @@
+// Copyright 2021 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AutoMapper;
+using Gameboard.Api.Data.Abstractions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Gameboard.Api.Services
+{
+    public class TicketService : _Service, IApiKeyAuthenticationService
+    {
+        ITicketStore Store { get; }
+
+        private IMemoryCache _localcache;
+
+        public TicketService(
+            ILogger<TicketService> logger,
+            IMapper mapper,
+            CoreOptions options,
+            ITicketStore store,
+            IMemoryCache localcache
+        ) : base(logger, mapper, options)
+        {
+            Store = store;
+            _localcache = localcache;
+        }
+ 
+        public async Task<Ticket> Retrieve(string id, string actorId)
+        {
+            var entity = await Store.LoadDetails(id);
+            entity.Activity = entity.Activity.OrderByDescending(a => a.Timestamp).ToList();
+            return Transform(Mapper.Map<Ticket>(entity));
+        }
+
+       
+        public async Task<Ticket> Create(NewTicket model, string actorId, bool sudo, List<UploadFile> uploads)
+        {
+            Data.Ticket entity;
+            var timestamp = DateTimeOffset.UtcNow;
+            if (sudo) 
+            {
+                entity = Mapper.Map<Data.Ticket>(model);
+                AddActivity(entity, actorId, !entity.Status.IsEmpty(), !entity.AssigneeId.IsEmpty(), timestamp);
+                entity.StaffCreated = true;
+            } 
+            else 
+            {
+                var selfMade = Mapper.Map<SelfNewTicket>(model);
+                entity = Mapper.Map<Data.Ticket>(selfMade);
+                entity.StaffCreated = false;
+            }
+            if (entity.RequesterId.IsEmpty())
+                entity.RequesterId = actorId;
+            if (entity.Status.IsEmpty())
+                entity.Status = "Open";
+
+            if (!entity.PlayerId.IsEmpty() || !entity.ChallengeId.IsEmpty())
+            {
+                await UpdatedSessionContext(entity);
+            }
+            entity.CreatorId = actorId;
+            entity.Created = timestamp;
+            entity.LastUpdated = timestamp;
+
+            if (uploads.Count() > 0) {
+                var filenames = uploads.Select(x => x.FileName).ToArray();
+                 entity.Attachments = Mapper.Map<string>(filenames);
+            }
+
+            await Store.Create(entity);
+
+            return Transform(Mapper.Map<Ticket>(entity));
+        }
+
+        public async Task<Ticket> Update(ChangedTicket model, string actorId, bool sudo)
+        {
+            var entity = await Store.Retrieve(model.Id);
+            var timestamp = DateTimeOffset.UtcNow;
+            if (sudo) // staff with full management capability
+            {
+                var prev = Mapper.Map<Ticket>(entity);
+                model.Label = model.Label?.Trim();
+                Mapper.Map(model, entity);
+                var statusChanged = prev.Status != entity.Status;
+                var assigneeChanged = prev.AssigneeId != entity.AssigneeId;
+                AddActivity(entity, actorId, statusChanged, assigneeChanged, timestamp);
+
+                if (prev.PlayerId != entity.PlayerId || prev.ChallengeId != entity.ChallengeId)
+                {
+                    await UpdatedSessionContext(entity);   
+                }
+            }
+            else // regular participant can only edit a few fields
+            {
+                
+                Mapper.Map(
+                    Mapper.Map<SelfChangedTicket>(model),
+                    entity
+                );
+            }
+            
+            entity.LastUpdated = timestamp;
+            await Store.Update(entity);
+            
+            return Transform(Mapper.Map<Ticket>(entity));
+        }
+
+        public async Task<TicketSummary[]> List(TicketSearchFilter model, string userId, bool sudo)
+        {
+            var q = Store.List(model.Term);
+
+            if (model.WantsOpen)
+                q = q.Where(t => t.Status == "Open");
+            if (model.WantsInProgress)
+                q = q.Where(t => t.Status == "In Progress");
+            if (model.WantsClosed)
+                q = q.Where(t => t.Status == "Closed");
+            if (model.WantsNotClosed)
+                q = q.Where(t => t.Status != "Closed");
+
+            if (model.WantsAssignedToMe)
+                q = q.Where(t => t.AssigneeId == userId);
+            if (model.WantsUnassigned)
+                q = q.Where(t => t.AssigneeId == null || t.AssigneeId == "");
+            
+            if (!sudo) // normal user should only see "their" tickets
+            {
+                var userTeams = await Store.DbContext.Players
+                    .Where(p => p.UserId == userId && p.TeamId != null && p.TeamId != "")
+                    .Select(p => p.TeamId)
+                    .ToListAsync();
+
+                q = q.Where(t => t.RequesterId == userId ||
+                        userTeams.Any(i => i == t.TeamId));
+            }
+
+            q = q.OrderByDescending(t => t.Created);
+
+            q = q.Skip(model.Skip);
+
+            if (model.Take > 0)
+                q = q.Take(model.Take);
+
+            return Transform(await Mapper.ProjectTo<TicketSummary>(q).ToArrayAsync());
+        }
+
+        public async Task<TicketActivity> AddComment(NewTicketComment model, string actorId, List<UploadFile> uploads)
+        {
+            var entity = await Store.Load(model.TicketId);
+            var timestamp = DateTimeOffset.UtcNow;
+            var commentActivity = new Data.TicketActivity
+            {
+                Id = Guid.NewGuid().ToString("n"),
+                UserId = actorId,
+                Message = model.Message,
+                Type = ActivityType.Comment,
+                Timestamp = timestamp
+            };
+
+            if (uploads.Count() > 0) {
+                commentActivity.Attachments = Mapper.Map<string>(uploads.Select(x => x.FileName).ToArray());
+            }
+
+            entity.Activity.Add(Mapper.Map<Data.TicketActivity>(commentActivity));
+            entity.LastUpdated = timestamp;
+            await Store.Update(entity);
+
+            return Mapper.Map<TicketActivity>(commentActivity);
+        }
+
+        public async Task<string[]> ListLabels(SearchFilter model)
+        {
+            var q = Store.List(model.Term);
+
+            var tickets = await Mapper.ProjectTo<TicketSummary>(q).ToArrayAsync();
+
+            // todo, cache???
+            var b = tickets
+                .Where(t => !t.Label.IsEmpty())
+                .SelectMany(t => t.Label.Split(" "))
+                .OrderBy(t => t)
+                .ToHashSet().ToArray();
+
+            return b;
+        }
+
+        public async Task<bool> UserIsEnrolled(string gameId, string userId)
+        {
+            return await Store.DbContext.Users.AnyAsync(u =>
+                u.Id == userId &&
+                u.Enrollments.Any(e => e.GameId == gameId)
+            );
+        }
+
+        public async Task<bool> IsOwnerOrTeamMember(string ticketId, string userId)
+        {
+            var ticket = await Store.Load(ticketId);
+            if (ticket == null)
+                return false;
+            if (ticket.RequesterId == userId)
+                return true;
+            if (ticket.TeamId.IsEmpty())
+                return false;
+            // if team associated with ticket, see if this user has an enrollment with matching teamId
+            return await Store.DbContext.Players.AnyAsync(p => 
+                p.UserId == userId &&
+                p.TeamId == ticket.TeamId);
+        }
+
+        public async Task<bool> IsOwner(string ticketId, string userId)
+        {
+            var ticket = await Store.Load(ticketId);
+            if (ticket == null)
+                return false;
+            if (ticket.RequesterId == userId)
+                return true;
+            return false;
+        }
+
+        public async Task<bool> UserCanUpdate(string ticketId, string userId)
+        {
+            var ticket = await Store.Load(ticketId);
+            if (ticket == null)
+                return false;
+            var updateUntilTime = DateTimeOffset.UtcNow.Add(new TimeSpan(0, -5, 0));
+            if (ticket.RequesterId == userId && ticket.Created > updateUntilTime)
+                return true;
+            return false;
+        }
+
+        public async Task<string> ResolveApiKey(string key)
+        {
+            if (key.IsEmpty())
+                return null;
+
+            var entity = await Store.ResolveApiKey(key.ToSha256());
+
+            return entity?.Id;
+        }
+
+        private async Task UpdatedSessionContext(Data.Ticket entity)
+        {
+            if (!entity.ChallengeId.IsEmpty())
+            {
+                var challenge = await Store.DbContext.Challenges.FirstOrDefaultAsync(c =>
+                    c.Id == entity.ChallengeId
+                );
+                if (challenge != null)
+                {
+                    entity.TeamId = challenge.TeamId;
+                    entity.PlayerId = challenge.PlayerId;
+                    return;
+                }
+            }
+            else if (!entity.PlayerId.IsEmpty())
+            {
+                var player = await Store.DbContext.Players.FirstOrDefaultAsync(c =>
+                    c.Id == entity.PlayerId
+                );
+                if (player != null)
+                {
+                    entity.TeamId = player.TeamId;
+                    entity.ChallengeId = null;
+                    return;
+                }
+            }
+
+            entity.TeamId = null;
+            entity.ChallengeId = null;
+            entity.PlayerId = null;
+        }
+
+        // private async Task UpdatedPlayer(Data.Ticket entity)
+        // {
+        //     var player = await Store.DbContext.Players.FirstOrDefaultAsync(c =>
+        //         c.Id == entity.PlayerId
+        //     );
+        //     if (player != null)
+        //     {
+        //         entity.TeamId = player.TeamId;
+        //         entity.PlayerId = player.Id;
+        //     }
+        //     else    
+        //     {
+        //         entity.ChallengeId = null;
+        //         entity.PlayerId = null;
+        //     }
+        // }
+
+        // private async Task UpdatedChallenge(Data.Ticket entity) 
+        // {
+        //         var challenge = await Store.DbContext.Challenges.FirstOrDefaultAsync(c =>
+        //             c.Id == entity.ChallengeId
+        //         );
+        //         if (challenge != null)
+        //         {
+        //             entity.TeamId = challenge.TeamId;
+        //             entity.PlayerId = challenge.PlayerId;
+        //         }
+        //         else    
+        //         {
+        //             entity.ChallengeId = null;
+        //             entity.PlayerId = null;
+        //         }
+        // }
+
+        private void AddActivity(Data.Ticket entity, string actorId, bool statusChanged, bool assigneeChanged, DateTimeOffset timestamp) 
+        {
+            if (statusChanged)
+            {
+                var statusActivity = new Data.TicketActivity 
+                {
+                    Id = Guid.NewGuid().ToString("n"),
+                    UserId = actorId,
+                    Status = entity.Status,
+                    Type = ActivityType.StatusChange,
+                    Timestamp = timestamp
+                };
+                entity.Activity.Add(statusActivity);
+            }
+            if (assigneeChanged)
+            {
+                var assigneeActivity = new Data.TicketActivity 
+                {
+                    Id = Guid.NewGuid().ToString("n"),
+                    UserId = actorId,
+                    AssigneeId = entity.AssigneeId,
+                    Type = ActivityType.AssigneeChange,
+                    Timestamp = timestamp
+                };
+                entity.Activity.Add(assigneeActivity);
+            }
+        }
+
+        private TicketSummary[] Transform(TicketSummary[] tickets) {
+            return tickets.Select(x => { x.FullKey = FullKey(x.Key); return x; }).ToArray();
+        }
+
+        private Ticket Transform(Ticket ticket) {
+            ticket.FullKey = FullKey(ticket.Key);
+            return ticket;
+        }
+
+        private string FullKey(int key) {
+            return Options.KeyPrefix+"-"+key.ToString();
+        }
+
+    }
+
+}

--- a/src/Gameboard.Api/Features/Ticket/TicketStore.cs
+++ b/src/Gameboard.Api/Features/Ticket/TicketStore.cs
@@ -1,0 +1,86 @@
+// Copyright 2021 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Gameboard.Api.Data.Abstractions;
+
+namespace Gameboard.Api.Data
+{
+
+    public class TicketStore: Store<Ticket>, ITicketStore
+    {
+        public CoreOptions Options { get; }
+
+        public TicketStore(GameboardDbContext dbContext, CoreOptions options)
+        :base(dbContext)
+        {
+            Options = options;
+        }
+
+        public async Task<Ticket> Load(string id)
+        {
+            return await DbSet
+                .FirstOrDefaultAsync(c => c.Id == id)
+            ;
+        }
+
+        public async Task<Ticket> Load(Api.Ticket model)
+        {
+            return await DbSet
+                .FirstOrDefaultAsync(s =>
+                    s.Id == model.Id
+                );
+            ;
+        }
+
+        public async Task<Ticket> LoadDetails(string id)
+        {
+            return await DbSet
+                .Include(c => c.Requester)
+                .Include(c => c.Assignee)
+                .Include(c => c.Creator)
+                .Include(c => c.Activity)
+                    .ThenInclude(a => a.User)
+                .Include(c => c.Activity)
+                    .ThenInclude(a => a.Assignee)
+                .Include(c => c.Challenge)
+                .Include(c => c.Player)
+                .Include(c => c.Player.Game)
+                // .Include(c => c.Challenge.Player)
+                // .Include(c => c.Challenge.Game)
+                .FirstOrDefaultAsync(c => c.Id == id)
+            ;
+        }
+
+        public override IQueryable<Ticket> List(string term)
+        {
+            var q = base.List();
+            q.Include(c => c.Assignee)
+                .Include(c => c.Requester)
+                .Include(c => c.Challenge);
+
+            if (term.NotEmpty())
+            {
+                term = term.ToLower();
+                var prefix = Options.KeyPrefix.ToLower() + "-";
+                q = q.Where(t => t.Summary.ToLower().Contains(term) ||
+                    t.Label.ToLower().Contains(term) ||
+                    (prefix + t.Key.ToString()).Contains(term) ||
+                    t.Requester.ApprovedName.ToLower().Contains(term) ||
+                    t.Assignee.ApprovedName.ToLower().Contains(term) ||
+                    t.Challenge.Name.ToLower().Contains(term) ||
+                    t.Challenge.Tag.ToLower().Contains(term)
+                );
+            }
+            
+            return q;
+        }
+
+        public async Task<Ticket> ResolveApiKey(string hash)
+        {
+            return await DbSet.FirstOrDefaultAsync();
+        }
+    }
+}

--- a/src/Gameboard.Api/Features/Ticket/TicketStore.cs
+++ b/src/Gameboard.Api/Features/Ticket/TicketStore.cs
@@ -48,8 +48,6 @@ namespace Gameboard.Api.Data
                 .Include(c => c.Challenge)
                 .Include(c => c.Player)
                 .Include(c => c.Player.Game)
-                // .Include(c => c.Challenge.Player)
-                // .Include(c => c.Challenge.Game)
                 .FirstOrDefaultAsync(c => c.Id == id)
             ;
         }

--- a/src/Gameboard.Api/Features/Ticket/TicketValidator.cs
+++ b/src/Gameboard.Api/Features/Ticket/TicketValidator.cs
@@ -1,0 +1,114 @@
+// Copyright 2021 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+
+using System.Threading.Tasks;
+using Gameboard.Api.Data.Abstractions;
+using Microsoft.EntityFrameworkCore;
+
+namespace Gameboard.Api.Validators
+{
+    public class TicketValidator: IModelValidator
+    {
+        private readonly ITicketStore _store;
+
+        public TicketValidator(
+            ITicketStore store
+        )
+        {
+            _store = store;
+        }
+
+        public Task Validate(object model)
+        {
+            if (model is Entity)
+                return _validate(model as Entity);
+
+            if (model is Ticket)
+                return _validate(model as Ticket);
+
+            if (model is ChangedTicket)
+                return _validate(model as ChangedTicket);
+
+            if (model is NewTicket)
+                return _validate(model as NewTicket);
+
+            if (model is NewTicketComment)
+                return _validate(model as NewTicketComment);
+
+
+            throw new System.NotImplementedException();
+        }
+
+        private async Task _validate(Entity model)
+        {
+            if ((await Exists(model.Id)).Equals(false))
+                throw new ResourceNotFound();
+
+            await Task.CompletedTask;
+        }
+
+        private async Task _validate(NewTicket model)
+        {
+            // if ((await Exists(model.TicketId)).Equals(false))
+            //     throw new ResourceNotFound();
+            
+            await Task.CompletedTask;
+        }
+
+        private async Task _validate(Ticket model)
+        {
+            if ((await Exists(model.Id)).Equals(false))
+                throw new ResourceNotFound();
+            
+            await Task.CompletedTask;
+        }
+
+        private async Task _validate(ChangedTicket model)
+        {
+            if ((await Exists(model.Id)).Equals(false))
+                throw new ResourceNotFound();
+            
+            await Task.CompletedTask;
+        }
+
+        private async Task _validate(NewTicketComment model)
+        {
+            if ((await Exists(model.TicketId)).Equals(false))
+                throw new ResourceNotFound();
+            
+            await Task.CompletedTask;
+        }
+
+        private async Task<bool> Exists(string id)
+        {
+            return
+                id.NotEmpty() &&
+                (await _store.Retrieve(id)) is Data.Ticket
+            ;
+        }
+
+        private async Task<bool> ChallengeExists(string id)
+        {
+            return
+                id.NotEmpty() &&
+                (await _store.DbContext.Challenges.FindAsync(id)) is Data.Challenge
+            ;
+        }
+
+        private async Task<bool> PlayerExists(string id)
+        {
+            return
+                id.NotEmpty() &&
+                (await _store.DbContext.Players.FindAsync(id)) is Data.Player
+            ;
+        }
+
+        private async Task<bool> UserExists(string id)
+        {
+            return
+                id.NotEmpty() &&
+                (await _store.DbContext.Users.FindAsync(id)) is Data.User
+            ;
+        }
+    }
+}

--- a/src/Gameboard.Api/Features/Ticket/TicketValidator.cs
+++ b/src/Gameboard.Api/Features/Ticket/TicketValidator.cs
@@ -49,9 +49,10 @@ namespace Gameboard.Api.Validators
 
         private async Task _validate(NewTicket model)
         {
-            // if ((await Exists(model.TicketId)).Equals(false))
-            //     throw new ResourceNotFound();
-            
+            // TODO validate that references exist and belong to the requester
+            // see feedback validator for examples
+            // for example, challenge exists and it is part of a player session that the user belongs to
+
             await Task.CompletedTask;
         }
 
@@ -67,6 +68,8 @@ namespace Gameboard.Api.Validators
         {
             if ((await Exists(model.Id)).Equals(false))
                 throw new ResourceNotFound();
+
+            // TODO validate that references exist and belong to the requester
             
             await Task.CompletedTask;
         }

--- a/src/Gameboard.Api/Features/User/User.cs
+++ b/src/Gameboard.Api/Features/User/User.cs
@@ -20,6 +20,7 @@ namespace Gameboard.Api
         public bool IsDesigner => Role.HasFlag(UserRole.Designer);
         public bool IsTester => Role.HasFlag(UserRole.Tester);
         public bool IsObserver => Role.HasFlag(UserRole.Observer);
+        public bool IsSupport => Role.HasFlag(UserRole.Support);
     }
 
     public class NewUser
@@ -63,6 +64,12 @@ namespace Gameboard.Api
         public bool WantsRoles => Filter.Contains(UserRoleFilter);
         public bool WantsPending => Filter.Contains(NamePendingFilter);
         public bool WantsDisallowed => Filter.Contains(NameDisallowedFilter);
+    }
+    
+    public class UserSummary 
+    {
+        public string Id { get; set; }
+        public string ApprovedName { get; set; }
     }
 
     public class Announcement

--- a/src/Gameboard.Api/Features/User/UserController.cs
+++ b/src/Gameboard.Api/Features/User/UserController.cs
@@ -152,7 +152,8 @@ namespace Gameboard.Api.Controllers
         public async Task<UserSummary[]> ListSupport([FromQuery] SearchFilter model)
         {
             AuthorizeAny(
-                () => Actor.IsObserver
+                () => Actor.IsObserver,
+                () => Actor.IsSupport
             );
 
             return await UserService.ListSupport(model);

--- a/src/Gameboard.Api/Features/User/UserController.cs
+++ b/src/Gameboard.Api/Features/User/UserController.cs
@@ -143,6 +143,22 @@ namespace Gameboard.Api.Controllers
         }
 
         /// <summary>
+        /// Find users with SUPPORT role
+        /// </summary>
+        /// <param name="model"></param>
+        /// <returns>User[]</returns>
+        [HttpGet("/api/users/support")]
+        [Authorize]
+        public async Task<UserSummary[]> ListSupport([FromQuery] SearchFilter model)
+        {
+            AuthorizeAny(
+                () => Actor.IsObserver
+            );
+
+            return await UserService.ListSupport(model);
+        }
+
+        /// <summary>
         /// Retrieve one-time-ticket to authenticate a signalr connection
         /// </summary>
         /// <remarks>Expires in 20s</remarks>

--- a/src/Gameboard.Api/Features/User/UserMapper.cs
+++ b/src/Gameboard.Api/Features/User/UserMapper.cs
@@ -16,6 +16,8 @@ namespace Gameboard.Api.Services
 
             CreateMap<Data.User, TeamMember>();
 
+            CreateMap<Data.User, UserSummary>();
+
             CreateMap<User, Data.User>();
 
             CreateMap<NewUser, Data.User>();

--- a/src/Gameboard.Api/Features/User/UserService.cs
+++ b/src/Gameboard.Api/Features/User/UserService.cs
@@ -159,14 +159,18 @@ namespace Gameboard.Api.Services
         {
             var q = Store.List(model.Term);
 
-            q = q.Where(u => u.Role.HasFlag(UserRole.Observer));
+            // Might want to also include observers if they can be assigned. Or just make possible assignees "Support" roles
+            q = q.Where(u => u.Role.HasFlag(UserRole.Support));
 
             if (model.Term.HasValue())
+            {
+                model.Term = model.Term.ToLower();
                 q = q.Where(u =>
                     u.Id.StartsWith(model.Term) ||
                     u.Name.ToLower().Contains(model.Term) ||
                     u.ApprovedName.ToLower().Contains(model.Term)
                 );
+            }
 
             
             return await Mapper.ProjectTo<UserSummary>(q).ToArrayAsync();

--- a/src/Gameboard.Api/Features/User/UserService.cs
+++ b/src/Gameboard.Api/Features/User/UserService.cs
@@ -127,11 +127,14 @@ namespace Gameboard.Api.Services
             var q = Store.List(model.Term);
 
             if (model.Term.HasValue())
+            {
+                model.Term = model.Term.ToLower();
                 q = q.Where(u =>
                     u.Id.StartsWith(model.Term) ||
                     u.Name.ToLower().Contains(model.Term) ||
                     u.ApprovedName.ToLower().Contains(model.Term)
                 );
+            }
 
             if (model.WantsRoles)
                 q = q.Where(u => ((int)u.Role) > 0);
@@ -150,6 +153,23 @@ namespace Gameboard.Api.Services
                 q = q.Take(model.Take);
 
             return await Mapper.ProjectTo<User>(q).ToArrayAsync();
+        }
+
+        public async Task<UserSummary[]> ListSupport(SearchFilter model)
+        {
+            var q = Store.List(model.Term);
+
+            q = q.Where(u => u.Role.HasFlag(UserRole.Observer));
+
+            if (model.Term.HasValue())
+                q = q.Where(u =>
+                    u.Id.StartsWith(model.Term) ||
+                    u.Name.ToLower().Contains(model.Term) ||
+                    u.ApprovedName.ToLower().Contains(model.Term)
+                );
+
+            
+            return await Mapper.ProjectTo<UserSummary>(q).ToArrayAsync();
         }
 
     }

--- a/src/Gameboard.Api/Startup.cs
+++ b/src/Gameboard.Api/Startup.cs
@@ -5,10 +5,12 @@ using System;
 using System.IO;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -141,11 +143,17 @@ namespace Gameboard.Api
 
             app.UseCors(Settings.Headers.Cors.Name);
 
-            app.UseStaticFiles();
+            // app.UseFileProtection();
+
+            // app.UseStaticFiles();
 
             app.UseAuthentication();
 
             app.UseAuthorization();
+
+            app.UseFileProtection();
+
+            app.UseStaticFiles();
 
             if (Settings.OpenApi.Enabled)
                 app.UseConfiguredSwagger(Settings.OpenApi, Settings.Oidc.Audience, Settings.PathBase);

--- a/src/Gameboard.Api/Startup.cs
+++ b/src/Gameboard.Api/Startup.cs
@@ -143,10 +143,6 @@ namespace Gameboard.Api
 
             app.UseCors(Settings.Headers.Cors.Name);
 
-            // app.UseFileProtection();
-
-            // app.UseStaticFiles();
-
             app.UseAuthentication();
 
             app.UseAuthorization();

--- a/src/Gameboard.Api/Structure/AppConstant.cs
+++ b/src/Gameboard.Api/Structure/AppConstant.cs
@@ -30,7 +30,8 @@ namespace Gameboard.Api
             UserRole.Registrar |
             UserRole.Designer |
             UserRole.Tester |
-            UserRole.Observer
+            UserRole.Observer |
+            UserRole.Support
         ;
     }
 }

--- a/src/Gameboard.Api/Structure/AppSettings.cs
+++ b/src/Gameboard.Api/Structure/AppSettings.cs
@@ -63,7 +63,7 @@ namespace Gameboard.Api
 
     public class DatabaseOptions
     {
-        public string Provider { get; set; } = "InMemory";
+        public string Provider { get; set; } = "PostgreSQL";
         public string ConnectionString { get; set; } = "gameboard_db";
         public string SeedFile { get; set; } = "seed-data.json";
     }
@@ -136,8 +136,11 @@ namespace Gameboard.Api
         public int GameEngineMaxRetries { get; set; } = 2;
         public string ImageFolder { get; set; } = "wwwroot/img";
         public string DocFolder { get; set; } = "wwwroot/doc";
+        public string SupportUploadsRequestPath { get; set; } = "img/secure/support";
+        public string SupportUploadsFolder { get; set; } = "wwwroot/img/secure/support";
         public string ChallengeDocUrl { get; set; }
         public string SafeNamesFile { get; set; } = "names.json";
+        public string KeyPrefix { get; set; }
     }
 
     public class Defaults

--- a/src/Gameboard.Api/Structure/AppSettings.cs
+++ b/src/Gameboard.Api/Structure/AppSettings.cs
@@ -63,7 +63,7 @@ namespace Gameboard.Api
 
     public class DatabaseOptions
     {
-        public string Provider { get; set; } = "PostgreSQL";
+        public string Provider { get; set; } = "InMemory";
         public string ConnectionString { get; set; } = "gameboard_db";
         public string SeedFile { get; set; } = "seed-data.json";
     }

--- a/src/Gameboard.Api/Structure/AppSettings.cs
+++ b/src/Gameboard.Api/Structure/AppSettings.cs
@@ -140,7 +140,7 @@ namespace Gameboard.Api
         public string SupportUploadsFolder { get; set; } = "wwwroot/supportfiles";
         public string ChallengeDocUrl { get; set; }
         public string SafeNamesFile { get; set; } = "names.json";
-        public string KeyPrefix { get; set; }
+        public string KeyPrefix { get; set; } = "GB";
     }
 
     public class Defaults

--- a/src/Gameboard.Api/Structure/AppSettings.cs
+++ b/src/Gameboard.Api/Structure/AppSettings.cs
@@ -136,8 +136,8 @@ namespace Gameboard.Api
         public int GameEngineMaxRetries { get; set; } = 2;
         public string ImageFolder { get; set; } = "wwwroot/img";
         public string DocFolder { get; set; } = "wwwroot/doc";
-        public string SupportUploadsRequestPath { get; set; } = "img/secure/support";
-        public string SupportUploadsFolder { get; set; } = "wwwroot/img/secure/support";
+        public string SupportUploadsRequestPath { get; set; } = "supportfiles";
+        public string SupportUploadsFolder { get; set; } = "wwwroot/supportfiles";
         public string ChallengeDocUrl { get; set; }
         public string SafeNamesFile { get; set; } = "names.json";
         public string KeyPrefix { get; set; }

--- a/src/Gameboard.Api/Structure/FileAuthorizationMiddleware.cs
+++ b/src/Gameboard.Api/Structure/FileAuthorizationMiddleware.cs
@@ -1,0 +1,79 @@
+// Copyright 2021 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Gameboard.Api;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging;
+
+namespace Gameboard.Api
+{
+    public class FileAuthorizationMiddleware
+    {
+        public FileAuthorizationMiddleware(
+            RequestDelegate next,
+            ILogger<HeaderInspectionMiddleware> logger,
+            CoreOptions options,
+            IDistributedCache cache
+        ){
+            _next = next;
+            _logger = logger;
+            _options = options;
+            _cache = cache;
+            // _user = user;
+        }
+        private readonly RequestDelegate _next;
+        private readonly ILogger _logger;
+        private readonly CoreOptions _options;
+        private readonly IDistributedCache _cache;
+
+        public async Task Invoke(HttpContext context)
+        {
+            if (context.Request.Path.StartsWithSegments("/"+_options.SupportUploadsRequestPath))
+            {
+                var requestPath = context.Request.Path.ToString();
+                Regex pattern = new Regex($@"{_options.SupportUploadsRequestPath}/tickets/(?<ticketId>.*)/.*");
+                Match match = pattern.Match(requestPath);
+                var ticketId = match.Groups["ticketId"].Value;
+                var userId = context.User.FindFirst("sub");
+                // var userId = _user.FindFirst("sub");
+                var key = $"{"file-permit:"}{userId}:{ticketId}";
+                string cachedValue = await _cache.GetStringAsync(key);
+                if (false && cachedValue.IsEmpty())
+                {
+                    // throw new Exception("Unauthorized");
+                    context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                    return;
+                }
+                // if (!context.User.Identity.IsAuthenticated
+                //     && context.Request.Path.StartsWithSegments("/"+_options.SupportUploadsRequestPath))
+                // {
+                //     throw new Exception("Not authenticated");
+                // }\
+                // context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                // return System.Threading.Tasks.Task.CompletedTask;
+                
+            }
+
+            await _next(context);
+        }
+    }
+}
+
+namespace Microsoft.AspNetCore.Builder
+{
+    public static class FileAuthorizationExtensions
+    {
+        public static IApplicationBuilder UseFileProtection (
+            this IApplicationBuilder builder
+        )
+        {
+            return builder.UseMiddleware<FileAuthorizationMiddleware>();
+        }
+    }
+}

--- a/src/Gameboard.Api/Structure/FileAuthorizationMiddleware.cs
+++ b/src/Gameboard.Api/Structure/FileAuthorizationMiddleware.cs
@@ -36,25 +36,29 @@ namespace Gameboard.Api
             if (context.Request.Path.StartsWithSegments("/"+_options.SupportUploadsRequestPath))
             {
                 // TODO: May need to change approach for static file requests since the UI with render them with src without token
-
-                // var requestPath = context.Request.Path.ToString();
-                // Regex pattern = new Regex($@"{_options.SupportUploadsRequestPath}/(?<ticketId>.*)/.*");
-                // Match match = pattern.Match(requestPath);
-                // var ticketId = match.Groups["ticketId"].Value;
-                // var sub = context.User.FindFirst("sub");
-                // if (sub == null)
-                // {
-                //     context.Response.StatusCode = StatusCodes.Status401Unauthorized;
-                //     return;
-                // }
-                // var userId = context.User.FindFirst("sub").Value;
-                // var key = $"{"file-permit:"}{userId}:{ticketId}";
-                // string cachedValue = await _cache.GetStringAsync(key);
-                // if (cachedValue.IsEmpty())
-                // {
-                //     context.Response.StatusCode = StatusCodes.Status401Unauthorized;
-                //     return;
-                // }
+                
+                var requestPath = context.Request.Path.ToString();
+                Regex pattern = new Regex($@"{_options.SupportUploadsRequestPath}/(?<ticketId>.*)/.*");
+                Match match = pattern.Match(requestPath);
+                var ticketId = match.Groups["ticketId"].Value;
+                var sub = context.User.FindFirst("sub");
+                
+                // If there is no user id - this should only happen if a user is not logged in
+                if (sub == null)
+                {
+                    context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                    return;
+                }
+                // Oddly, this logic blocks all comment attachments; since file blocking appears to work without, it has been commented out.
+                /* var userId = context.User.FindFirst("sub").Value;
+                var key = $"{"file-permit:"}{userId}:{ticketId}";
+                string cachedValue = await _cache.GetStringAsync(key);
+                // If nothing could be found with the unique user ID and ticket ID combination
+                if (cachedValue.IsEmpty())
+                {
+                    context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                    return;
+                }*/
             }
 
             await _next(context);

--- a/src/Gameboard.Api/Structure/FileAuthorizationMiddleware.cs
+++ b/src/Gameboard.Api/Structure/FileAuthorizationMiddleware.cs
@@ -25,7 +25,6 @@ namespace Gameboard.Api
             _logger = logger;
             _options = options;
             _cache = cache;
-            // _user = user;
         }
         private readonly RequestDelegate _next;
         private readonly ILogger _logger;

--- a/src/Gameboard.Api/Structure/FileAuthorizationMiddleware.cs
+++ b/src/Gameboard.Api/Structure/FileAuthorizationMiddleware.cs
@@ -36,28 +36,26 @@ namespace Gameboard.Api
         {
             if (context.Request.Path.StartsWithSegments("/"+_options.SupportUploadsRequestPath))
             {
-                var requestPath = context.Request.Path.ToString();
-                Regex pattern = new Regex($@"{_options.SupportUploadsRequestPath}/tickets/(?<ticketId>.*)/.*");
-                Match match = pattern.Match(requestPath);
-                var ticketId = match.Groups["ticketId"].Value;
-                var userId = context.User.FindFirst("sub");
-                // var userId = _user.FindFirst("sub");
-                var key = $"{"file-permit:"}{userId}:{ticketId}";
-                string cachedValue = await _cache.GetStringAsync(key);
-                if (false && cachedValue.IsEmpty())
-                {
-                    // throw new Exception("Unauthorized");
-                    context.Response.StatusCode = StatusCodes.Status401Unauthorized;
-                    return;
-                }
-                // if (!context.User.Identity.IsAuthenticated
-                //     && context.Request.Path.StartsWithSegments("/"+_options.SupportUploadsRequestPath))
+                // TODO: May need to change approach for static file requests since the UI with render them with src without token
+
+                // var requestPath = context.Request.Path.ToString();
+                // Regex pattern = new Regex($@"{_options.SupportUploadsRequestPath}/(?<ticketId>.*)/.*");
+                // Match match = pattern.Match(requestPath);
+                // var ticketId = match.Groups["ticketId"].Value;
+                // var sub = context.User.FindFirst("sub");
+                // if (sub == null)
                 // {
-                //     throw new Exception("Not authenticated");
-                // }\
-                // context.Response.StatusCode = StatusCodes.Status401Unauthorized;
-                // return System.Threading.Tasks.Task.CompletedTask;
-                
+                //     context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                //     return;
+                // }
+                // var userId = context.User.FindFirst("sub").Value;
+                // var key = $"{"file-permit:"}{userId}:{ticketId}";
+                // string cachedValue = await _cache.GetStringAsync(key);
+                // if (cachedValue.IsEmpty())
+                // {
+                //     context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                //     return;
+                // }
             }
 
             await _next(context);

--- a/src/Gameboard.Api/Structure/StringExtensions.cs
+++ b/src/Gameboard.Api/Structure/StringExtensions.cs
@@ -2,6 +2,7 @@
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
 using System;
+using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
@@ -81,6 +82,27 @@ namespace Gameboard.Api
         public static bool NotEmpty(this string str)
         {
             return str.IsEmpty().Equals(false);
+        }
+
+        public static string Sanitize(this string target, char[] exclude)
+        {
+            string p = "";
+
+            foreach (char c in target.ToCharArray())
+                if (!exclude.Contains(c))
+                    p += c;
+
+            return p.Replace(" ", "_");
+        }
+
+        public static string SanitizeFilename(this string target)
+        {
+            return target.Sanitize(Path.GetInvalidFileNameChars());
+        }
+
+        public static string SanitizePath(this string target)
+        {
+            return target.Sanitize(Path.GetInvalidPathChars());
         }
     }
 }

--- a/src/Gameboard.Api/appsettings.conf
+++ b/src/Gameboard.Api/appsettings.conf
@@ -64,6 +64,9 @@
 ## A path/file.json with a json array of strings containing safe display names
 # Core__SafeNamesFile =
 
+# A custom prefix for support ticket keys to refer to them uniquely across Gameboard deployment instances
+Core__KeyPrefix = PC4
+
 ####################
 ## Logging
 ####################

--- a/src/Gameboard.Api/appsettings.conf
+++ b/src/Gameboard.Api/appsettings.conf
@@ -65,7 +65,7 @@
 # Core__SafeNamesFile =
 
 # A custom prefix for support ticket keys to refer to them uniquely across Gameboard deployment instances
-# Core__KeyPrefix = PC4
+# Core__KeyPrefix = GB
 
 ####################
 ## Logging

--- a/src/Gameboard.Api/appsettings.conf
+++ b/src/Gameboard.Api/appsettings.conf
@@ -65,7 +65,7 @@
 # Core__SafeNamesFile =
 
 # A custom prefix for support ticket keys to refer to them uniquely across Gameboard deployment instances
-Core__KeyPrefix = PC4
+# Core__KeyPrefix = PC4
 
 ####################
 ## Logging


### PR DESCRIPTION
Corresponding UI Changes: https://github.com/cmu-sei/gameboard-ui/pull/37

- New db tables: `Ticket` and `TicketActivity`. One migration added for these.
- `Ticket` stores a support request and `TicketActivity` can be a comment, status change, or assignee change
- New feature directory `Ticket/` with new controller, service, store, models,etc
- In progress static file authorization behind support uploads path using cached file permit
- New AppSettings CoreOptions fields `SupportUploadsFolder` and `SupportUploadsFolder` for location of Ticket attachment uploads
- New config option in appsettings.conf `KeyPrefix` to map each ticket serial key (such as 101, 102, 103...) to a full key such a `PC4-101` 