### PR TITLE
Report enhancements

### DIFF
--- a/src/Gameboard.Api/Features/Game/GameService.cs
+++ b/src/Gameboard.Api/Features/Game/GameService.cs
@@ -88,10 +88,10 @@ namespace Gameboard.Api.Services
             if (model.WantsPast)
                 q = q.Where(g => g.GameEnd < now);
 
-            if (model.WantsPast)
-                q = q.OrderByDescending(g => g.GameStart).ThenBy(g => g.Name);
-            else
+            if (model.WantsFuture)
                 q = q.OrderBy(g => g.GameStart).ThenBy(g => g.Name);
+            else
+                q = q.OrderByDescending(g => g.GameStart).ThenBy(g => g.Name);
 
             q = q.Skip(model.Skip);
 

--- a/src/Gameboard.Api/Features/Hubs/AppHub.cs
+++ b/src/Gameboard.Api/Features/Hubs/AppHub.cs
@@ -48,16 +48,14 @@ namespace Gameboard.Api.Hubs
 
         public async Task Listen(string id)
         {
-            var tasks = new List<Task>();
-            
             await Leave();
 
             if (Context.User.IsInRole(UserRole.Support.ToString()))
-                tasks.Add(Groups.AddToGroupAsync(Context.ConnectionId, AppConstants.InternalSupportChannel));
+                await Groups.AddToGroupAsync(Context.ConnectionId, AppConstants.InternalSupportChannel);
             
             if (id == Context.UserIdentifier)
             {
-                tasks.Add(Groups.AddToGroupAsync(Context.ConnectionId, id));
+                await Groups.AddToGroupAsync(Context.ConnectionId, id);
             }
             else
             {
@@ -69,15 +67,13 @@ namespace Gameboard.Api.Hubs
 
                     Context.Items.Add(ContextPlayerKey, player);
 
-                    tasks.Add(Groups.AddToGroupAsync(Context.ConnectionId, player.TeamId));
+                    await Groups.AddToGroupAsync(Context.ConnectionId, player.TeamId);
 
-                    tasks.Add(Clients.OthersInGroup(player.TeamId).PresenceEvent(
+                    await Clients.OthersInGroup(player.TeamId).PresenceEvent(
                         new HubEvent<TeamPlayer>(player, EventAction.Arrived)
-                    ));
+                    );
                 }
             }
-
-            await Task.WhenAll(tasks);
 
         }
 

--- a/src/Gameboard.Api/Features/Report/ReportController.cs
+++ b/src/Gameboard.Api/Features/Report/ReportController.cs
@@ -521,7 +521,7 @@ namespace Gameboard.Api.Controllers
             return Ok(tickets);
         }
 
