### PR TITLE
Miscellaneous admin and support improvements

### DIFF
--- a/src/Gameboard.Api/Extensions/DefaultsStartupExtensions.cs
+++ b/src/Gameboard.Api/Extensions/DefaultsStartupExtensions.cs
@@ -28,11 +28,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 if (File.Exists(certificateFile))
                     certificateTemplate = File.ReadAllText(certificateFile);
 
+                var shiftTimezone = defaults.ShiftTimezone.NotEmpty() ? defaults.ShiftTimezone : Defaults.ShiftTimezoneFallback;
+                var shiftStrings = defaults.ShiftStrings != null ? defaults.ShiftStrings : Defaults.ShiftStringsFallback;
+                var shifts = defaults.ShiftStrings != null ? new System.DateTimeOffset[shiftStrings.Length][] : Defaults.ShiftsFallback;
+                if (defaults.ShiftStrings != null) {
+                    for (int i = 0; i < shiftStrings.Length; i++) {
+                        shifts[i] = new System.DateTimeOffset[] { Defaults.ConvertTime(shiftStrings[i][0], shiftTimezone), Defaults.ConvertTime(shiftStrings[i][1], shiftTimezone) };
+                    }
+                }
+
                 return new Defaults {
                     FeedbackTemplate = feedbackTemplate,
                     FeedbackTemplateFile = defaults.FeedbackTemplateFile,
                     CertificateTemplate = certificateTemplate,
-                    CertificateTemplateFile = defaults.CertificateTemplateFile
+                    CertificateTemplateFile = defaults.CertificateTemplateFile,
+                    ShiftStrings = shiftStrings,
+                    Shifts = shifts,
+                    ShiftTimezone = shiftTimezone
                 };
             });
             

