### PR TITLE
Bugfixes and ticket improvements

### DIFF
--- a/src/Gameboard.Api/Features/Player/PlayerService.cs
+++ b/src/Gameboard.Api/Features/Player/PlayerService.cs
@@ -411,7 +411,8 @@ namespace Gameboard.Api.Services
                     p.UserId.StartsWith(term) ||
                     p.Sponsor.StartsWith(term) ||
                     p.User.Name.ToLower().Contains(term) ||
-                    p.User.ApprovedName.ToLower().Contains(term)
+                    p.User.ApprovedName.ToLower().Contains(term) ||
+                    Store.DbSet.Where(p2 => p2.TeamId == p.TeamId && (p2.UserId.StartsWith(term) || p2.User.ApprovedName.ToLower().Contains(term))).Any()
                 );
             }
 

--- a/src/Gameboard.Api/Features/Report/ReportService.cs
+++ b/src/Gameboard.Api/Features/Report/ReportService.cs
@@ -490,8 +490,9 @@ namespace Gameboard.Api.Services
                         var shift2Count = 0;
                         var outsideShiftCount = 0;
                         g.ToList().ForEach(ticket => {
-                            // Convert creation to local time
-                            var ticketCreatedHour = ticket.Created.ToLocalTime().Hour;
+                            // Force convert creation to eastern standard time
+                            DateTimeOffset tz = TimeZoneInfo.ConvertTime(ticket.Created, TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time"));
+                            var ticketCreatedHour = tz.Hour;
                             if (ticketCreatedHour >= 8 && ticketCreatedHour < 16)
                                 shift1Count += 1;
                             else if (ticketCreatedHour >= 16 && ticketCreatedHour < 23)

--- a/src/Gameboard.Api/Features/Ticket/TicketController.cs
+++ b/src/Gameboard.Api/Features/Ticket/TicketController.cs
@@ -116,9 +116,15 @@ namespace Gameboard.Api.Controllers
 
             await Validate(model);
 
+            // Retrieve the previous ticket result for comparison soon
+            var prevTicket = await TicketService.Retrieve(model.Id, Actor.Id);
             var result = await TicketService.Update(model, Actor.Id, Actor.IsSupport);
-            
-            await Notify(Mapper.Map<TicketNotification>(result), EventAction.Updated);
+            // Ignore labels being different
+            if (result.Label != prevTicket.Label) prevTicket.LastUpdated = result.LastUpdated;
+            // If the ticket hasn't been meaningfully updated, don't send a notification
+            if (prevTicket.LastUpdated != result.LastUpdated) {
+                await Notify(Mapper.Map<TicketNotification>(result), EventAction.Updated);
+            }
 
             return result;
         }

--- a/src/Gameboard.Api/Features/Ticket/TicketService.cs
+++ b/src/Gameboard.Api/Features/Ticket/TicketService.cs
@@ -209,6 +209,8 @@ namespace Gameboard.Api.Services
 
             entity.Activity.Add(Mapper.Map<Data.TicketActivity>(commentActivity));
             entity.LastUpdated = timestamp;
+            // Set the ticket status to be Open if it was closed before and someone leaves a new comment
+            entity.Status = entity.Status == "Closed" ? "Open" : entity.Status;
             await Store.Update(entity);
 
             var result = Mapper.Map<TicketActivity>(commentActivity);


### PR DESCRIPTION
- Timezone on backend now forcibly updated to EST to address support ticket hour-shifting bug
  - Hours should now always format in EST
- Closed tickets are now marked as Open again if someone leaves a comment on them
- Changing the label on a ticket does not send a notification
- Players for a game who are part of a team can now be searched for using their user ID or approved name