-        [HttpGet("api/report/seriesstats")]
+        [HttpGet("api/report/gameseriesstats")]
         [Authorize]
         public async Task<ActionResult<SeriesReport>> GetSeriesStats() {
             AuthorizeAny(
@@ -531,7 +531,7 @@ namespace Gameboard.Api.Controllers
             return Ok(await Service.GetSeriesStats());
         }
 
-        [HttpGet("api/report/trackstats")]
+        [HttpGet("api/report/gametrackstats")]
         [Authorize]
         public async Task<ActionResult<TrackReport>> GetTrackStats() {
             AuthorizeAny(
@@ -541,7 +541,7 @@ namespace Gameboard.Api.Controllers
             return Ok(await Service.GetTrackStats());
         }
 
-        [HttpGet("api/report/seasonstats")]
+        [HttpGet("api/report/gameseasonstats")]
         [Authorize]
         public async Task<ActionResult<SeasonReport>> GetSeasonStats() {
             AuthorizeAny(
@@ -551,7 +551,7 @@ namespace Gameboard.Api.Controllers
             return Ok(await Service.GetSeasonStats());
         }
 
-        [HttpGet("api/report/divisionstats")]
+        [HttpGet("api/report/gamedivisionstats")]
         [Authorize]
         public async Task<ActionResult<DivisionReport>> GetDivisionStats() {
             AuthorizeAny(
@@ -561,7 +561,7 @@ namespace Gameboard.Api.Controllers
             return Ok(await Service.GetDivisionStats());
         }
 
-        [HttpGet("api/report/modestats")]
+        [HttpGet("api/report/gamemodestats")]
         [Authorize]
         public async Task<ActionResult<ModeReport>> GetModeStats() {
             AuthorizeAny(
@@ -585,7 +585,7 @@ namespace Gameboard.Api.Controllers
         /// Export series stats to CSV
         /// </summary>
         /// <returns></returns>
-        [HttpGet("api/report/exportseriesstats")]
+        [HttpGet("api/report/exportgameseriesstats")]
         [Authorize]
         [ProducesResponseType(typeof(FileContentResult), 200)]
         public async Task<IActionResult> ExportSeriesStats()
@@ -603,7 +603,7 @@ namespace Gameboard.Api.Controllers
         /// Export track stats to CSV
         /// </summary>
         /// <returns></returns>
-        [HttpGet("api/report/exporttrackstats")]
+        [HttpGet("api/report/exportgametrackstats")]
         [Authorize]
         [ProducesResponseType(typeof(FileContentResult), 200)]
         public async Task<IActionResult> ExportTrackStats()
@@ -621,7 +621,7 @@ namespace Gameboard.Api.Controllers
         /// Export season stats to CSV
         /// </summary>
         /// <returns></returns>
-        [HttpGet("api/report/exportseasonstats")]
+        [HttpGet("api/report/exportgameseasonstats")]
         [Authorize]
         [ProducesResponseType(typeof(FileContentResult), 200)]
         public async Task<IActionResult> ExportSeasonStats()
@@ -639,7 +639,7 @@ namespace Gameboard.Api.Controllers
         /// Export division stats to CSV
         /// </summary>
         /// <returns></returns>
-        [HttpGet("api/report/exportdivisionstats")]
+        [HttpGet("api/report/exportgamedivisionstats")]
         [Authorize]
         [ProducesResponseType(typeof(FileContentResult), 200)]
         public async Task<IActionResult> ExportDivisionStats()
@@ -657,7 +657,7 @@ namespace Gameboard.Api.Controllers
         /// Export mode stats to CSV
         /// </summary>
         /// <returns></returns>
-        [HttpGet("api/report/exportmodestats")]
+        [HttpGet("api/report/exportgamemodestats")]
         [Authorize]
         [ProducesResponseType(typeof(FileContentResult), 200)]
         public async Task<IActionResult> ExportModeStats()
@@ -697,7 +697,7 @@ namespace Gameboard.Api.Controllers
             return File(
                 Service.ConvertToBytes(correlationStats),
                 "application/octet-stream",
-                string.Format("season-stats-{0}", DateTime.UtcNow.ToString("yyyy-MM-dd")) + ".csv");
+                string.Format("correlation-stats-{0}", DateTime.UtcNow.ToString("yyyy-MM-dd")) + ".csv");
         }
 
         // Helper method to create participation reports
@@ -723,7 +723,7 @@ namespace Gameboard.Api.Controllers
                 // .NET inserts a garbage header line ("Item1", "Item2", ... "ItemN") into a CSV when its lines are created via a Tuple with more than 3 items, so we have to remove the first 5*(n+1) bytes from the resulting array
                 fileBytes.ToArray().TakeLast(fileBytes.Count() - (numItemsPerRow * itemLengthSkip + numItemsPerRow + newlineSkip)).ToArray(),
                 "application/octet-stream",
-                string.Format("season-stats-{0}", DateTime.UtcNow.ToString("yyyy-MM-dd")) + ".csv");
+                string.Format("{0}-stats-{1}", report.Key.ToLower(), DateTime.UtcNow.ToString("yyyy-MM-dd")) + ".csv");
         }
     }
 }

--- a/src/Gameboard.Api/Features/Report/ReportModels.cs
+++ b/src/Gameboard.Api/Features/Report/ReportModels.cs
@@ -137,6 +137,19 @@ namespace Gameboard.Api
         }
     }
 