--- a/src/Gameboard.Api/Features/Challenge/ChallengeController.cs
+++ b/src/Gameboard.Api/Features/Challenge/ChallengeController.cs
@@ -355,7 +355,7 @@ namespace Gameboard.Api.Controllers
         public async Task<ChallengeSummary[]> List([FromQuery] SearchFilter model)
         {
             AuthorizeAny(
-                () => Actor.IsDirector
+                () => Actor.IsDirector || Actor.IsSupport
             );
 
             return await ChallengeService.List(model);
@@ -388,7 +388,7 @@ namespace Gameboard.Api.Controllers
         public async Task<ArchivedChallenge[]> ListArchived([FromQuery] SearchFilter model)
         {
             AuthorizeAny(
-                () => Actor.IsDirector
+                () => Actor.IsDirector || Actor.IsSupport
             );
 
             return await ChallengeService.ListArchived(model);

--- a/src/Gameboard.Api/Features/Challenge/ChallengeController.cs
+++ b/src/Gameboard.Api/Features/Challenge/ChallengeController.cs
@@ -280,6 +280,7 @@ namespace Gameboard.Api.Controllers
             AuthorizeAny(
               () => Actor.IsDirector,
               () => Actor.IsObserver,
+              () => Actor.IsSupport,
               () => isTeamMember
             );
 
@@ -318,7 +319,8 @@ namespace Gameboard.Api.Controllers
         {
             AuthorizeAny(
               () => Actor.IsDirector,
-              () => Actor.IsObserver
+              () => Actor.IsObserver,
+              () => Actor.IsSupport
             );
             return await ChallengeService.GetChallengeConsoles(gid);
         }
@@ -329,7 +331,8 @@ namespace Gameboard.Api.Controllers
         {
             AuthorizeAny(
               () => Actor.IsDirector,
-              () => Actor.IsObserver
+              () => Actor.IsObserver,
+              () => Actor.IsSupport
             );
             return ChallengeService.GetConsoleActors(gid);
         }
@@ -340,7 +343,8 @@ namespace Gameboard.Api.Controllers
         {
             AuthorizeAny(
               () => Actor.IsDirector,
-              () => Actor.IsObserver
+              () => Actor.IsObserver,
+              () => Actor.IsSupport
             );
             return ChallengeService.GetConsoleActor(uid);
         }
@@ -355,7 +359,8 @@ namespace Gameboard.Api.Controllers
         public async Task<ChallengeSummary[]> List([FromQuery] SearchFilter model)
         {
             AuthorizeAny(
-                () => Actor.IsDirector || Actor.IsSupport
+                () => Actor.IsDirector,
+                () => Actor.IsSupport
             );
 
             return await ChallengeService.List(model);
@@ -388,7 +393,8 @@ namespace Gameboard.Api.Controllers
         public async Task<ArchivedChallenge[]> ListArchived([FromQuery] SearchFilter model)
         {
             AuthorizeAny(
-                () => Actor.IsDirector || Actor.IsSupport
+                () => Actor.IsDirector,
+                () => Actor.IsSupport
             );
 
             return await ChallengeService.ListArchived(model);

--- a/src/Gameboard.Api/Features/Report/ReportController.cs
+++ b/src/Gameboard.Api/Features/Report/ReportController.cs
@@ -24,7 +24,8 @@ namespace Gameboard.Api.Controllers
             GameService gameService,
             ChallengeSpecService challengeSpecService,
             FeedbackService feedbackService,
-            TicketService ticketService
+            TicketService ticketService,
+            Defaults defaults
         ): base(logger, cache)
         {
             Service = service;
@@ -32,6 +33,7 @@ namespace Gameboard.Api.Controllers
             FeedbackService = feedbackService;
             ChallengeSpecService = challengeSpecService;
             TicketService = ticketService;
+            Defaults = defaults;
         }
 
         ReportService Service { get; }
@@ -39,6 +41,7 @@ namespace Gameboard.Api.Controllers
         FeedbackService FeedbackService { get; }
         ChallengeSpecService ChallengeSpecService { get; }
         TicketService TicketService { get; }
+        Defaults Defaults { get; }
 
         [HttpGet("/api/report/userstats")]
         [Authorize]

--- a/src/Gameboard.Api/Features/Report/ReportController.cs
+++ b/src/Gameboard.Api/Features/Report/ReportController.cs
@@ -702,18 +702,18 @@ namespace Gameboard.Api.Controllers
 
         // Helper method to create participation reports
         public FileContentResult ConstructParticipationReport(ParticipationReport report) {
-            List<Tuple<string, string, string, string>> participationStats = new List<Tuple<string, string, string, string>>();
-            participationStats.Add(new Tuple<string, string, string, string>(report.Key, "Game Count", "Player Count", "Players with Sessions Count"));
+            List<Tuple<string, string, string, string, string>> participationStats = new List<Tuple<string, string, string, string, string>>();
+            participationStats.Add(new Tuple<string, string, string, string, string>(report.Key, "Game Count", "Player Count", "Players with Sessions Count", "Challenges Deployed Count"));
 
             foreach (ParticipationStat stat in report.Stats)
             {
-                participationStats.Add(new Tuple<string, string, string, string>(stat.Key, stat.GameCount.ToString(), stat.PlayerCount.ToString(), stat.SessionPlayerCount.ToString()));
+                participationStats.Add(new Tuple<string, string, string, string, string>(stat.Key, stat.GameCount.ToString(), stat.PlayerCount.ToString(), stat.SessionPlayerCount.ToString(), stat.ChallengesDeployedCount.ToString()));
             }
 
             // Create the byte array now to remove a header row shortly
             byte[] fileBytes = Service.ConvertToBytes(participationStats);
             // The number of items per row
-            int numItemsPerRow = 4;
+            int numItemsPerRow = 5;
             // The set length of each garbage string item in the header
             int itemLengthSkip = 5;
             // The character size of a newline character

--- a/src/Gameboard.Api/Features/Report/ReportController.cs
+++ b/src/Gameboard.Api/Features/Report/ReportController.cs
@@ -864,12 +864,12 @@ namespace Gameboard.Api.Controllers
 
         // Helper method to create participation reports
         public FileContentResult ConstructParticipationReport(ParticipationReport report) {
-            List<Tuple<string, string, string, string, string>> participationStats = new List<Tuple<string, string, string, string, string>>();
-            participationStats.Add(new Tuple<string, string, string, string, string>(report.Key, "Game Count", "Player Count", "Players with Sessions Count", "Challenges Deployed Count"));
+            List<Tuple<string, string, string, string, string, string, string>> participationStats = new List<Tuple<string, string, string, string, string, string, string>>();
+            participationStats.Add(new Tuple<string, string, string, string, string, string, string>(report.Key, "Game Count", "Player Count", "Players with Sessions Count", "Team Count", "Teams with Session Count", "Challenges Deployed Count"));
 
             foreach (ParticipationStat stat in report.Stats)
             {
-                participationStats.Add(new Tuple<string, string, string, string, string>(stat.Key, stat.GameCount.ToString(), stat.PlayerCount.ToString(), stat.SessionPlayerCount.ToString(), stat.ChallengesDeployedCount.ToString()));
+                participationStats.Add(new Tuple<string, string, string, string, string, string, string>(stat.Key, stat.GameCount.ToString(), stat.PlayerCount.ToString(), stat.SessionPlayerCount.ToString(), stat.TeamCount.ToString(), stat.SessionTeamCount.ToString(), stat.ChallengesDeployedCount.ToString()));
             }
 
             return ConstructManyColumnTupleReport(participationStats, report.Key.ToLower());
@@ -881,7 +881,7 @@ namespace Gameboard.Api.Controllers
             // Create the byte array now to remove a header row shortly
             byte[] fileBytes = Service.ConvertToBytes(stats);
             // The number of items per row
-            int numItemsPerRow = 5;
+            int numItemsPerRow = 4;
             // The set length of each garbage string item in the header
             int itemLengthSkip = 5;
             // The character size of a newline character

--- a/src/Gameboard.Api/Features/Report/ReportModels.cs
+++ b/src/Gameboard.Api/Features/Report/ReportModels.cs
@@ -100,6 +100,7 @@ namespace Gameboard.Api
         public int GameCount { get; set; }
         public int PlayerCount { get; set; }
         public int SessionPlayerCount { get; set; }
+        public int ChallengesDeployedCount { get; set; }
     }
 
     public class SeriesReport : ParticipationReport

--- a/src/Gameboard.Api/Features/Report/ReportModels.cs
+++ b/src/Gameboard.Api/Features/Report/ReportModels.cs
@@ -125,6 +125,8 @@ namespace Gameboard.Api
         public int GameCount { get; set; }
         public int PlayerCount { get; set; }
         public int SessionPlayerCount { get; set; }
+        public int TeamCount { get; set; }
+        public int SessionTeamCount { get; set; }
         public int ChallengesDeployedCount { get; set; }
     }
 

--- a/src/Gameboard.Api/Features/Report/ReportService.cs
+++ b/src/Gameboard.Api/Features/Report/ReportService.cs
@@ -16,12 +16,14 @@ namespace Gameboard.Api.Services
     {
         GameboardDbContext Store { get; }
         ITicketStore TicketStore { get; }
+        Defaults Defaults { get; }
         ChallengeService _challengeService { get; }
 
         public ReportService (
             ILogger<ReportService> logger,
             IMapper mapper,
             CoreOptions options,
+            Defaults defaults,
             GameboardDbContext store,
             ITicketStore ticketStore,
             ChallengeService challengeService,
@@ -31,6 +33,7 @@ namespace Gameboard.Api.Services
             Store = store;
             _challengeService = challengeService;
             TicketStore = ticketStore;
+            Defaults = defaults;
         }
 
         internal Task<UserReport> GetUserStats()
@@ -505,39 +508,57 @@ namespace Gameboard.Api.Services
                 .OrderBy(detail => detail.Key).ToArray();
         }
 
-        internal async Task<TicketDayGroup[]> GetTicketVolume(TicketReportFilter model)
+        internal async Task<TicketDayReport> GetTicketVolume(TicketReportFilter model)
         {
             var q = ListFilteredTickets(model);
             var tickets = await q.ToArrayAsync();
 
-            // Todo: make sure times are eastern when grouping days and shifts
-            var result = tickets
+            var ticketsGrouped = tickets
                 .GroupBy(g => new {
-                    Date = g.Created.ToString("MM/dd/yyyy"),
-                    DayOfWeek = g.Created.DayOfWeek.ToString()
-                })
+                    Date = TimeZoneInfo.ConvertTime(g.Created, TimeZoneInfo.FindSystemTimeZoneById(Defaults.ShiftTimezone)).ToString("MM/dd/yyyy"),
+                    DayOfWeek = TimeZoneInfo.ConvertTime(g.Created, TimeZoneInfo.FindSystemTimeZoneById(Defaults.ShiftTimezone)).DayOfWeek.ToString()
+                });
+
+            // Get the shifts provided in AppSettings.cs
+            DateTimeOffset[][] shifts = Defaults.Shifts;
+
+            // Counts
+            int[][] shiftCountsByDay = new int[ticketsGrouped.Count()][];
+            int[] outsideShiftCountsByDay = new int[ticketsGrouped.Count()];
+
+            // Set the number of days observed so far
+            int dayNum = 0;
+
+            var result = ticketsGrouped
                 .Select(g => {
-                        var shift1Count = 0;
-                        var shift2Count = 0;
-                        var outsideShiftCount = 0;
-                        g.ToList().ForEach(ticket => {
-                            // Force convert creation to eastern standard time
-                            DateTimeOffset tz = TimeZoneInfo.ConvertTime(ticket.Created, TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time"));
-                            var ticketCreatedHour = tz.Hour;
-                            if (ticketCreatedHour >= 8 && ticketCreatedHour < 16)
-                                shift1Count += 1;
-                            else if (ticketCreatedHour >= 16 && ticketCreatedHour < 23)
-                                shift2Count += 1;
-                            else 
-                                outsideShiftCount += 1;
-                        });
-                        return new TicketDayGroup {
+                    // Set the shift counts 
+                    shiftCountsByDay[dayNum] = new int[shifts.Length];
+                    g.ToList().ForEach(ticket => {
+                        // Force convert creation to the default timezone (in AppSettings.cs this is Eastern Standard Time)
+                        DateTimeOffset tz = TimeZoneInfo.ConvertTime(ticket.Created, TimeZoneInfo.FindSystemTimeZoneById(Defaults.ShiftTimezone));
+                        var ticketCreatedHour = tz.Hour;
+                        // Flag to check if we've found a matching shift or not
+                        var found = false;
+                        // Loop through all given shifts
+                        for (int i = 0; i < shifts.Length; i++) {
+                            // See if the ticket falls within this shift; each shift hour is already converted to the default time
+                            if (ticketCreatedHour >= shifts[i][0].Hour && ticketCreatedHour < shifts[i][1].Hour) {
+                                shiftCountsByDay[dayNum][i] += 1;
+                                found = true;
+                            }
+                        }
+                        // If we haven't found a matching shift for this ticket, it's outside shift hours for this day
+                        if (!found) outsideShiftCountsByDay[dayNum] += 1;
+                    });
+                    // Increase the number of days observed
+                    dayNum += 1;
+                    // Create a new TicketDayGroup and set its attributes
+                    return new TicketDayGroup {
                         Date = g.Key.Date,
                         DayOfWeek = g.Key.DayOfWeek,
-                        Count = shift1Count + shift2Count + outsideShiftCount,
-                        Shift1Count = shift1Count,
-                        Shift2Count = shift2Count,
-                        OutsideShiftCount = outsideShiftCount
+                        Count = shiftCountsByDay[dayNum - 1].Sum() + outsideShiftCountsByDay[dayNum - 1],
+                        ShiftCounts = shiftCountsByDay[dayNum - 1],
+                        OutsideShiftCount = outsideShiftCountsByDay[dayNum - 1]
                     };
                 })
                 .OrderByDescending(g => g.Date)
@@ -546,9 +567,18 @@ namespace Gameboard.Api.Services
             // if no custom date range, only show the most recent 10
             if (!model.WantsAfterStartTime && !model.WantsBeforeEndTime) 
                 result = result.Take(7);
+            
+            string timezone = "";
+            foreach (string word in Defaults.ShiftTimezone.Split(" ")) {
+                timezone += word.First();
+            }
 
-            return result.ToArray();
+            TicketDayReport ticketDayReport = new TicketDayReport {
+                Timezone = timezone,
+                TicketDays = result.ToArray()
+            };
 
+            return ticketDayReport;
         }
 
         internal async Task<TicketLabelGroup[]> GetTicketLabels(TicketReportFilter model)

--- a/src/Gameboard.Api/Features/Report/ReportService.cs
+++ b/src/Gameboard.Api/Features/Report/ReportService.cs
@@ -616,10 +616,8 @@ namespace Gameboard.Api.Services
             if (!model.WantsAfterStartTime && !model.WantsBeforeEndTime) 
                 result = result.Take(7);
             
-            string timezone = "";
-            foreach (string word in Defaults.ShiftTimezone.Split(" ")) {
-                timezone += word.First();
-            }
+            string[] tzWords = Defaults.ShiftTimezone.Split(" ");
+            string timezone = tzWords[0].First() + "" + tzWords[tzWords.Length - 1].First();
 
             TicketDayReport ticketDayReport = new TicketDayReport {
                 Timezone = timezone,

--- a/src/Gameboard.Api/Features/Report/ReportService.cs
+++ b/src/Gameboard.Api/Features/Report/ReportService.cs
@@ -620,6 +620,7 @@ namespace Gameboard.Api.Services
             string timezone = tzWords[0].First() + "" + tzWords[tzWords.Length - 1].First();
 
             TicketDayReport ticketDayReport = new TicketDayReport {
+                Shifts = Defaults.ShiftStrings,
                 Timezone = timezone,
                 TicketDays = result.ToArray()
             };

--- a/src/Gameboard.Api/Features/Report/ReportService.cs
+++ b/src/Gameboard.Api/Features/Report/ReportService.cs
@@ -252,8 +252,12 @@ namespace Gameboard.Api.Services
                     PlayerCount = Store.Players.Where(p => (string.IsNullOrWhiteSpace(p.Game.Competition) ? blankName : p.Game.Competition) == s.Key.Series).Select(p => p.UserId).Distinct().Count(),
                     // Get the number of enrolled players in the series
                     SessionPlayerCount = Store.Players.Where(p => (string.IsNullOrWhiteSpace(p.Game.Competition) ? blankName : p.Game.Competition) == s.Key.Series && p.SessionBegin.ToString() != "-infinity" && p.SessionBegin > DateTimeOffset.MinValue).Select(p => p.UserId).Distinct().Count(),
+                    // Get the number of registered teams in the series
+                    TeamCount = Store.Players.Where(p => (string.IsNullOrWhiteSpace(p.Game.Competition) ? blankName : p.Game.Competition) == s.Key.Series).Select(p => p.TeamId).Distinct().Count(),
+                    // Get the number of enrolled teams in the series
+                    SessionTeamCount = Store.Players.Where(p => (string.IsNullOrWhiteSpace(p.Game.Competition) ? blankName : p.Game.Competition) == s.Key.Series && p.SessionBegin.ToString() != "-infinity" && p.SessionBegin > DateTimeOffset.MinValue).Select(p => p.TeamId).Distinct().Count(),
                     // Get the number of challenges deployed in this series
-                    ChallengesDeployedCount = Store.ArchivedChallenges.Join(Store.Games, ac => ac.GameId, g => g.Id, (ac, g) => new { GameId = g.Id, Series = g.Competition }).Join(Store.Challenges, g => g.GameId, c => c.GameId, (c, g) => new { Series = c.Series }).Where(g => (string.IsNullOrWhiteSpace(g.Series) ? blankName : g.Series) == s.Key.Series).Count()
+                    ChallengesDeployedCount = Store.ArchivedChallenges.Join(Store.Games, ac => ac.GameId, g => g.Id, (ac, g) => new { GameId = g.Id, Series = g.Competition }).Where(g => (string.IsNullOrWhiteSpace(g.Series) ? blankName : g.Series) == s.Key.Series).Count() + Store.Challenges.Join(Store.Games, c => c.GameId, g => g.Id, (c, g) => new { Series = g.Competition }).Where(g => (string.IsNullOrWhiteSpace(g.Series) ? blankName : g.Series) == s.Key.Series).Count()
                 }
             ).OrderBy(stat => stat.Key).ToArray();
 
@@ -291,8 +295,12 @@ namespace Gameboard.Api.Services
                     PlayerCount = Store.Players.Where(p => (string.IsNullOrWhiteSpace(p.Game.Track) ? blankName : p.Game.Track) == s.Key.Track).Select(p => p.UserId).Distinct().Count(),
                     // Get the number of enrolled players in the track
                     SessionPlayerCount = Store.Players.Where(p => (string.IsNullOrWhiteSpace(p.Game.Track) ? blankName : p.Game.Track) == s.Key.Track && p.SessionBegin.ToString() != "-infinity" && p.SessionBegin > DateTimeOffset.MinValue).Select(p => p.UserId).Distinct().Count(),
+                    // Get the number of registered teams in the track
+                    TeamCount = Store.Players.Where(p => (string.IsNullOrWhiteSpace(p.Game.Track) ? blankName : p.Game.Track) == s.Key.Track).Select(p => p.TeamId).Distinct().Count(),
+                    // Get the number of enrolled teams in the track
+                    SessionTeamCount = Store.Players.Where(p => (string.IsNullOrWhiteSpace(p.Game.Track) ? blankName : p.Game.Track) == s.Key.Track && p.SessionBegin.ToString() != "-infinity" && p.SessionBegin > DateTimeOffset.MinValue).Select(p => p.TeamId).Distinct().Count(),
                     // Get the number of challenges deployed in this track
-                    ChallengesDeployedCount = Store.ArchivedChallenges.Join(Store.Games, ac => ac.GameId, g => g.Id, (ac, g) => new { GameId = g.Id, Track = g.Track }).Join(Store.Challenges, g => g.GameId, c => c.GameId, (c, g) => new { Track = c.Track }).Where(g => (string.IsNullOrWhiteSpace(g.Track) ? blankName : g.Track) == s.Key.Track).Count()
+                    ChallengesDeployedCount = Store.ArchivedChallenges.Join(Store.Games, ac => ac.GameId, g => g.Id, (ac, g) => new { GameId = g.Id, Track = g.Track }).Where(g => (string.IsNullOrWhiteSpace(g.Track) ? blankName : g.Track) == s.Key.Track).Count() + Store.Challenges.Join(Store.Games, c => c.GameId, g => g.Id, (c, g) => new { Track = g.Track }).Where(g => (string.IsNullOrWhiteSpace(g.Track) ? blankName : g.Track) == s.Key.Track).Count()
                 }
             ).OrderBy(stat => stat.Key).ToArray();
 
