### PR TITLE
refactor hasDeployedGamespace field

### DIFF
--- a/src/Gameboard.Api/Features/Challenge/Challenge.cs
+++ b/src/Gameboard.Api/Features/Challenge/Challenge.cs
@@ -18,7 +18,7 @@ namespace Gameboard.Api
         public DateTimeOffset EndTime { get; set; }
         public DateTimeOffset LastScoreTime { get; set; }
         public DateTimeOffset LastSyncTime { get; set; }
-        public bool HasGamespaceDeployed { get; set; }
+        public bool HasDeployedGamespace { get; set; }
         public int Points { get; set; }
         public int Score { get; set; }
         public long Duration { get; set; }
@@ -41,7 +41,7 @@ namespace Gameboard.Api
         public DateTimeOffset EndTime { get; set; }
         public DateTimeOffset LastScoreTime { get; set; }
         public DateTimeOffset LastSyncTime { get; set; }
-        public bool HasGamespaceDeployed { get; set; }
+        public bool HasDeployedGamespace { get; set; }
         public int Points { get; set; }
         public int Score { get; set; }
         public long Duration { get; set; }

--- a/src/Gameboard.Api/Features/Challenge/ChallengeMapper.cs
+++ b/src/Gameboard.Api/Features/Challenge/ChallengeMapper.cs
@@ -69,9 +69,6 @@ namespace Gameboard.Api.Services
                 .ForMember(d => d.GameName, opt => opt.MapFrom(s => s.Game.Name))
                 .ForMember(d => d.UserId, opt => opt.MapFrom(s => s.Player.UserId))
                 .ForMember(d => d.Score, opt => opt.MapFrom(s => (int)Math.Floor(s.Score)))
-                .ForMember(d => d.IsActive, opt => opt.MapFrom(s =>
-                    JsonSerializer.Deserialize<TopoMojo.Api.Client.GameState>(s.State, JsonOptions).IsActive)
-                )
             ;
 
             // Squash arrays of challenge events, submissions, and team members into a single record


### PR DESCRIPTION
Fixes field name mismatch: `hasGamespaceDeployed` &rarr; `hasDeployedGamespace`.