+    public class CorrelationReport
+    {
+        public string Title { get; set; } = "Correlation Report";
+        public DateTime Timestamp { get; set; }
+        public CorrelationStat[] Stats { get; set; }
+    }
+
+    public class CorrelationStat
+    {
+        public int GameCount { get; set; }
+        public int UserCount { get; set; }
+    }
+
     public class Part
     {
         public string Text { get; set; }

--- a/src/Gameboard.Api/Features/Report/ReportModels.cs
+++ b/src/Gameboard.Api/Features/Report/ReportModels.cs
@@ -39,6 +39,7 @@ namespace Gameboard.Api
         public string GameId { get; set; }
         public string GameName { get; set; }
         public int PlayerCount { get; set; }
+        public int SessionPlayerCount { get; set; }
     }
 
     public class SponsorStat
@@ -84,6 +85,21 @@ namespace Gameboard.Api
         public Part[] Parts { get; set; }
         public int AttemptCount { get; set; }
         public string ChallengeId { get; set; }
+    }
+
+    public class SeasonReport
+    {
+        public string Title { get; set; } = "Season Report";
+        public DateTime Timestamp { get; set; }
+        public SeasonStat[] Stats { get; set; }
+    }
+
+    public class SeasonStat
+    {
+        public string Season { get; set; }
+        public int GameCount { get; set; }
+        public int PlayerCount { get; set; }
+        public int SessionPlayerCount { get; set; }
     }
 
     public class Part

--- a/src/Gameboard.Api/Features/Report/ReportModels.cs
+++ b/src/Gameboard.Api/Features/Report/ReportModels.cs
@@ -87,19 +87,54 @@ namespace Gameboard.Api
         public string ChallengeId { get; set; }
     }
 
-    public class SeasonReport
+    public class ParticipationReport
     {
-        public string Title { get; set; } = "Season Report";
+        public string Key { get; set; } = "Participation";
         public DateTime Timestamp { get; set; }
-        public SeasonStat[] Stats { get; set; }
+        public ParticipationStat[] Stats { get; set; }
     }
 
-    public class SeasonStat
+    public class ParticipationStat
     {
-        public string Season { get; set; }
+        public string Key { get; set; }
         public int GameCount { get; set; }
         public int PlayerCount { get; set; }
         public int SessionPlayerCount { get; set; }
+    }
+
+    public class SeriesReport : ParticipationReport
+    {
+        public SeriesReport() {
+            Key = "Series";
+        }
+    }
+
+    public class TrackReport : ParticipationReport
+    {
+        public TrackReport() {
+            Key = "Track";
+        }
+    }
+
+    public class SeasonReport : ParticipationReport
+    {
+        public SeasonReport() {
+            Key = "Season";
+        }
+    }
+
+    public class DivisionReport : ParticipationReport
+    {
+        public DivisionReport() {
+            Key = "Division";
+        }
+    }
+
+    public class ModeReport : ParticipationReport
+    {
+        public ModeReport() {
+            Key = "Mode";
+        }
     }
 
     public class Part

--- a/src/Gameboard.Api/Features/Report/ReportService.cs
+++ b/src/Gameboard.Api/Features/Report/ReportService.cs
@@ -407,6 +407,33 @@ namespace Gameboard.Api.Services
             return Task.FromResult(modeReport);
         }
 
+        internal Task<CorrelationReport> GetCorrelationStats() {
+
+            // Create a temporary table to first group by the user ID and count the number of games played
+            var tempTable = Store.Players.GroupBy(g => g.UserId).Select(
+                s => new {
+                    UserId = s.Key,
+                    GameCount = s.Count()
+                }
+            );
+
+            // Re-group by the number of games played to count the number of users who enrolled in them
+            CorrelationStat[] stats = tempTable.GroupBy(g => g.GameCount ).Select(
+                s => new CorrelationStat {  
+                    GameCount = s.Key,
+                    UserCount = s.Count()
+                }
+            ).OrderBy(stat => stat.GameCount).ToArray();
+
+            CorrelationReport correlationReport = new CorrelationReport
+            {
+                Timestamp = DateTime.UtcNow,
+                Stats = stats
+            };
+
+            return Task.FromResult(correlationReport);
+        }
+
         private static string GetCommonGroupString(string original) {
             return string.IsNullOrWhiteSpace(original) ? "N/A" : original;
         }