@@ -330,8 +338,12 @@ namespace Gameboard.Api.Services
                     PlayerCount = Store.Players.Where(p => (string.IsNullOrWhiteSpace(p.Game.Season) ? blankName : p.Game.Season) == s.Key.Season).Select(p => p.UserId).Distinct().Count(),
                     // Get the number of enrolled players in the division
                     SessionPlayerCount = Store.Players.Where(p => (string.IsNullOrWhiteSpace(p.Game.Season) ? blankName : p.Game.Season) == s.Key.Season && p.SessionBegin.ToString() != "-infinity" && p.SessionBegin > DateTimeOffset.MinValue).Select(p => p.UserId).Distinct().Count(),
+                    // Get the number of registered teams in the season
+                    TeamCount = Store.Players.Where(p => (string.IsNullOrWhiteSpace(p.Game.Season) ? blankName : p.Game.Season) == s.Key.Season).Select(p => p.TeamId).Distinct().Count(),
+                    // Get the number of enrolled teams in the season
+                    SessionTeamCount = Store.Players.Where(p => (string.IsNullOrWhiteSpace(p.Game.Season) ? blankName : p.Game.Season) == s.Key.Season && p.SessionBegin.ToString() != "-infinity" && p.SessionBegin > DateTimeOffset.MinValue).Select(p => p.TeamId).Distinct().Count(),
                     // Get the number of challenges deployed in this season
