### PR TITLE
Feedback enhancements - more feedback options added

### DIFF
--- a/src/Gameboard.Api/Features/Feedback/Feedback.cs
+++ b/src/Gameboard.Api/Features/Feedback/Feedback.cs
@@ -43,6 +43,8 @@ namespace Gameboard.Api
         public string[] Options { get; set; }
         // Display type
         public string Display { get; set; }
+        // Specification for a certain answer
+        public QuestionSpecify Specify { get; set; }
     }
 
     public class GameFeedbackTemplate
@@ -139,6 +141,12 @@ namespace Gameboard.Api
         public int Count { get; set; } // how many responses for this question
         public int Lowest { get; set; } // lowest rating given
         public int Highest { get; set; } // highest rating given
+    }
+
+    public class QuestionSpecify
+    {
+        public string Key { get; set; }
+        public string Prompt { get; set; }
     }
 
 }

--- a/src/Gameboard.Api/Features/Feedback/Feedback.cs
+++ b/src/Gameboard.Api/Features/Feedback/Feedback.cs
@@ -38,6 +38,11 @@ namespace Gameboard.Api
         public int Max { get; set; }
         public string MinLabel { get; set; }
         public string MaxLabel { get; set; }
+
+        // For 'selectOne' and 'selectAllThatApply' type questions only
+        public string[] Options { get; set; }
+        // Display type
+        public string Display { get; set; }
     }
 
     public class GameFeedbackTemplate
@@ -111,6 +116,8 @@ namespace Gameboard.Api
         public int ConfiguredCount { get; set; }
         public int LikertCount { get; set; }
         public int TextCount { get; set; }
+        public int SelectOneCount { get; set; }
+        public int SelectAllThatApplyCount { get; set;}
         public int RequiredCount { get; set; }
         public int ResponsesCount { get; set; }
         public int MaxResponseCount { get; set; }

--- a/src/Gameboard.Api/Features/Feedback/Feedback.cs
+++ b/src/Gameboard.Api/Features/Feedback/Feedback.cs
@@ -39,7 +39,7 @@ namespace Gameboard.Api
         public string MinLabel { get; set; }
         public string MaxLabel { get; set; }
 
-        // For 'selectOne' and 'selectAllThatApply' type questions only
+        // For 'selectOne' and 'selectMany' type questions only
         public string[] Options { get; set; }
         // Display type
         public string Display { get; set; }
@@ -119,7 +119,7 @@ namespace Gameboard.Api
         public int LikertCount { get; set; }
         public int TextCount { get; set; }
         public int SelectOneCount { get; set; }
-        public int SelectAllThatApplyCount { get; set;}
+        public int SelectManyCount { get; set;}
         public int RequiredCount { get; set; }
         public int ResponsesCount { get; set; }
         public int MaxResponseCount { get; set; }

--- a/src/Gameboard.Api/Features/Report/ReportController.cs
+++ b/src/Gameboard.Api/Features/Report/ReportController.cs
@@ -472,7 +472,7 @@ namespace Gameboard.Api.Controllers
                 LikertCount = questionTemplate.Where(q => q.Type == "likert").Count(),
                 TextCount = questionTemplate.Where(q => q.Type == "text").Count(),
                 SelectOneCount = questionTemplate.Where(q => q.Type == "selectOne").Count(),
-                SelectAllThatApplyCount = questionTemplate.Where(q => q.Type == "selectAllThatApply").Count(),
+                SelectManyCount = questionTemplate.Where(q => q.Type == "selectMany").Count(),
                 RequiredCount = questionTemplate.Where(q => q.Required).Count(),
                 ResponsesCount = feedback.Length,
                 MaxResponseCount = maxResponses,

--- a/src/Gameboard.Api/Features/Report/ReportController.cs
+++ b/src/Gameboard.Api/Features/Report/ReportController.cs
@@ -471,6 +471,8 @@ namespace Gameboard.Api.Controllers
                 ConfiguredCount = questionTemplate.Length,
                 LikertCount = questionTemplate.Where(q => q.Type == "likert").Count(),
                 TextCount = questionTemplate.Where(q => q.Type == "text").Count(),
+                SelectOneCount = questionTemplate.Where(q => q.Type == "selectOne").Count(),
+                SelectAllThatApplyCount = questionTemplate.Where(q => q.Type == "selectAllThatApply").Count(),
                 RequiredCount = questionTemplate.Where(q => q.Required).Count(),
                 ResponsesCount = feedback.Length,
                 MaxResponseCount = maxResponses,


### PR DESCRIPTION
Backend part of the feedback expansion. Allows questions more flexibility in a few ways:
- Questions can now be single-select multiple choice by using `selectOne` as the question type in the feedback yaml file
  - Can be turned into a dropdown by adding `display: dropdown` under the question; otherwise uses radio buttons
- Questions can now be multi-select multiple choice by using `selectMany` as the question type in the feedback yaml file
- Text box can be added to a single-select or multi-select question by adding `specify` under the question, then providing a `key` and a `prompt`
  - `key` determines what answer option in a question has the text box (maximum one text box is allowed per question)
  - `prompt` is the guidance text to help a user give an answer in the text box (can also be left empty)

Example of a single-select dropdown:
```yaml
- id: q1
  prompt: Best captain?
  type: selectOne
  display: dropdown
  options:
    - Kirk
    - Picard
    - Sisko
    - Janeway
    - Archer
```

Example of a multi-select with a text box on the "Other" option:
```yaml
- id: q2
  prompt: What board games do you like?
  type: selectMany
  options:
    - Monopoly
    - Sorry
    - Clue
    - Mouse Trap
    - Settlers of Catan
    - Other
  specify:
    key: Other
    prompt: Please enter a board game for 2+ players ages 8 and up.
```