--- a/src/Gameboard.Api/Features/Report/ReportService.cs
+++ b/src/Gameboard.Api/Features/Report/ReportService.cs
@@ -222,24 +222,193 @@ namespace Gameboard.Api.Services
             return challengeDetailReport;
         }
 
-        internal Task<SeasonReport> GetSeasonStats() {
+        internal Task<SeriesReport> GetSeriesStats() {
 
-            SeasonStat[] stats = Store.Games.GroupBy(g => g.Season).Select(
-                s => new SeasonStat {
-                    Season = s.Key,
-                    GameCount = s.Count(),
-                    PlayerCount = Store.Players.Where(p => p.Game.Season == s.Key).Select(p => p.UserId).Distinct().Count(),
-                    SessionPlayerCount = Store.Players.Where(p => p.Game.Season == s.Key && p.SessionBegin.ToString() != "-infinity" && p.SessionBegin > DateTimeOffset.MinValue).Select(p => p.UserId).Distinct().Count()
+            // Create a temporary table of all series with the number of games in that series included
+            var tempTable = Store.Games.Select(
+                g => new {
+                    // Replace null, white space, or empty series with "N/A"
+                    Series = string.IsNullOrWhiteSpace(g.Competition) ? "N/A" : g.Competition
+                // To create the table we have to group by the series, then count the rows in each group
+                }).GroupBy(g => g.Series).Select(
+                s => new {
+                    Series = s.Key,
+                    GameCount = s.Count()
+                });
+
+            // Perform actual grouping logic using the above table; we group by both columns
+            ParticipationStat[] stats = tempTable.GroupBy(g => new { g.Series, g.GameCount } ).Select(
+                s => new ParticipationStat {
+                    // Get the formatted series
+                    Key = s.Key.Series,
+                    // Get the number of games in the series
+                    GameCount = s.Key.GameCount,
+                    // Get the number of registered players in the series
+                    PlayerCount = Store.Players.Where(p => p.Game.Competition == s.Key.Series).Select(p => p.UserId).Distinct().Count(),
+                    // Get the number of enrolled players in the series
+                    SessionPlayerCount = Store.Players.Where(p => p.Game.Competition == s.Key.Series && p.SessionBegin.ToString() != "-infinity" && p.SessionBegin > DateTimeOffset.MinValue).Select(p => p.UserId).Distinct().Count()
                 }
-            ).OrderBy(stat => stat.Season).ToArray();
+            ).OrderBy(stat => stat.Key).ToArray();
 
-            SeasonReport seasonReport = new SeasonReport
+            SeriesReport seriesReport = new SeriesReport
             {
                 Timestamp = DateTime.UtcNow,
                 Stats = stats
             };
 
-            return Task.FromResult(seasonReport);
+            return Task.FromResult(seriesReport);
+        }
+
+        internal Task<TrackReport> GetTrackStats() {
+
+            // Create a temporary table of all tracks with the number of games in that track included
+            var tempTable = Store.Games.Select(
+                g => new {
+                    // Replace null, white space, or empty tracks with "N/A"
+                    Track = string.IsNullOrWhiteSpace(g.Track) ? "N/A" : g.Track
+                // To create the table we have to group by the track, then count the rows in each group
+                }).GroupBy(g => g.Track).Select(
+                s => new {
+                    Track = s.Key,
+                    GameCount = s.Count()
+                });
+
+            // Perform actual grouping logic using the above table; we group by both columns
+            ParticipationStat[] stats = tempTable.GroupBy(g => new { g.Track, g.GameCount } ).Select(
+                s => new ParticipationStat {
+                    // Get the formatted track
+                    Key = s.Key.Track,
+                    // Get the number of games in the track
+                    GameCount = s.Key.GameCount,
+                    // Get the number of registered players in the track
+                    PlayerCount = Store.Players.Where(p => p.Game.Track == s.Key.Track).Select(p => p.UserId).Distinct().Count(),
+                    // Get the number of enrolled players in the track
+                    SessionPlayerCount = Store.Players.Where(p => p.Game.Track == s.Key.Track && p.SessionBegin.ToString() != "-infinity" && p.SessionBegin > DateTimeOffset.MinValue).Select(p => p.UserId).Distinct().Count()
+                }
+            ).OrderBy(stat => stat.Key).ToArray();
+
+            TrackReport trackReport = new TrackReport
+            {
+                Timestamp = DateTime.UtcNow,
+                Stats = stats
+            };
+
+            return Task.FromResult(trackReport);
+        }
+
+        internal Task<SeasonReport> GetSeasonStats() {
+
+            // Create a temporary table of all divisions with the number of games in that division included
+            var tempTable = Store.Games.Select(
+                g => new {
+                    // Replace null, white space, or empty divisions with "N/A"
+                    Season = string.IsNullOrWhiteSpace(g.Season) ? "N/A" : g.Season
+                // To create the table we have to group by the division, then count the rows in each group
+                }).GroupBy(g => g.Season).Select(
+                s => new {
+                    Season = s.Key,
+                    GameCount = s.Count()
+                });
+
+            // Perform actual grouping logic using the above table; we group by both columns
+            ParticipationStat[] stats = tempTable.GroupBy(g => new { g.Season, g.GameCount } ).Select(
+                s => new ParticipationStat {
+                    // Get the formatted division
+                    Key = s.Key.Season,
+                    // Get the number of games in the division
+                    GameCount = s.Key.GameCount,
+                    // Get the number of registered players in the division
+                    PlayerCount = Store.Players.Where(p => p.Game.Season == s.Key.Season).Select(p => p.UserId).Distinct().Count(),
+                    // Get the number of enrolled players in the division
+                    SessionPlayerCount = Store.Players.Where(p => p.Game.Season == s.Key.Season && p.SessionBegin.ToString() != "-infinity" && p.SessionBegin > DateTimeOffset.MinValue).Select(p => p.UserId).Distinct().Count()
+                }
+            ).OrderBy(stat => stat.Key).ToArray();
+
+            SeasonReport divisionReport = new SeasonReport
+            {
+                Timestamp = DateTime.UtcNow,
+                Stats = stats
+            };
+
+            return Task.FromResult(divisionReport);
+        }
+
+        internal Task<DivisionReport> GetDivisionStats() {
+
+            // Create a temporary table of all divisions with the number of games in that division included
+            var tempTable = Store.Games.Select(
+                g => new {
+                    // Replace null, white space, or empty divisions with "N/A"
+                    Division = string.IsNullOrWhiteSpace(g.Division) ? "N/A" : g.Division
+                // To create the table we have to group by the division, then count the rows in each group
+                }).GroupBy(g => g.Division).Select(
+                s => new {
+                    Division = s.Key,
+                    GameCount = s.Count()
+                });
+
+            // Perform actual grouping logic using the above table; we group by both columns
+            ParticipationStat[] stats = tempTable.GroupBy(g => new { g.Division, g.GameCount } ).Select(
+                s => new ParticipationStat {
+                    // Get the formatted division
+                    Key = s.Key.Division,
+                    // Get the number of games in the division
+                    GameCount = s.Key.GameCount,
+                    // Get the number of registered players in the division
+                    PlayerCount = Store.Players.Where(p => p.Game.Division == s.Key.Division).Select(p => p.UserId).Distinct().Count(),
+                    // Get the number of enrolled players in the division
+                    SessionPlayerCount = Store.Players.Where(p => p.Game.Division == s.Key.Division && p.SessionBegin.ToString() != "-infinity" && p.SessionBegin > DateTimeOffset.MinValue).Select(p => p.UserId).Distinct().Count()
+                }
+            ).OrderBy(stat => stat.Key).ToArray();
+
+            DivisionReport divisionReport = new DivisionReport
+            {
+                Timestamp = DateTime.UtcNow,
+                Stats = stats
+            };
+
+            return Task.FromResult(divisionReport);
+        }
+
+        internal Task<ModeReport> GetModeStats() {
+
+            // Create a temporary table of all modes with the number of games in that mode included
+            var tempTable = Store.Games.Select(
+                g => new {
+                    // Replace null, white space, or empty modes with "N/A"
+                    Mode = string.IsNullOrWhiteSpace(g.Mode) ? "N/A" : g.Mode
+                // To create the table we have to group by the mode, then count the rows in each group
+                }).GroupBy(g => g.Mode).Select(
+                s => new {
+                    Mode = s.Key,
+                    GameCount = s.Count()
+                });
+
+            // Perform actual grouping logic using the above table; we group by both columns
+            ParticipationStat[] stats = tempTable.GroupBy(g => new { g.Mode, g.GameCount } ).Select(
+                s => new ParticipationStat {
+                    // Get the formatted mode
+                    Key = s.Key.Mode,
+                    // Get the number of games in the mode
+                    GameCount = s.Key.GameCount,
+                    // Get the number of registered players in the mode
+                    PlayerCount = Store.Players.Where(p => p.Game.Mode == s.Key.Mode).Select(p => p.UserId).Distinct().Count(),
+                    // Get the number of enrolled players in the mode
+                    SessionPlayerCount = Store.Players.Where(p => p.Game.Mode == s.Key.Mode && p.SessionBegin.ToString() != "-infinity" && p.SessionBegin > DateTimeOffset.MinValue).Select(p => p.UserId).Distinct().Count()
+                }
+            ).OrderBy(stat => stat.Key).ToArray();
+
+            ModeReport modeReport = new ModeReport
+            {
+                Timestamp = DateTime.UtcNow,
+                Stats = stats
+            };
+
+            return Task.FromResult(modeReport);
+        }
+
+        private static string GetCommonGroupString(string original) {
+            return string.IsNullOrWhiteSpace(original) ? "N/A" : original;
         }
 
         // Compute aggregates for each feedback question in template based on all responses in feedback table

--- a/src/Gameboard.Api/Features/Report/ReportService.cs
+++ b/src/Gameboard.Api/Features/Report/ReportService.cs
@@ -228,8 +228,8 @@ namespace Gameboard.Api.Services
                 s => new SeasonStat {
                     Season = s.Key,
                     GameCount = s.Count(),
-                    PlayerCount = Store.Players.Where(p => p.Game.Season == s.Key).Count(),
-                    SessionPlayerCount = Store.Players.Where(p => p.Game.Season == s.Key && p.SessionBegin.ToString() != "-infinity" && p.SessionBegin > DateTimeOffset.MinValue).Count()
+                    PlayerCount = Store.Players.Where(p => p.Game.Season == s.Key).Select(p => p.UserId).Distinct().Count(),
+                    SessionPlayerCount = Store.Players.Where(p => p.Game.Season == s.Key && p.SessionBegin.ToString() != "-infinity" && p.SessionBegin > DateTimeOffset.MinValue).Select(p => p.UserId).Distinct().Count()
                 }
             ).OrderBy(stat => stat.Season).ToArray();
 

--- a/src/Gameboard.Api/Features/Ticket/TicketController.cs
+++ b/src/Gameboard.Api/Features/Ticket/TicketController.cs
@@ -193,10 +193,10 @@ namespace Gameboard.Api.Controllers
                 var fileNum = 1;
                 foreach (var upload in uploads)
                 {
-                    string nameOnly = Path.GetFileNameWithoutExtension(upload.FileName).ToLower();
+                    string nameOnly = Path.GetFileNameWithoutExtension(upload.FileName);
                     string extension = Path.GetExtension(upload.FileName);
                     string filename = $"{nameOnly}_{fileNum}{extension}";
-                    var sanitized = filename.SanitizeFilename();
+                    var sanitized = filename.SanitizeFilename().ToLower();
                     result.Add(new UploadFile{ FileName = sanitized, File = upload});
                     fileNum += 1;
                 }

--- a/src/Gameboard.Api/Features/Ticket/TicketService.cs
+++ b/src/Gameboard.Api/Features/Ticket/TicketService.cs
@@ -30,7 +30,7 @@ namespace Gameboard.Api.Services
             Store = store;
             _localcache = localcache;
         }