-                    ChallengesDeployedCount = Store.ArchivedChallenges.Join(Store.Games, ac => ac.GameId, g => g.Id, (ac, g) => new { GameId = g.Id, Season = g.Season }).Join(Store.Challenges, g => g.GameId, c => c.GameId, (c, g) => new { Season = c.Season }).Where(g => (string.IsNullOrWhiteSpace(g.Season) ? blankName : g.Season) == s.Key.Season).Count()
+                    ChallengesDeployedCount = Store.ArchivedChallenges.Join(Store.Games, ac => ac.GameId, g => g.Id, (ac, g) => new { GameId = g.Id, Season = g.Season }).Where(g => (string.IsNullOrWhiteSpace(g.Season) ? blankName : g.Season) == s.Key.Season).Count() + Store.Challenges.Join(Store.Games, c => c.GameId, g => g.Id, (c, g) => new { Season = g.Season }).Where(g => (string.IsNullOrWhiteSpace(g.Season) ? blankName : g.Season) == s.Key.Season).Count()
                 }
             ).OrderBy(stat => stat.Key).ToArray();
 
@@ -369,8 +381,12 @@ namespace Gameboard.Api.Services
                     PlayerCount = Store.Players.Where(p => (string.IsNullOrWhiteSpace(p.Game.Division) ? blankName : p.Game.Division) == s.Key.Division).Select(p => p.UserId).Distinct().Count(),
                     // Get the number of enrolled players in the division
                     SessionPlayerCount = Store.Players.Where(p => (string.IsNullOrWhiteSpace(p.Game.Division) ? blankName : p.Game.Division) == s.Key.Division && p.SessionBegin.ToString() != "-infinity" && p.SessionBegin > DateTimeOffset.MinValue).Select(p => p.UserId).Distinct().Count(),
+                    // Get the number of registered teams in the division
+                    TeamCount = Store.Players.Where(p => (string.IsNullOrWhiteSpace(p.Game.Division) ? blankName : p.Game.Division) == s.Key.Division).Select(p => p.TeamId).Distinct().Count(),
+                    // Get the number of enrolled teams in the division
+                    SessionTeamCount = Store.Players.Where(p => (string.IsNullOrWhiteSpace(p.Game.Division) ? blankName : p.Game.Division) == s.Key.Division && p.SessionBegin.ToString() != "-infinity" && p.SessionBegin > DateTimeOffset.MinValue).Select(p => p.TeamId).Distinct().Count(),
                     // Get the number of challenges deployed in this division
-                    ChallengesDeployedCount = Store.ArchivedChallenges.Join(Store.Games, ac => ac.GameId, g => g.Id, (ac, g) => new { GameId = g.Id, Division = g.Division }).Join(Store.Challenges, g => g.GameId, c => c.GameId, (c, g) => new { Division = c.Division }).Where(g => (string.IsNullOrWhiteSpace(g.Division) ? blankName : g.Division) == s.Key.Division).Count()
+                    ChallengesDeployedCount = Store.ArchivedChallenges.Join(Store.Games, ac => ac.GameId, g => g.Id, (ac, g) => new { GameId = g.Id, Division = g.Division }).Where(g => (string.IsNullOrWhiteSpace(g.Division) ? blankName : g.Division) == s.Key.Division).Count() + Store.Challenges.Join(Store.Games, c => c.GameId, g => g.Id, (c, g) => new { Division = g.Division }).Where(g => (string.IsNullOrWhiteSpace(g.Division) ? blankName : g.Division) == s.Key.Division).Count()
                 }
             ).OrderBy(stat => stat.Key).ToArray();
 