- 
+
         public async Task<Ticket> Retrieve(string id, string actorId)
         {
             var entity = await Store.LoadDetails(id);
@@ -45,7 +45,7 @@ namespace Gameboard.Api.Services
             return Transform(Mapper.Map<Ticket>(entity));
         }
 
-       
+
         public async Task<Ticket> Create(NewTicket model, string actorId, bool sudo, List<UploadFile> uploads)
         {
             Data.Ticket entity;
@@ -55,8 +55,8 @@ namespace Gameboard.Api.Services
                 entity = Mapper.Map<Data.Ticket>(model);
                 AddActivity(entity, actorId, !entity.Status.IsEmpty(), !entity.AssigneeId.IsEmpty(), timestamp);
                 entity.StaffCreated = true;
-            } 
-            else 
+            }
+            else
             {
                 var selfMade = Mapper.Map<SelfNewTicket>(model);
                 entity = Mapper.Map<Data.Ticket>(selfMade);
@@ -75,9 +75,10 @@ namespace Gameboard.Api.Services
             entity.Created = timestamp;
             entity.LastUpdated = timestamp;
 
-            if (uploads.Count() > 0) {
+            if (uploads.Count() > 0)
+            {
                 var filenames = uploads.Select(x => x.FileName).ToArray();
-                 entity.Attachments = Mapper.Map<string>(filenames);
+                entity.Attachments = Mapper.Map<string>(filenames);
             }
 
             await Store.Create(entity);
@@ -100,21 +101,21 @@ namespace Gameboard.Api.Services
 
                 if (prev.PlayerId != entity.PlayerId || prev.ChallengeId != entity.ChallengeId)
                 {
-                    await UpdatedSessionContext(entity);   
+                    await UpdatedSessionContext(entity);
                 }
             }
             else // regular participant can only edit a few fields
             {
-                
+
                 Mapper.Map(
                     Mapper.Map<SelfChangedTicket>(model),
                     entity
                 );
             }
-            
+
             entity.LastUpdated = timestamp;
             await Store.Update(entity);
-            
+
             return Transform(Mapper.Map<Ticket>(entity));
         }
 