@@ -408,8 +424,12 @@ namespace Gameboard.Api.Services
                     PlayerCount = Store.Players.Where(p => (string.IsNullOrWhiteSpace(p.Game.Mode) ? blankName : p.Game.Mode) == s.Key.Mode).Select(p => p.UserId).Distinct().Count(),
                     // Get the number of enrolled players in the mode
                     SessionPlayerCount = Store.Players.Where(p => (string.IsNullOrWhiteSpace(p.Game.Mode) ? blankName : p.Game.Mode) == s.Key.Mode && p.SessionBegin.ToString() != "-infinity" && p.SessionBegin > DateTimeOffset.MinValue).Select(p => p.UserId).Distinct().Count(),
+                    // Get the number of registered teams in the mode
+                    TeamCount = Store.Players.Where(p => (string.IsNullOrWhiteSpace(p.Game.Mode) ? blankName : p.Game.Mode) == s.Key.Mode).Select(p => p.TeamId).Distinct().Count(),
+                    // Get the number of enrolled teams in the mode
+                    SessionTeamCount = Store.Players.Where(p => (string.IsNullOrWhiteSpace(p.Game.Mode) ? blankName : p.Game.Mode) == s.Key.Mode && p.SessionBegin.ToString() != "-infinity" && p.SessionBegin > DateTimeOffset.MinValue).Select(p => p.TeamId).Distinct().Count(),
                     // Get the number of challenges deployed in this mode