@@ -135,7 +136,7 @@ namespace Gameboard.Api.Services
                 q = q.Where(t => t.AssigneeId == userId);
             if (model.WantsUnassigned)
                 q = q.Where(t => t.AssigneeId == null || t.AssigneeId == "");
-            
+
             if (!sudo) // normal user should only see "their" tickets (requester or team member)
             {
                 var userTeams = await Store.DbContext.Players
@@ -148,7 +149,8 @@ namespace Gameboard.Api.Services
             }
 
             // Ordering in descending order
-            if (model.WantsOrderingDesc) {
+            if (model.WantsOrderingDesc)
+            {
                 if (model.WantsOrderingByKey)
                     q = q.OrderByDescending(t => t.Key);
                 if (model.WantsOrderingBySummary)
@@ -161,7 +163,8 @@ namespace Gameboard.Api.Services
                     q = q.OrderByDescending(t => t.LastUpdated);
             }
             // Ordering in ascending order
-            else {
+            else
+            {
                 if (model.WantsOrderingByKey)
                     q = q.OrderBy(t => t.Key);
                 if (model.WantsOrderingBySummary)
@@ -199,7 +202,8 @@ namespace Gameboard.Api.Services
                 Timestamp = timestamp
             };
 
-            if (uploads.Count() > 0) {
+            if (uploads.Count() > 0)
+            {
                 commentActivity.Attachments = Mapper.Map<string>(uploads.Select(x => x.FileName).ToArray());
             }
 
@@ -248,9 +252,10 @@ namespace Gameboard.Api.Services
             if (ticket.TeamId.IsEmpty())
                 return false;
             // if team associated with ticket, see if this user has an enrollment with matching teamId
-            return await Store.DbContext.Players.AnyAsync(p => 
+            return await Store.DbContext.Players.AnyAsync(p =>
                 p.UserId == userId &&
-                p.TeamId == ticket.TeamId);
+                p.TeamId == ticket.TeamId
+            );
         }
 
         public async Task<bool> IsOwnerOrTeamMember(string ticketId, string userId)
@@ -263,9 +268,10 @@ namespace Gameboard.Api.Services
             if (ticket.TeamId.IsEmpty())
                 return false;
             // if team associated with ticket, see if this user has an enrollment with matching teamId
-            return await Store.DbContext.Players.AnyAsync(p => 
+            return await Store.DbContext.Players.AnyAsync(p =>
                 p.UserId == userId &&
-                p.TeamId == ticket.TeamId);
+                p.TeamId == ticket.TeamId
+            );
         }
 
         public async Task<bool> IsOwner(string ticketId, string userId)
@@ -331,11 +337,11 @@ namespace Gameboard.Api.Services
             entity.PlayerId = null;
         }
 