-                    ChallengesDeployedCount = Store.ArchivedChallenges.Join(Store.Games, ac => ac.GameId, g => g.Id, (ac, g) => new { GameId = g.Id, Mode = g.Mode }).Join(Store.Challenges, g => g.GameId, c => c.GameId, (c, g) => new { Mode = c.Mode }).Where(g => (string.IsNullOrWhiteSpace(g.Mode) ? blankName : g.Mode) == s.Key.Mode).Count()
+                    ChallengesDeployedCount = Store.ArchivedChallenges.Join(Store.Games, ac => ac.GameId, g => g.Id, (ac, g) => new { GameId = g.Id, Mode = g.Mode }).Where(g => (string.IsNullOrWhiteSpace(g.Mode) ? blankName : g.Mode) == s.Key.Mode).Count() + Store.Challenges.Join(Store.Games, c => c.GameId, g => g.Id, (c, g) => new { Mode = g.Mode }).Where(g => (string.IsNullOrWhiteSpace(g.Mode) ? blankName : g.Mode) == s.Key.Mode).Count()
                 }
             ).OrderBy(stat => stat.Key).ToArray();
 

--- a/src/Gameboard.Api/Features/Report/ReportService.cs
+++ b/src/Gameboard.Api/Features/Report/ReportService.cs
@@ -347,13 +347,13 @@ namespace Gameboard.Api.Services
                 }
             ).OrderBy(stat => stat.Key).ToArray();
 
-            SeasonReport divisionReport = new SeasonReport
+            SeasonReport seasonReport = new SeasonReport
             {
                 Timestamp = DateTime.UtcNow,
                 Stats = stats
             };
 
-            return Task.FromResult(divisionReport);
+            return Task.FromResult(seasonReport);
         }
 
         internal Task<DivisionReport> GetDivisionStats() {

--- a/src/Gameboard.Api/Features/Ticket/Ticket.cs
+++ b/src/Gameboard.Api/Features/Ticket/Ticket.cs
@@ -183,7 +183,7 @@ namespace Gameboard.Api
 
     public class TicketDayReport
     {
-        public string[][] Shifts { get; set; } = Defaults.ShiftStrings;
+        public string[][] Shifts { get; set; }
         public string Timezone { get; set; }
         public TicketDayGroup[] TicketDays { get; set; }
     }

--- a/src/Gameboard.Api/Features/Ticket/Ticket.cs
+++ b/src/Gameboard.Api/Features/Ticket/Ticket.cs
@@ -181,13 +181,19 @@ namespace Gameboard.Api
         public bool WantsBeforeEndTime => EndRange != DateTimeOffset.MinValue;
     }
 
+    public class TicketDayReport
+    {
+        public string[][] Shifts { get; set; } = Defaults.ShiftStrings;
+        public string Timezone { get; set; }
+        public TicketDayGroup[] TicketDays { get; set; }
+    }
+
     public class TicketDayGroup
     {
         public string Date { get; set; }
         public string DayOfWeek { get; set; }
         public int Count { get; set; }
-        public int Shift1Count { get; set; }
-        public int Shift2Count { get; set; }
+        public int[] ShiftCounts { get; set; }
         public int OutsideShiftCount { get; set; }
     }
 

--- a/src/Gameboard.Api/Structure/AppSettings.cs
+++ b/src/Gameboard.Api/Structure/AppSettings.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Cors.Infrastructure;
+using System;
 
 namespace Gameboard.Api
 {
@@ -149,6 +150,31 @@ namespace Gameboard.Api
         public string FeedbackTemplate { get; set; } = "";
         public string CertificateTemplateFile { get; set; }
         public string CertificateTemplate { get; set; } = "";
+        // The timezone to format support shifts in
+        public static string ShiftTimezone { get; set; } = "Eastern Standard Time";
+        // The support shifts; each string[] is the shift start time and the shift end time
+        public static string[][] ShiftStrings { get; } = new string[][] {
+            new string[] { "8:00 AM", "4:00 PM" },
+            new string[] { "4:00 PM", "11:00 PM" }
+        };
+        // Get date-formatted versions of the shifts
+        public static DateTimeOffset[][] Shifts { get; set; } = GetShifts();
+
+        // Helper method to format shifts as DateTimeOffset objects
+        private static DateTimeOffset[][] GetShifts() {
+            DateTimeOffset[][] offsets = new DateTimeOffset[ShiftStrings.Length][];
+            // Create a new DateTimeOffset representation for every string time given
+            for (int i = 0; i < ShiftStrings.Length; i++)
+            {
+                offsets[i] = new DateTimeOffset[] { ConvertTime(ShiftStrings[i][0]), ConvertTime(ShiftStrings[i][1]) };
+            }
+            return offsets;
+        }
+
+        // Helper method to convert a given string time into a DateTimeOffset representation
+        private static DateTimeOffset ConvertTime(string time) {
+            return TimeZoneInfo.ConvertTime(DateTimeOffset.Parse(time), TimeZoneInfo.FindSystemTimeZoneById(ShiftTimezone));
+        }
     }
 
 }

--- a/src/Gameboard.Api/Structure/AppSettings.cs
+++ b/src/Gameboard.Api/Structure/AppSettings.cs
@@ -151,29 +151,34 @@ namespace Gameboard.Api
         public string CertificateTemplateFile { get; set; }
         public string CertificateTemplate { get; set; } = "";
         // The timezone to format support shifts in