-        private void AddActivity(Data.Ticket entity, string actorId, bool statusChanged, bool assigneeChanged, DateTimeOffset timestamp) 
+        private void AddActivity(Data.Ticket entity, string actorId, bool statusChanged, bool assigneeChanged, DateTimeOffset timestamp)
         {
             if (statusChanged)
             {
-                var statusActivity = new Data.TicketActivity 
+                var statusActivity = new Data.TicketActivity
                 {
                     Id = Guid.NewGuid().ToString("n"),
                     UserId = actorId,
@@ -347,7 +353,7 @@ namespace Gameboard.Api.Services
             }
             if (assigneeChanged)
             {
-                var assigneeActivity = new Data.TicketActivity 
+                var assigneeActivity = new Data.TicketActivity
                 {
                     Id = Guid.NewGuid().ToString("n"),
                     UserId = actorId,
@@ -360,17 +366,20 @@ namespace Gameboard.Api.Services
         }
 
         // Transform functions to create full ticket key with configurable key prefix
-        private TicketSummary[] Transform(TicketSummary[] tickets) {
+        private TicketSummary[] Transform(TicketSummary[] tickets)
+        {
             return tickets.Select(x => { x.FullKey = FullKey(x.Key); return x; }).ToArray();
         }
 
-        private Ticket Transform(Ticket ticket) {
+        private Ticket Transform(Ticket ticket)
+        {
             ticket.FullKey = FullKey(ticket.Key);
             return ticket;
         }
 
-        private string FullKey(int key) {
-            return Options.KeyPrefix+"-"+key.ToString();
+        private string FullKey(int key)
+        {
+            return Options.KeyPrefix + "-" + key.ToString();
         }
 
     }

--- a/src/Gameboard.Api/Features/User/UserService.cs
+++ b/src/Gameboard.Api/Features/User/UserService.cs
@@ -146,10 +146,10 @@ namespace Gameboard.Api.Services
                 q = q.Where(u => ((int)u.Role) > 0);
 
             if (model.WantsPending)
-                q = q.Where(u => string.IsNullOrEmpty(u.NameStatus) && u.Name != u.ApprovedName);
+                q = q.Where(u => u.NameStatus.Equals(AppConstants.NameStatusPending));
 
             if (model.WantsDisallowed)
-                q = q.Where(u => !string.IsNullOrEmpty(u.NameStatus));
+                q = q.Where(u => !string.IsNullOrEmpty(u.NameStatus) && !u.NameStatus.Equals(AppConstants.NameStatusPending));
 
             q = q.OrderBy(p => p.ApprovedName);
 


### PR DESCRIPTION
- Additional reports (listed as Participation Reports) added for different game attributes, displaying how many unique users registered and enrolled in games grouped by that attribute:
  - Series report
  - Track report
  - Season report
  - Division report
  - Mode report
- Additional report added: Correlation report
  - Displays the number of users who registered for different amounts of games
    - Example: Five users registered for one game, two other users registered for two games
  - Listed under Participation Report
- User report extended to show number of users who have enrolled in a game