-        public static string ShiftTimezone { get; set; } = "Eastern Standard Time";
+        public string ShiftTimezone { get; set; }
+        public static string ShiftTimezoneFallback { get; set; } = "Eastern Standard Time";
         // The support shifts; each string[] is the shift start time and the shift end time
-        public static string[][] ShiftStrings { get; } = new string[][] {
+        public string[][] ShiftStrings { get; set; }
+        public static string[][] ShiftStringsFallback { get; } = new string[][] {
             new string[] { "8:00 AM", "4:00 PM" },
             new string[] { "4:00 PM", "11:00 PM" }
         };
         // Get date-formatted versions of the shifts
-        public static DateTimeOffset[][] Shifts { get; set; } = GetShifts();
+        public DateTimeOffset[][] Shifts { get; set; }
+        public static DateTimeOffset[][] ShiftsFallback { get; set; } = GetShifts(ShiftStringsFallback);
 
         // Helper method to format shifts as DateTimeOffset objects
-        private static DateTimeOffset[][] GetShifts() {
-            DateTimeOffset[][] offsets = new DateTimeOffset[ShiftStrings.Length][];
+        public static DateTimeOffset[][] GetShifts(string[][] shiftStrings) {
+            DateTimeOffset[][] offsets = new DateTimeOffset[shiftStrings.Length][];
             // Create a new DateTimeOffset representation for every string time given
-            for (int i = 0; i < ShiftStrings.Length; i++)
+            for (int i = 0; i < shiftStrings.Length; i++)
             {
-                offsets[i] = new DateTimeOffset[] { ConvertTime(ShiftStrings[i][0]), ConvertTime(ShiftStrings[i][1]) };
+                offsets[i] = new DateTimeOffset[] { 
+                    ConvertTime(shiftStrings[i][0], ShiftTimezoneFallback), 
+                    ConvertTime(shiftStrings[i][1], ShiftTimezoneFallback) };
             }
             return offsets;
         }
 
         // Helper method to convert a given string time into a DateTimeOffset representation
-        private static DateTimeOffset ConvertTime(string time) {
-            return TimeZoneInfo.ConvertTime(DateTimeOffset.Parse(time), TimeZoneInfo.FindSystemTimeZoneById(ShiftTimezone));
+        public static DateTimeOffset ConvertTime(string time, string shiftTimezone) {
+            return TimeZoneInfo.ConvertTime(DateTimeOffset.Parse(time), TimeZoneInfo.FindSystemTimeZoneById(shiftTimezone));
         }
     }
 

--- a/src/Gameboard.Api/appsettings.conf
+++ b/src/Gameboard.Api/appsettings.conf
@@ -108,6 +108,18 @@
 ## Specify a global default certificate template from an html file with only body contents
 # Defaults__CertificateTemplateFile = certificate-template.html
 
+## Specify support timezone; Eastern Standard Time by default, daylight savings included
+# Defaults__ShiftTimezone = Eastern Standard Time
+
+## Specify support intervals in EST
+# To add a new shift, follow this convention:
+# Defaults__ShiftStrings__shift-number_0 for the start of the shift
+# Defaults__ShiftStrings__shift-number_1 for the end of the shift
+# Defaults__ShiftStrings__0__0 = 8:00 AM
+# Defaults__ShiftStrings__0__1 = 4:00 PM
+# Defaults__ShiftStrings__1__0 = 4:00 PM
+# Defaults__ShiftStrings__1__1 = 11:00 PM
+
 ###################
 ## Example for appsettings.Development.conf
 ###################

--- a/src/Gameboard.Api/appsettings.conf
+++ b/src/Gameboard.Api/appsettings.conf
@@ -113,8 +113,8 @@
 
 ## Specify support intervals in EST
 # To add a new shift, follow this convention:
-# Defaults__ShiftStrings__shift-number_0 for the start of the shift
-# Defaults__ShiftStrings__shift-number_1 for the end of the shift
+# Defaults__ShiftStrings__shift-number__0 for the start of the shift
+# Defaults__ShiftStrings__shift-number__1 for the end of the shift
 # Defaults__ShiftStrings__0__0 = 8:00 AM
 # Defaults__ShiftStrings__0__1 = 4:00 PM
 # Defaults__ShiftStrings__1__0 = 4:00 PM


### PR DESCRIPTION
- Support roles now have limited administrative abilities, able to access admin challenge metrics and observe challenges
- New fields added to participation reports:
  - **Team Count**: the number of teams who enrolled for a game across a given participation metric
  - **Teams with Sessions Count**: the number of teams who began a session for a game across a given participation metric
  - **Number of Challenges Deployed**: the number of challenges deployed across a given participation metric
- Participation reports render new fields in UI and via CSV export
- Ticket support shifts are configurable in AppSettings.cs and are filtered appropriately in the support report and when exporting the support report
- Board reports now accurately calculate the number of teams with one sponsor and display another row for the number of teams with multiple sponsors