### PR TITLE
Better gamebrain and cubespace integration

### DIFF
--- a/src/Gameboard.Api/.gitignore
+++ b/src/Gameboard.Api/.gitignore
@@ -8,3 +8,4 @@ wwwroot/supportfiles
 .dpk/
 .DS_Store
 Gameboard.xml
+seed-data.json

--- a/src/Gameboard.Api/Data/Entities/Challenge.cs
+++ b/src/Gameboard.Api/Data/Entities/Challenge.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Gameboard.Api.Data
@@ -28,14 +27,17 @@ namespace Gameboard.Api.Data
         public DateTimeOffset StartTime { get; set; }
         public DateTimeOffset EndTime { get; set; }
         public bool HasDeployedGamespace { get; set; }
-        [NotMapped] public ChallengeResult Result => Score == Points
+
+        [NotMapped]
+        public ChallengeResult Result => Score == Points
             ? ChallengeResult.Success
             : Score > 0
                 ? ChallengeResult.Partial
                 : ChallengeResult.None
         ;
-        [NotMapped] public long Duration => StartTime.NotEmpty() && LastScoreTime.NotEmpty()
-            ? (long) LastScoreTime.Subtract(StartTime).TotalMilliseconds
+        [NotMapped]
+        public long Duration => StartTime.NotEmpty() && LastScoreTime.NotEmpty()
+            ? (long)LastScoreTime.Subtract(StartTime).TotalMilliseconds
             : 0
         ;
 

--- a/src/Gameboard.Api/Data/Entities/ChallengeEvent.cs
+++ b/src/Gameboard.Api/Data/Entities/ChallengeEvent.cs
@@ -2,7 +2,6 @@
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
 using System;
-using System.ComponentModel.DataAnnotations;
 
 namespace Gameboard.Api.Data
 {
@@ -17,5 +16,4 @@ namespace Gameboard.Api.Data
         public DateTimeOffset Timestamp { get; set; }
         public Challenge Challenge { get; set; }
     }
-
 }

--- a/src/Gameboard.Api/Extensions/AuthenticationStartupExtensions.cs
+++ b/src/Gameboard.Api/Extensions/AuthenticationStartupExtensions.cs
@@ -34,6 +34,8 @@ namespace Microsoft.Extensions.DependencyInjection
                         RoleClaimType = AppConstants.RoleClaimName
                     };
 
+                    jwt.SaveToken = true;
+
                 })
                 .AddCookie(AppConstants.MksCookie, opt => {
                     opt.ExpireTimeSpan = new System.TimeSpan(0, options.MksCookieMinutes, 0);

--- a/src/Gameboard.Api/Extensions/SwaggerStartupExtensions.cs
+++ b/src/Gameboard.Api/Extensions/SwaggerStartupExtensions.cs
@@ -5,10 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using Gameboard.Api;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.OpenApi.Models;
-using Gameboard.Api;
-using System.Linq;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -29,10 +28,11 @@ namespace Microsoft.Extensions.DependencyInjection
                 {
                     Title = openapi.ApiName,
                     Version = "v1",
-                    Description = "API documentation and interaction"
+                    Description = "API documentation and interaction",
                 });
 
                 options.EnableAnnotations();
+                options.CustomSchemaIds(i => i.FullName);
 
 #if DEBUG
                 string[] files = Directory.GetFiles("bin", xmlDoc, SearchOption.AllDirectories);
@@ -44,10 +44,10 @@ namespace Microsoft.Extensions.DependencyInjection
                     options.IncludeXmlComments(xmlDoc);
 #endif
 
-                options.CustomSchemaIds(type => type.FullName.StartsWith("Gameboard")
-                    ? type.Name
-                    : type.FullName.Replace(".", "")
-                );
+                // options.CustomSchemaIds(type => type.FullName.StartsWith("Gameboard")
+                //     ? type.Name
+                //     : type.FullName.Replace(".", "")
+                // );
 
                 if (!string.IsNullOrEmpty(oidc.Authority))
                 {

--- a/src/Gameboard.Api/Features/Challenge/Challenge.cs
+++ b/src/Gameboard.Api/Features/Challenge/Challenge.cs
@@ -2,7 +2,7 @@
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
 using System;
-using System.Collections.Generic;
+using Gameboard.Api.Features.ChallengeEvents;
 using TopoMojo.Api.Client;
 
 namespace Gameboard.Api
@@ -23,7 +23,7 @@ namespace Gameboard.Api
         public int Score { get; set; }
         public long Duration { get; set; }
         public ChallengeResult Result { get; set; }
-        public ChallengeEvent[] Events { get; set; }
+        public ChallengeEventSummary[] Events { get; set; }
         public TopoMojo.Api.Client.GameState State { get; set; }
     }
 
@@ -46,7 +46,7 @@ namespace Gameboard.Api
         public int Score { get; set; }
         public long Duration { get; set; }
         public ChallengeResult Result { get; set; }
-        public ChallengeEvent[] Events { get; set; }
+        public ChallengeEventSummary[] Events { get; set; }
         public bool IsActive { get; set; }
     }
 
@@ -72,7 +72,7 @@ namespace Gameboard.Api
         public int Score { get; set; }
         public long Duration { get; set; }
         public ChallengeResult Result { get; set; }
-        public ChallengeEvent[] Events { get; set; }
+        public ChallengeEventSummary[] Events { get; set; }
     }
 
     public class ChallengeOverview
@@ -96,7 +96,7 @@ namespace Gameboard.Api
         public string Name { get; set; }
         public string Tag { get; set; }
         public string PlayerId { get; set; }
-        public string PlayerName { get; set; } 
+        public string PlayerName { get; set; }
         public long Duration { get; set; }
         public int ChallengeScore { get; set; }
         public int GameScore { get; set; }
@@ -107,44 +107,36 @@ namespace Gameboard.Api
 
     public class ObserveVM
     {
-      public string Id { get; set; }
-      public string Name { get; set; }
-      public string ChallengeId { get; set; }
-      public bool IsRunning { get; set; }
-      public bool IsVisible { get; set; }
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string ChallengeId { get; set; }
+        public bool IsRunning { get; set; }
+        public bool IsVisible { get; set; }
     }
 
     public class ConsoleRequest
     {
-      public string Name { get; set; }
-      public string SessionId { get; set; }
-      public ConsoleAction Action { get; set; }
-      public string Id => $"{Name}#{SessionId}";
+        public string Name { get; set; }
+        public string SessionId { get; set; }
+        public ConsoleAction Action { get; set; }
+        public string Id => $"{Name}#{SessionId}";
     }
 
     public class ConsoleSummary
     {
-      public string Id { get; set; }
-      public string Name { get; set; }
-      public string SessionId { get; set; }
-      public string Url { get; set; }
-      public bool IsRunning { get; set; }
-      public bool IsObserver { get; set; }
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string SessionId { get; set; }
+        public string Url { get; set; }
+        public bool IsRunning { get; set; }
+        public bool IsObserver { get; set; }
     }
 
     public enum ConsoleAction
     {
-      None,
-      Ticket,
-      Reset
-    }
-
-    public class ChallengeEvent
-    {
-        public string UserId { get; set; }
-        public string Text { get; set; }
-        public ChallengeEventType Type { get; set; }
-        public DateTimeOffset Timestamp { get; set; }
+        None,
+        Ticket,
+        Reset
     }
 
     public class ConsoleActor
@@ -180,13 +172,13 @@ namespace Gameboard.Api
         public int Score { get; set; }
         public long Duration { get; set; }
         public ChallengeResult Result { get; set; }
-        public ChallengeEvent[] Events { get; set; }
+        public ChallengeEventSummary[] Events { get; set; }
         public string[] TeamMembers { get; set; } // User Ids of all team members
         public bool IsActive { get; set; }
         public SectionSubmission[] Submissions { get; set; }
     }
 
-    public class ChallengeSearchFilter: SearchFilter
+    public class ChallengeSearchFilter : SearchFilter
     {
         public string uid { get; set; } // Used to search for all challenges of a user
     }

--- a/src/Gameboard.Api/Features/Challenge/ChallengeMapper.cs
+++ b/src/Gameboard.Api/Features/Challenge/ChallengeMapper.cs
@@ -5,7 +5,7 @@ using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using AutoMapper;
-
+using Gameboard.Api.Features.ChallengeEvents;
 
 namespace Gameboard.Api.Services
 {
@@ -61,8 +61,7 @@ namespace Gameboard.Api.Services
                 )
             ;
 
-            CreateMap<Data.ChallengeEvent, ChallengeEvent>()
-            ;
+
 
             CreateMap<Data.Challenge, ArchivedChallenge>()
                 .ForMember(d => d.PlayerName, opt => opt.MapFrom(s => s.Player.ApprovedName))
@@ -89,7 +88,7 @@ namespace Gameboard.Api.Services
 
             CreateMap<Data.ArchivedChallenge, ArchivedChallenge>()
                 .ForMember(d => d.Events, opt => opt.MapFrom(s =>
-                    JsonSerializer.Deserialize<ChallengeEvent[]>(s.Events, JsonOptions))
+                    JsonSerializer.Deserialize<ChallengeEventSummary[]>(s.Events, JsonOptions))
                 )
                 .ForMember(d => d.Submissions, opt => opt.MapFrom(s =>
                     JsonSerializer.Deserialize<TopoMojo.Api.Client.SectionSubmission[]>(s.Submissions, JsonOptions))
@@ -98,7 +97,7 @@ namespace Gameboard.Api.Services
                     JsonSerializer.Deserialize<string[]>(s.TeamMembers, JsonOptions))
                 )
             ;
-            
+
             CreateMap<Data.Challenge, ObserveChallenge>()
                 .ForMember(d => d.GameRank, opt => opt.MapFrom(s => s.Player.Rank))
                 .ForMember(d => d.GameScore, opt => opt.MapFrom(s => s.Player.Score))

--- a/src/Gameboard.Api/Features/Challenge/ChallengeService.cs
+++ b/src/Gameboard.Api/Features/Challenge/ChallengeService.cs
@@ -62,7 +62,8 @@ namespace Gameboard.Api.Services
 
             var lockkey = $"{player.TeamId}{model.SpecId}";
             var lockval = Guid.NewGuid();
-            var locked = _localcache.GetOrCreate(lockkey, entry => {
+            var locked = _localcache.GetOrCreate(lockkey, entry =>
+            {
                 entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(60);
                 return lockval;
             });
@@ -93,7 +94,8 @@ namespace Gameboard.Api.Services
 
             Exception error = null;
 
-            try {
+            try
+            {
                 var state = await Mojo.RegisterGamespaceAsync(new GamespaceRegistration
                 {
                     Players = new RegistrationPlayer[] {
@@ -136,12 +138,12 @@ namespace Gameboard.Api.Services
             }
             finally
             {
-               _localcache.Remove(lockkey);
+                _localcache.Remove(lockkey);
             }
 
             if (error is Exception)
                 throw error;
-                
+
             return Mapper.Map<Challenge>(entity);
         }
 
@@ -171,15 +173,6 @@ namespace Gameboard.Api.Services
 
             return result;
         }
-
-        // public async Task Update(ChangedChallenge model)
-        // {
-        //     var entity = await Store.Retrieve(model.Id);
-
-        //     Mapper.Map(model, entity);
-
-        //     await Store.Update(entity);
-        // }
 
         public async Task Delete(string id)
         {
@@ -239,9 +232,9 @@ namespace Gameboard.Api.Services
         }
 
         public async Task<ArchivedChallenge[]> ListArchived(SearchFilter model)
-        { 
+        {
             var q = Store.DbContext.ArchivedChallenges.AsQueryable();
-            
+
             if (model.Term.NotEmpty())
             {
                 var term = model.Term.ToLower();
@@ -253,7 +246,7 @@ namespace Gameboard.Api.Services
                     c.PlayerName.ToLower().Contains(term) // Team Name (or indiv. Player Name)
                 );
             }
-    
+
             q = q.OrderByDescending(p => p.LastSyncTime);
 
             q = q.Skip(model.Skip);
@@ -514,7 +507,6 @@ namespace Gameboard.Api.Services
                 return null;
 
             var entity = await Store.ResolveApiKey(key.ToSha256());
-
             return entity?.Id;
         }
 

--- a/src/Gameboard.Api/Features/Challenge/ChallengeValidator.cs
+++ b/src/Gameboard.Api/Features/Challenge/ChallengeValidator.cs
@@ -3,11 +3,10 @@
 
 using System.Threading.Tasks;
 using Gameboard.Api.Data.Abstractions;
-using Microsoft.EntityFrameworkCore;
 
 namespace Gameboard.Api.Validators
 {
-    public class ChallengeValidator: IModelValidator
+    public class ChallengeValidator : IModelValidator
     {
         private readonly IChallengeStore _store;
 
@@ -32,19 +31,16 @@ namespace Gameboard.Api.Validators
             throw new System.NotImplementedException();
         }
 
-        private async Task _validate(PlayerDataFilter model)
+        private Task _validate(PlayerDataFilter model)
         {
-            await Task.CompletedTask;
+            return Task.CompletedTask;
         }
 
         private async Task _validate(Entity model)
         {
             if ((await Exists(model.Id)).Equals(false))
                 throw new ResourceNotFound();
-
-            await Task.CompletedTask;
         }
-
 
         private async Task _validate(NewChallenge model)
         {
@@ -57,12 +53,12 @@ namespace Gameboard.Api.Validators
             var player = await _store.DbContext.Players.FindAsync(model.PlayerId);
 
             if (player.IsLive.Equals(false))
-              throw new SessionNotActive();
+                throw new SessionNotActive();
 
             var spec = await _store.DbContext.ChallengeSpecs.FindAsync(model.SpecId);
 
             if (spec.GameId != player.GameId)
-              throw new ActionForbidden();
+                throw new ActionForbidden();
 
             // Note: not checking "already exists" since this is used idempotently
 

--- a/src/Gameboard.Api/Features/Challenge/IChallengeStore.cs
+++ b/src/Gameboard.Api/Features/Challenge/IChallengeStore.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 
 namespace Gameboard.Api.Data.Abstractions
 {
-
     public interface IChallengeStore : IStore<Challenge>
     {
         Task<Data.Challenge> Load(NewChallenge model);
@@ -15,5 +14,4 @@ namespace Gameboard.Api.Data.Abstractions
         Task<int> ChallengeGamespaceCount(string teamId);
         Task<Data.Challenge> ResolveApiKey(string key);
     }
-
 }

--- a/src/Gameboard.Api/Features/ChallengeEvents/ChallengeEventController.cs
+++ b/src/Gameboard.Api/Features/ChallengeEvents/ChallengeEventController.cs
@@ -1,0 +1,50 @@
+// Copyright 2021 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+
+using System.Threading.Tasks;
+using Gameboard.Api.Features.ChallengeEvents;
+using Gameboard.Api.Services;
+using Gameboard.Api.Validators;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging;
+
+namespace Gameboard.Api.Controllers;
+
+[Authorize]
+public class ChallengeEventController : _Controller
+{
+    private ConsoleActorMap _actorMap;
+    private ChallengeEventService _challengeEventService;
+
+    public ChallengeEventController(
+        // required by _Controller
+        IDistributedCache cache,
+        ILogger<ChallengeEventController> logger,
+        ChallengeEventValidator validator,
+        // other stuff
+        ChallengeEventService challengeEventService,
+        PlayerService playerService,
+        ConsoleActorMap actorMap
+    ) : base(logger, cache, validator)
+    {
+        this._actorMap = actorMap;
+        this._challengeEventService = challengeEventService;
+    }
+
+    /// <summary>
+    ///     Log an event for a given challenge.
+    /// </summary>
+    /// <param name="model">NewChallengeEvent</param>
+    /// <returns>ChallengeEvent</returns>
+    [HttpPost("api/challengeEvent")]
+    [Authorize]
+    public async Task<Data.ChallengeEvent> Create([FromBody] NewChallengeEvent model)
+    {
+        AuthorizeAny(() => Actor.IsDirector);
+        await Validate(model);
+
+        return await _challengeEventService.Add(model);
+    }
+}

--- a/src/Gameboard.Api/Features/ChallengeEvents/ChallengeEventMaps.cs
+++ b/src/Gameboard.Api/Features/ChallengeEvents/ChallengeEventMaps.cs
@@ -1,0 +1,12 @@
+using AutoMapper;
+using Gameboard.Api.Data;
+
+namespace Gameboard.Api.Features.ChallengeEvents;
+
+public class ChallengeEventMaps : Profile
+{
+    public ChallengeEventMaps()
+    {
+        CreateMap<ChallengeEvent, ChallengeEventSummary>();
+    }
+}

--- a/src/Gameboard.Api/Features/ChallengeEvents/ChallengeEventModels.cs
+++ b/src/Gameboard.Api/Features/ChallengeEvents/ChallengeEventModels.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Gameboard.Api.Features.ChallengeEvents;
+
+public class ChallengeEventSummary
+{
+    public string UserId { get; set; }
+    public string Text { get; set; }
+    public ChallengeEventType Type { get; set; }
+    public DateTimeOffset Timestamp { get; set; }
+}
+
+public class NewChallengeEvent
+{
+    public string ChallengeId { get; set; }
+    public string UserId { get; set; }
+    public string TeamId { get; set; }
+    public string Text { get; set; }
+    public ChallengeEventType Type { get; set; }
+    public DateTimeOffset Timestamp { get; set; }
+}

--- a/src/Gameboard.Api/Features/ChallengeEvents/ChallengeEventService.cs
+++ b/src/Gameboard.Api/Features/ChallengeEvents/ChallengeEventService.cs
@@ -1,0 +1,33 @@
+
+using System.Threading.Tasks;
+using AutoMapper;
+using Gameboard.Api.Data;
+using Gameboard.Api.Features.ChallengeEvents;
+using Microsoft.Extensions.Logging;
+using TopoMojo.Api.Client;
+
+namespace Gameboard.Api.Services;
+
+public class ChallengeEventService : _Service
+{
+    private ITopoMojoApiClient Mojo { get; }
+    private IChallengeEventStore Store { get; }
+
+    public ChallengeEventService(
+        ILogger<ChallengeEventService> logger,
+        IMapper mapper,
+        CoreOptions options,
+        IChallengeEventStore store,
+        ITopoMojoApiClient mojo
+    ) : base(logger, mapper, options)
+    {
+        Store = store;
+        Mojo = mojo;
+    }
+
+    public async Task<ChallengeEvent> Add(NewChallengeEvent model)
+    {
+        var challengeEvent = Mapper.Map<ChallengeEvent>(model);
+        return await Store.Create(challengeEvent);
+    }
+}

--- a/src/Gameboard.Api/Features/ChallengeEvents/ChallengeEventStore.cs
+++ b/src/Gameboard.Api/Features/ChallengeEvents/ChallengeEventStore.cs
@@ -1,0 +1,9 @@
+using Gameboard.Api.Data;
+
+namespace Gameboard.Api.Features.ChallengeEvents;
+
+public class ChallengeEventStore : Store<ChallengeEvent>, IChallengeEventStore
+{
+    public ChallengeEventStore(GameboardDbContext dbContext)
+    : base(dbContext) { }
+}

--- a/src/Gameboard.Api/Features/ChallengeEvents/ChallengeEventValidator.cs
+++ b/src/Gameboard.Api/Features/ChallengeEvents/ChallengeEventValidator.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Gameboard.Api.Features.ChallengeEvents;
+using Microsoft.EntityFrameworkCore;
+
+namespace Gameboard.Api.Validators;
+
+public class ChallengeEventValidator : IModelValidator
+{
+    private readonly IChallengeEventStore _store;
+
+    public ChallengeEventValidator(IChallengeEventStore store)
+    {
+        _store = store;
+    }
+
+    public async Task Validate(object model)
+    {
+        if (model is NewChallengeEvent)
+            await ValidateNewChallengeEvent(model as NewChallengeEvent);
+
+        throw new NotImplementedException();
+    }
+
+    private async Task<bool> ValidateNewChallengeEvent(NewChallengeEvent model)
+    {
+        return
+            await ChallengeExists(model.ChallengeId) &&
+            await UserExists(model.UserId) &&
+            await TeamExists(model);
+    }
+
+    private async Task<bool> ChallengeExists(string id)
+        => id.NotEmpty() && (await _store.DbContext.Challenges.FindAsync(id)) is Data.Challenge;
+
+    private async Task<bool> TeamExists(NewChallengeEvent model)
+        => model.TeamId.NotEmpty() && (
+            await _store
+                .DbContext.Players
+                .Where(p => p.UserId == model.UserId && p.TeamId == model.TeamId)
+                .FirstOrDefaultAsync()
+            ) != null;
+
+    private async Task<bool> UserExists(string id)
+        => id.NotEmpty() && (await _store.DbContext.Users.FindAsync(id)) is Data.User;
+}

--- a/src/Gameboard.Api/Features/ChallengeEvents/IChallengeEventStore.cs
+++ b/src/Gameboard.Api/Features/ChallengeEvents/IChallengeEventStore.cs
@@ -1,0 +1,9 @@
+using Gameboard.Api.Data;
+using Gameboard.Api.Data.Abstractions;
+
+namespace Gameboard.Api.Features.ChallengeEvents;
+
+public interface IChallengeEventStore : IStore<ChallengeEvent>
+{
+    // IStore enforces everything we're using right now
+}

--- a/src/Gameboard.Api/Features/ChallengeSpec/ChallengeSpecController.cs
+++ b/src/Gameboard.Api/Features/ChallengeSpec/ChallengeSpecController.cs
@@ -2,13 +2,12 @@
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
-
 using Gameboard.Api.Services;
-using Microsoft.AspNetCore.Authorization;
 using Gameboard.Api.Validators;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging;
 
 namespace Gameboard.Api.Controllers
 {
@@ -22,13 +21,13 @@ namespace Gameboard.Api.Controllers
             IDistributedCache cache,
             ChallengeSpecValidator validator,
             ChallengeSpecService challengespecService
-        ): base(logger, cache, validator)
+        ) : base(logger, cache, validator)
         {
             ChallengeSpecService = challengespecService;
         }
 
         /// <summary>
-        /// Create new challengespec
+        /// Create a new challengespec.
         /// </summary>
         /// <param name="model"></param>
         /// <returns></returns>
@@ -48,7 +47,7 @@ namespace Gameboard.Api.Controllers
         /// <returns></returns>
         [HttpGet("api/challengespec/{id}")]
         [Authorize(AppConstants.DesignerPolicy)]
-        public async Task<ChallengeSpec> Retrieve([FromRoute]string id)
+        public async Task<ChallengeSpec> Retrieve([FromRoute] string id)
         {
             return await ChallengeSpecService.Retrieve(id);
         }
@@ -73,7 +72,7 @@ namespace Gameboard.Api.Controllers
         /// <returns></returns>
         [HttpDelete("/api/challengespec/{id}")]
         [Authorize(AppConstants.DesignerPolicy)]
-        public async Task Delete([FromRoute]string id)
+        public async Task Delete([FromRoute] string id)
         {
             await ChallengeSpecService.Delete(id);
             return;
@@ -98,7 +97,7 @@ namespace Gameboard.Api.Controllers
         /// <returns></returns>
         [HttpPost("/api/challengespecs/sync/{id}")]
         [Authorize(AppConstants.DesignerPolicy)]
-        public async Task Sync([FromQuery]string id)
+        public async Task Sync([FromQuery] string id)
         {
             await ChallengeSpecService.Sync(id);
         }

--- a/src/Gameboard.Api/Features/ChallengeSpec/ChallengeSpecService.cs
+++ b/src/Gameboard.Api/Features/ChallengeSpec/ChallengeSpecService.cs
@@ -1,29 +1,28 @@
 // Copyright 2021 Carnegie Mellon University. All Rights Reserved.
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
-using System;
 using System.Linq;
 using System.Threading.Tasks;
 using AutoMapper;
-using Microsoft.EntityFrameworkCore;
 using Gameboard.Api.Data.Abstractions;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using TopoMojo.Api.Client;
 
 namespace Gameboard.Api.Services
 {
-    public class ChallengeSpecService: _Service
+    public class ChallengeSpecService : _Service
     {
         IChallengeSpecStore Store { get; }
         ITopoMojoApiClient Mojo { get; }
 
-        public ChallengeSpecService (
+        public ChallengeSpecService(
             ILogger<ChallengeSpecService> logger,
             IMapper mapper,
             CoreOptions options,
             IChallengeSpecStore store,
             ITopoMojoApiClient mojo
-        ): base(logger, mapper, options)
+        ) : base(logger, mapper, options)
         {
             Store = store;
             Mojo = mojo;
@@ -58,7 +57,6 @@ namespace Gameboard.Api.Services
         public async Task Update(ChangedChallengeSpec account)
         {
             var entity = await Store.Retrieve(account.Id);
-
             Mapper.Map(account, entity);
 
             await Store.Update(entity);
@@ -89,7 +87,7 @@ namespace Gameboard.Api.Services
                 .ToDictionary(o => o.ExternalId)
             ;
 
-            foreach(var spec in Store.DbSet.Where(s => s.GameId == id))
+            foreach (var spec in Store.DbSet.Where(s => s.GameId == id))
             {
                 if (externals.ContainsKey(spec.ExternalId).Equals(false))
                     continue;
@@ -101,5 +99,4 @@ namespace Gameboard.Api.Services
             await Store.DbContext.SaveChangesAsync();
         }
     }
-
 }

--- a/src/Gameboard.Api/Features/ChallengeSpec/ChallengeSpecStore.cs
+++ b/src/Gameboard.Api/Features/ChallengeSpec/ChallengeSpecStore.cs
@@ -1,18 +1,15 @@
 // Copyright 2021 Carnegie Mellon University. All Rights Reserved.
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore;
 using Gameboard.Api.Data.Abstractions;
 
 namespace Gameboard.Api.Data
 {
 
-    public class ChallengeSpecStore: Store<ChallengeSpec>, IChallengeSpecStore
+    public class ChallengeSpecStore : Store<ChallengeSpec>, IChallengeSpecStore
     {
         public ChallengeSpecStore(GameboardDbContext dbContext)
-        :base(dbContext)
+        : base(dbContext)
         {
 
         }

--- a/src/Gameboard.Api/Features/Game/Game.cs
+++ b/src/Gameboard.Api/Features/Game/Game.cs
@@ -85,6 +85,7 @@ namespace Gameboard.Api
         public string Season { get; set; }
         public string Track { get; set; }
         public string Division { get; set; }
+        public string Mode { get; set; }
         public string Logo { get; set; }
         public string Sponsor { get; set; }
         public GameFeedbackTemplate FeedbackTemplate { get; set; }

--- a/src/Gameboard.Api/Features/Game/GameController.cs
+++ b/src/Gameboard.Api/Features/Game/GameController.cs
@@ -237,7 +237,7 @@ namespace Gameboard.Api.Controllers
             HttpClient gb = CreateGamebrain();
             gb.DefaultRequestHeaders.Add("Authorization", $"Bearer {accessToken}");
             HttpResponseMessage m = await gb.GetAsync($"admin/headless_client/{tid}");
-            return await m.Content.ReadAsStringAsync();
+            return accessToken;
             /*
             var address = gb.BaseAddress;
             var content = await m.Content.ReadAsStringAsync();

--- a/src/Gameboard.Api/Features/Game/GameController.cs
+++ b/src/Gameboard.Api/Features/Game/GameController.cs
@@ -252,7 +252,7 @@ namespace Gameboard.Api.Controllers
             return await m.Content.ReadAsStringAsync();
         }
 
-        [HttpGet("/api/hasGamespace/{gid}/{tid")]
+        [HttpGet("/api/hasGamespace/{gid}/{tid}")]
         [Authorize]
         public async Task<ActionResult<bool>> HasGamespace([FromRoute] string gid, [FromRoute] string tid)
         {

--- a/src/Gameboard.Api/Features/Game/GameController.cs
+++ b/src/Gameboard.Api/Features/Game/GameController.cs
@@ -244,6 +244,8 @@ namespace Gameboard.Api.Controllers
         [Authorize]
         public async Task<string> DeployUnitySpace([FromRoute]string gid, [FromRoute]string tid)
         {
+            Console.WriteLine($"Deploy? {gid} is the GID.");
+
             AuthorizeAny(
                 () => Actor.IsDirector,
                 () => GameService.UserIsTeamPlayer(Actor.Id, gid, tid).Result

--- a/src/Gameboard.Api/Features/Game/GameController.cs
+++ b/src/Gameboard.Api/Features/Game/GameController.cs
@@ -13,7 +13,6 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Caching.Distributed;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 

--- a/src/Gameboard.Api/Features/Game/GameController.cs
+++ b/src/Gameboard.Api/Features/Game/GameController.cs
@@ -2,6 +2,7 @@
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -231,6 +232,7 @@ namespace Gameboard.Api.Controllers
             );
 
             var gb = await CreateGamebrain();
+            Debug.WriteLine($"HEY BEN! We're about to post to admin/deploy/{gid}/{tid}");
             var m = await gb.PostAsync($"admin/deploy/{gid}/{tid}", null);
             return await m.Content.ReadAsStringAsync();
         }

--- a/src/Gameboard.Api/Features/Game/GameController.cs
+++ b/src/Gameboard.Api/Features/Game/GameController.cs
@@ -256,9 +256,9 @@ namespace Gameboard.Api.Controllers
             return await m.Content.ReadAsStringAsync();
         }
 
-        [HttpGet("/api/undeployunityspace/{gid}/{tid}")]
+        [HttpGet("/api/undeployunityspace/{tid}")]
         [Authorize]
-        public async Task<string> UndeployUnitySpace([FromRoute]string gid, [FromRoute]string tid)
+        public async Task<string> UndeployUnitySpace([FromRoute]string tid)
         {
             AuthorizeAny(
                 // () => Actor.IsAdmin
@@ -268,7 +268,7 @@ namespace Gameboard.Api.Controllers
             var accessToken = await HttpContext.GetTokenAsync("access_token");
             HttpClient gb = CreateGamebrain();
             gb.DefaultRequestHeaders.Add("Authorization", $"Bearer {accessToken}");
-            HttpResponseMessage m = await gb.GetAsync($"admin/undeploy/{gid}/{tid}");
+            HttpResponseMessage m = await gb.GetAsync($"admin/undeploy/{tid}");
             return await m.Content.ReadAsStringAsync();
         }
 

--- a/src/Gameboard.Api/Features/Game/GameController.cs
+++ b/src/Gameboard.Api/Features/Game/GameController.cs
@@ -232,7 +232,9 @@ namespace Gameboard.Api.Controllers
                 // () => GameService.UserIsOnTeam(Actor.Id, tid).Result
             );
             
-            return await GetGamebrain().GetStringAsync($"/admin/headless_client/{tid}");
+            HttpResponseMessage m = await GetGamebrain().GetAsync($"/admin/headless_client/{tid}");
+            
+            return await m.Content.ReadAsStringAsync();
         }
         #endregion
     }

--- a/src/Gameboard.Api/Features/Game/GameController.cs
+++ b/src/Gameboard.Api/Features/Game/GameController.cs
@@ -251,9 +251,9 @@ namespace Gameboard.Api.Controllers
             return await m.Content.ReadAsStringAsync();
         }
 
-        [HttpGet("/api/hasGamespace/{gid}/{tid}")]
+        [HttpGet("/api/getGamespace/{gid}/{tid}")]
         [Authorize]
-        public async Task<ActionResult<bool>> HasGamespace([FromRoute] string gid, [FromRoute] string tid)
+        public async Task<IActionResult> HasGamespace([FromRoute] string gid, [FromRoute] string tid)
         {
             AuthorizeAny(
                 () => GameService.UserIsTeamPlayer(Actor.Id, gid, tid).Result
@@ -265,18 +265,13 @@ namespace Gameboard.Api.Controllers
             if (m.IsSuccessStatusCode)
             {
                 var stringContent = await m.Content.ReadAsStringAsync();
-                var boolContent = false;
 
-                if (bool.TryParse(stringContent, out boolContent))
+                if (!stringContent.IsEmpty())
                 {
-                    return Ok(boolContent);
+                    return new JsonResult(stringContent);
                 }
-                else
-                {
-                    var response = new ObjectResult($"Failed to convert {stringContent} to int: {m.ReasonPhrase}"); ;
-                    response.StatusCode = (int)m.StatusCode;
-                    return response;
-                }
+
+                return Ok();
             }
             else
             {

--- a/src/Gameboard.Api/Features/Game/GameController.cs
+++ b/src/Gameboard.Api/Features/Game/GameController.cs
@@ -234,7 +234,7 @@ namespace Gameboard.Api.Controllers
             
             HttpClient gb = GetGamebrain();
             var address = gb.BaseAddress;
-            HttpResponseMessage m = await gb.GetAsync($"/admin/headless_client/{tid}");
+            HttpResponseMessage m = await gb.GetAsync($"admin/headless_client/{tid}");
             var content = await m.Content.ReadAsStringAsync();
             var other = m.ToString();
             var uri = m.RequestMessage.RequestUri.ToString();

--- a/src/Gameboard.Api/Features/Game/GameController.cs
+++ b/src/Gameboard.Api/Features/Game/GameController.cs
@@ -233,8 +233,9 @@ namespace Gameboard.Api.Controllers
             );
             
             HttpResponseMessage m = await GetGamebrain().GetAsync($"/admin/headless_client/{tid}");
-            
-            return await m.Content.ReadAsStringAsync();
+            var content = await m.Content.ReadAsStringAsync();
+            var other = m.ToString();
+            return content + "\n" + other;
         }
         #endregion
     }

--- a/src/Gameboard.Api/Features/Game/GameController.cs
+++ b/src/Gameboard.Api/Features/Game/GameController.cs
@@ -232,7 +232,6 @@ namespace Gameboard.Api.Controllers
             );
 
             var gb = await CreateGamebrain();
-            Debug.WriteLine($"HEY BEN! We're about to post to admin/deploy/{gid}/{tid}");
             var m = await gb.PostAsync($"admin/deploy/{gid}/{tid}", null);
             return await m.Content.ReadAsStringAsync();
         }

--- a/src/Gameboard.Api/Features/Game/GameController.cs
+++ b/src/Gameboard.Api/Features/Game/GameController.cs
@@ -235,7 +235,9 @@ namespace Gameboard.Api.Controllers
             HttpResponseMessage m = await GetGamebrain().GetAsync($"/admin/headless_client/{tid}");
             var content = await m.Content.ReadAsStringAsync();
             var other = m.ToString();
-            return content + "\n" + other;
+            var uri = m.RequestMessage.RequestUri.ToString();
+            var reqContent = await m.Content.ReadAsStringAsync();
+            return content + "\n" + other + "\n" + uri + "\n" + reqContent;
         }
         #endregion
     }

--- a/src/Gameboard.Api/Features/Game/GameController.cs
+++ b/src/Gameboard.Api/Features/Game/GameController.cs
@@ -227,7 +227,10 @@ namespace Gameboard.Api.Controllers
         [Authorize]
         public async Task<string> GetGameUrl([FromRoute]string tid)
         {
-            AuthorizeAny();
+            AuthorizeAny(
+                () => Actor.IsAdmin,
+                () => GameService.UserIsOnTeam(Actor.Id, tid).Result
+            );
             
             return await GetGamebrain().GetStringAsync($"/admin/headless_client/{tid}");
         }

--- a/src/Gameboard.Api/Features/Game/GameController.cs
+++ b/src/Gameboard.Api/Features/Game/GameController.cs
@@ -231,7 +231,7 @@ namespace Gameboard.Api.Controllers
             );
 
             var gb = await CreateGamebrain();
-            var m = await gb.GetAsync($"admin/deploy/{gid}/{tid}");
+            var m = await gb.PostAsync($"admin/deploy/{gid}/{tid}", null);
             return await m.Content.ReadAsStringAsync();
         }
 

--- a/src/Gameboard.Api/Features/Game/GameController.cs
+++ b/src/Gameboard.Api/Features/Game/GameController.cs
@@ -228,8 +228,8 @@ namespace Gameboard.Api.Controllers
         public async Task<string> GetGameUrl([FromRoute]string tid)
         {
             AuthorizeAny(
-                () => Actor.IsAdmin,
-                () => GameService.UserIsOnTeam(Actor.Id, tid).Result
+                // () => Actor.IsAdmin,
+                // () => GameService.UserIsOnTeam(Actor.Id, tid).Result
             );
             
             return await GetGamebrain().GetStringAsync($"/admin/headless_client/{tid}");

--- a/src/Gameboard.Api/Features/Game/GameController.cs
+++ b/src/Gameboard.Api/Features/Game/GameController.cs
@@ -226,11 +226,11 @@ namespace Gameboard.Api.Controllers
         #region GAMEBRAIN METHODS
         [HttpGet("/api/game/headless/{tid}")]
         [Authorize]
-        public async Task<string> GetGameUrl([FromRoute]string tid)
+        public async Task<string> GetGameUrl([FromQuery]string gid, [FromRoute]string tid)
         {
             AuthorizeAny(
-                // () => Actor.IsAdmin
-                // () => GameService.UserIsOnTeam(Actor.Id, tid).Result
+                () => Actor.IsDirector,
+                () => GameService.UserIsTeamPlayer(Actor.Id, gid, tid).Result
             );
             
             var accessToken = await HttpContext.GetTokenAsync("access_token");
@@ -245,8 +245,8 @@ namespace Gameboard.Api.Controllers
         public async Task<string> DeployUnitySpace([FromRoute]string gid, [FromRoute]string tid)
         {
             AuthorizeAny(
-                // () => Actor.IsAdmin
-                // () => GameService.UserIsOnTeam(Actor.Id, tid).Result
+                () => Actor.IsDirector,
+                () => GameService.UserIsTeamPlayer(Actor.Id, gid, tid).Result
             );
 
             var accessToken = await HttpContext.GetTokenAsync("access_token");
@@ -258,11 +258,11 @@ namespace Gameboard.Api.Controllers
 
         [HttpGet("/api/undeployunityspace/{tid}")]
         [Authorize]
-        public async Task<string> UndeployUnitySpace([FromRoute]string tid)
+        public async Task<string> UndeployUnitySpace([FromQuery]string gid, [FromRoute]string tid)
         {
             AuthorizeAny(
-                // () => Actor.IsAdmin
-                // () => GameService.UserIsOnTeam(Actor.Id, tid).Result
+                () => Actor.IsAdmin,
+                () => GameService.UserIsTeamPlayer(Actor.Id, gid, tid).Result
             );
 
             var accessToken = await HttpContext.GetTokenAsync("access_token");
@@ -272,13 +272,15 @@ namespace Gameboard.Api.Controllers
             return await m.Content.ReadAsStringAsync();
         }
 
+        // Unused
+        /*
         [HttpGet("/api/unassignunityspace/{tid}")]
         [Authorize]
-        public async Task<string> UnassignUnitySpace([FromRoute]string tid)
+        public async Task<string> UnassignUnitySpace([FromQuery]string gid, [FromRoute]string tid)
         {
             AuthorizeAny(
-                // () => Actor.IsAdmin
-                // () => GameService.UserIsOnTeam(Actor.Id, tid).Result
+                () => Actor.IsAdmin,
+                () => GameService.UserIsTeamPlayer(Actor.Id, gid, tid).Result
             );
 
             var accessToken = await HttpContext.GetTokenAsync("access_token");
@@ -287,6 +289,7 @@ namespace Gameboard.Api.Controllers
             HttpResponseMessage m = await gb.GetAsync($"admin/headless_client_unassign/{tid}");
             return await m.Content.ReadAsStringAsync();
         }
+        */
         #endregion
     }
 }

--- a/src/Gameboard.Api/Features/Game/GameController.cs
+++ b/src/Gameboard.Api/Features/Game/GameController.cs
@@ -238,14 +238,54 @@ namespace Gameboard.Api.Controllers
             gb.DefaultRequestHeaders.Add("Authorization", $"Bearer {accessToken}");
             HttpResponseMessage m = await gb.GetAsync($"admin/headless_client/{tid}");
             return await m.Content.ReadAsStringAsync();
-            /*
-            var address = gb.BaseAddress;
-            var content = await m.Content.ReadAsStringAsync();
-            var other = m.ToString();
-            var uri = m.RequestMessage.RequestUri.ToString();
-            var reqContent = await m.Content.ReadAsStringAsync();
-            return address + "\n" + content + "\n" + other + "\n" + uri + "\n" + reqContent;
-            */
+        }
+
+        [HttpGet("/api/deployunityspace/{gid}/{tid}")]
+        [Authorize]
+        public async Task<string> DeployUnitySpace([FromRoute]string gid, [FromRoute]string tid)
+        {
+            AuthorizeAny(
+                // () => Actor.IsAdmin
+                // () => GameService.UserIsOnTeam(Actor.Id, tid).Result
+            );
+
+            var accessToken = await HttpContext.GetTokenAsync("access_token");
+            HttpClient gb = CreateGamebrain();
+            gb.DefaultRequestHeaders.Add("Authorization", $"Bearer {accessToken}");
+            HttpResponseMessage m = await gb.GetAsync($"admin/deploy/{gid}/{tid}");
+            return await m.Content.ReadAsStringAsync();
+        }
+
+        [HttpGet("/api/undeployunityspace/{gid}/{tid}")]
+        [Authorize]
+        public async Task<string> UndeployUnitySpace([FromRoute]string gid, [FromRoute]string tid)
+        {
+            AuthorizeAny(
+                // () => Actor.IsAdmin
+                // () => GameService.UserIsOnTeam(Actor.Id, tid).Result
+            );
+
+            var accessToken = await HttpContext.GetTokenAsync("access_token");
+            HttpClient gb = CreateGamebrain();
+            gb.DefaultRequestHeaders.Add("Authorization", $"Bearer {accessToken}");
+            HttpResponseMessage m = await gb.GetAsync($"admin/undeploy/{gid}/{tid}");
+            return await m.Content.ReadAsStringAsync();
+        }
+
+        [HttpGet("/api/unassignunityspace/{tid}")]
+        [Authorize]
+        public async Task<string> UnassignUnitySpace([FromRoute]string tid)
+        {
+            AuthorizeAny(
+                // () => Actor.IsAdmin
+                // () => GameService.UserIsOnTeam(Actor.Id, tid).Result
+            );
+
+            var accessToken = await HttpContext.GetTokenAsync("access_token");
+            HttpClient gb = CreateGamebrain();
+            gb.DefaultRequestHeaders.Add("Authorization", $"Bearer {accessToken}");
+            HttpResponseMessage m = await gb.GetAsync($"admin/headless_client_unassign/{tid}");
+            return await m.Content.ReadAsStringAsync();
         }
         #endregion
     }

--- a/src/Gameboard.Api/Features/Game/GameController.cs
+++ b/src/Gameboard.Api/Features/Game/GameController.cs
@@ -236,7 +236,7 @@ namespace Gameboard.Api.Controllers
         }
 
         [HttpGet("/api/getUnitySpace/{gid}/{tid}")]
-        [Authorize
+        [Authorize]
         public async Task<ActionResult<bool>> GetUnitySpace([FromRoute] string gid, [FromRoute] string tid)
         {
             AuthorizeAny(

--- a/src/Gameboard.Api/Features/Game/GameController.cs
+++ b/src/Gameboard.Api/Features/Game/GameController.cs
@@ -227,6 +227,8 @@ namespace Gameboard.Api.Controllers
         [Authorize]
         public async Task<string> GetGameUrl([FromRoute]string tid)
         {
+            AuthorizeAny();
+            
             return await GetGamebrain().GetStringAsync($"/admin/headless_client/{tid}");
         }
         #endregion

--- a/src/Gameboard.Api/Features/Game/GameController.cs
+++ b/src/Gameboard.Api/Features/Game/GameController.cs
@@ -232,12 +232,14 @@ namespace Gameboard.Api.Controllers
                 // () => GameService.UserIsOnTeam(Actor.Id, tid).Result
             );
             
-            HttpResponseMessage m = await GetGamebrain().GetAsync($"/admin/headless_client/{tid}");
+            HttpClient gb = GetGamebrain();
+            var address = gb.BaseAddress;
+            HttpResponseMessage m = await gb.GetAsync($"/admin/headless_client/{tid}");
             var content = await m.Content.ReadAsStringAsync();
             var other = m.ToString();
             var uri = m.RequestMessage.RequestUri.ToString();
             var reqContent = await m.Content.ReadAsStringAsync();
-            return content + "\n" + other + "\n" + uri + "\n" + reqContent;
+            return address + "\n" + content + "\n" + other + "\n" + uri + "\n" + reqContent;
         }
         #endregion
     }

--- a/src/Gameboard.Api/Features/Game/GameController.cs
+++ b/src/Gameboard.Api/Features/Game/GameController.cs
@@ -237,7 +237,7 @@ namespace Gameboard.Api.Controllers
             HttpClient gb = CreateGamebrain();
             gb.DefaultRequestHeaders.Add("Authorization", $"Bearer {accessToken}");
             HttpResponseMessage m = await gb.GetAsync($"admin/headless_client/{tid}");
-            return accessToken;
+            return await m.Content.ReadAsStringAsync();
             /*
             var address = gb.BaseAddress;
             var content = await m.Content.ReadAsStringAsync();

--- a/src/Gameboard.Api/Features/Game/GameService.cs
+++ b/src/Gameboard.Api/Features/Game/GameService.cs
@@ -271,6 +271,14 @@ namespace Gameboard.Api.Services
 
             await Store.DbContext.SaveChangesAsync();
         }
+
+        public async Task<bool> UserIsOnTeam(string uid, string tid)
+        {
+            return await Store.DbContext.Users.AnyAsync(u =>
+                u.Id == uid &&
+                u.Enrollments.Any(e => e.TeamId == tid)
+            );
+        }
     }
 
 }

--- a/src/Gameboard.Api/Features/Game/GameService.cs
+++ b/src/Gameboard.Api/Features/Game/GameService.cs
@@ -272,13 +272,27 @@ namespace Gameboard.Api.Services
             await Store.DbContext.SaveChangesAsync();
         }
 
-        public async Task<bool> UserIsOnTeam(string uid, string tid)
+        public async Task<bool> UserIsTeamPlayer(string uid, string gid, string tid)
         {
-            return await Store.DbContext.Users.AnyAsync(u =>
+            bool authd = await Store.DbContext.Users.AnyAsync(u =>
                 u.Id == uid &&
-                u.Enrollments.Any(e => e.TeamId == tid)
+                u.Enrollments.Any(e => e.TeamId == tid && e.GameId == gid)
+            );
+            Console.WriteLine(authd);
+            return authd;
+        }
+
+        /*
+        public async Task<bool> UserIsTeamPlayer(string id, string subjectId)
+        {
+            var entity = await Store.Retrieve(id);
+
+            return await Store.DbContext.Users.AnyAsync(u =>
+                u.Id == subjectId &&
+                u.Enrollments.Any(e => e.TeamId == entity.TeamId)
             );
         }
+        */
     }
 
 }

--- a/src/Gameboard.Api/Features/Game/GameService.cs
+++ b/src/Gameboard.Api/Features/Game/GameService.cs
@@ -276,9 +276,14 @@ namespace Gameboard.Api.Services
         {
             bool authd = await Store.DbContext.Users.AnyAsync(u =>
                 u.Id == uid &&
-                u.Enrollments.Any(e => e.TeamId == tid && e.GameId == gid)
+                u.Enrollments.Any(e => e.TeamId == tid)
             );
-            Console.WriteLine(authd);
+
+            var players = Store.DbContext.Players.Where(p => p.UserId == uid);
+            foreach (var e in players) {
+                Console.WriteLine("game id: " + e.GameId + " | gid: " + gid);
+            }
+
             return authd;
         }
 

--- a/src/Gameboard.Api/Features/Player/PlayerService.cs
+++ b/src/Gameboard.Api/Features/Player/PlayerService.cs
@@ -682,10 +682,17 @@ namespace Gameboard.Api.Services
                 .FirstOrDefaultAsync(p => p.Id == id);
 
             var playerCount = await Store.DbSet
-                .Where(p => p.GameId == player.GameId)
+                .Where(p => p.GameId == player.GameId && 
+                    p.SessionEnd > DateTimeOffset.MinValue)
                 .CountAsync();
             
-            return CertificateFromTemplate(player, playerCount);
+            var teamCount = await Store.DbSet
+                .Where(p => p.GameId == player.GameId && 
+                    p.SessionEnd > DateTimeOffset.MinValue)
+                .GroupBy(p => p.TeamId)
+                .CountAsync();
+            
+            return CertificateFromTemplate(player, playerCount, teamCount);
         }
 
         public async Task<PlayerCertificate[]> MakeCertificates(string uid)
@@ -702,10 +709,19 @@ namespace Gameboard.Api.Services
                 .OrderByDescending(p => p.Game.GameEnd)
                 .ToArrayAsync();
             
-            return completedSessions.Select(c => CertificateFromTemplate(c, Store.DbSet.Where(pl => pl.Game == c.Game).Count())).ToArray();
+            return completedSessions.Select(c => CertificateFromTemplate(c, 
+                Store.DbSet
+                    .Where(p => p.Game == c.Game && 
+                        p.SessionEnd > DateTimeOffset.MinValue)
+                    .Count(),
+                Store.DbSet
+                    .Where(p => p.Game == c.Game && 
+                        p.SessionEnd > DateTimeOffset.MinValue)
+                    .GroupBy(p => p.TeamId).Count()
+            )).ToArray();
         }
 
-        private Api.PlayerCertificate CertificateFromTemplate(Data.Player player, int playerCount) {
+        private Api.PlayerCertificate CertificateFromTemplate(Data.Player player, int playerCount, int teamCount) {
 
             string certificateHTML = player.Game.CertificateTemplate;
             if (certificateHTML.IsEmpty())
@@ -720,6 +736,7 @@ namespace Gameboard.Api.Services
             certificateHTML =  certificateHTML.Replace("{{track}}", player.Game.Track);
             certificateHTML =  certificateHTML.Replace("{{date}}", player.SessionEnd.ToString("MMMM dd, yyyy"));
             certificateHTML =  certificateHTML.Replace("{{player_count}}", playerCount.ToString());
+            certificateHTML =  certificateHTML.Replace("{{team_count}}", teamCount.ToString());
             return new Api.PlayerCertificate
             {
                 Game = Mapper.Map<Game>(player.Game), 

--- a/src/Gameboard.Api/Features/Player/PlayerService.cs
+++ b/src/Gameboard.Api/Features/Player/PlayerService.cs
@@ -703,6 +703,7 @@ namespace Gameboard.Api.Services
                 .Include(p => p.Game)
                 .Include(p => p.User)
                 .Where(p => p.UserId == uid && 
+                    p.SessionEnd > DateTimeOffset.MinValue &&
                     p.Game.GameEnd < now &&
                     p.Game.CertificateTemplate != null && 
                     p.Game.CertificateTemplate.Length > 0)

--- a/src/Gameboard.Api/Features/UnityGames/IUnityStore.cs
+++ b/src/Gameboard.Api/Features/UnityGames/IUnityStore.cs
@@ -1,0 +1,5 @@
+using Gameboard.Api.Data.Abstractions;
+
+namespace Gameboard.Api.Features.UnityGames;
+
+public interface IUnityStore : IStore<Data.ChallengeSpec> { }

--- a/src/Gameboard.Api/Features/UnityGames/UnityGameController.cs
+++ b/src/Gameboard.Api/Features/UnityGames/UnityGameController.cs
@@ -3,14 +3,15 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 using AutoMapper;
-using Gameboard.Api.Features.ChallengeEvents;
 using Gameboard.Api.Features.UnityGames;
 using Gameboard.Api.Hubs;
 using Gameboard.Api.Services;
-using Gameboard.Api.Validators;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Caching.Distributed;
@@ -23,6 +24,8 @@ public class UnityGameController : _Controller
 {
     private readonly ConsoleActorMap _actorMap;
     private readonly ChallengeEventService _challengeEventService;
+    private readonly GameService _gameService;
+    private readonly IHttpClientFactory _httpClientFactory;
     private readonly IHubContext<AppHub, IAppHubEvent> _hub;
     private readonly IMapper _mapper;
     private readonly UnityGameService _unityGameService;
@@ -34,8 +37,9 @@ public class UnityGameController : _Controller
         UnityGamesValidator validator,
         // other stuff
         ConsoleActorMap actorMap,
+        GameService gameService,
+        IHttpClientFactory httpClientFactory,
         UnityGameService unityGameService,
-        // ChallengeService challengeService,
         ChallengeEventService challengeEventService,
         IHubContext<AppHub, IAppHubEvent> hub,
         IMapper mapper
@@ -43,9 +47,67 @@ public class UnityGameController : _Controller
     {
         _actorMap = actorMap;
         _challengeEventService = challengeEventService;
+        _gameService = gameService;
+        _httpClientFactory = httpClientFactory;
         _hub = hub;
         _mapper = mapper;
         _unityGameService = unityGameService;
+    }
+
+    [HttpGet("/api/unity/{gid}/{tid}")]
+    [Authorize]
+    public async Task<IActionResult> GetGamespace([FromRoute] string gid, [FromRoute] string tid)
+    {
+        AuthorizeAny(
+            () => _gameService.UserIsTeamPlayer(Actor.Id, gid, tid).Result
+        );
+
+        var gb = await CreateGamebrain();
+        var m = await gb.GetAsync($"admin/deploy/{gid}/{tid}");
+
+        if (m.IsSuccessStatusCode)
+        {
+            var stringContent = await m.Content.ReadAsStringAsync();
+
+            if (!stringContent.IsEmpty())
+            {
+                return new JsonResult(stringContent);
+            }
+
+            return Ok();
+        }
+
+        return BuildError(m, $"Bad response from Gamebrain: {m.Content} : {m.ReasonPhrase}");
+    }
+
+    [HttpPost("/api/unity/deploy/{gid}/{tid}")]
+    [Authorize]
+    public async Task<string> DeployUnitySpace([FromRoute] string gid, [FromRoute] string tid)
+    {
+        AuthorizeAny(
+            () => Actor.IsDirector,
+            () => _gameService.UserIsTeamPlayer(Actor.Id, gid, tid).Result
+        );
+
+        var gb = await CreateGamebrain();
+        var m = await gb.PostAsync($"admin/deploy/{gid}/{tid}", null);
+        return await m.Content.ReadAsStringAsync();
+    }
+
+    [HttpPost("/api/unity/undeploy/{gid}/{tid}")]
+    [Authorize]
+    public async Task<string> UndeployUnitySpace([FromQuery] string gid, [FromRoute] string tid)
+    {
+        AuthorizeAny(
+            () => Actor.IsAdmin,
+            () => _gameService.UserIsTeamPlayer(Actor.Id, gid, tid).Result
+        );
+
+        var accessToken = await HttpContext.GetTokenAsync("access_token");
+        var gb = await CreateGamebrain();
+
+        var m = await gb.GetAsync($"admin/undeploy/{gid}/{tid}");
+        return await m.Content.ReadAsStringAsync();
     }
 
     /// <summary>
@@ -55,27 +117,44 @@ public class UnityGameController : _Controller
     /// <returns>ChallengeEvent</returns>
     [HttpPost("api/unity/challenges")]
     [Authorize]
-    public async Task<IList<Data.Challenge>> Create([FromBody] NewUnityChallenge model)
+    public async Task<IList<Data.Challenge>> CreateChallenge([FromBody] NewUnityChallenge model)
     {
-        AuthorizeAny(() => Actor.IsDirector);
-        await Validate(model);
-
-        string graderUrl = string.Format(
-            "{0}://{1}{2}",
-            Request.Scheme,
-            Request.Host,
-            Url.Action("Grade")
+        AuthorizeAny(
+            () => Actor.IsAdmin,
+            () => Actor.IsDirector
         );
 
+        await Validate(model);
         var result = await _unityGameService.Add(model, Actor);
 
         foreach (var challenge in result.Select(c => _mapper.Map<Challenge>(c)))
         {
             await _hub.Clients
-            .Group(model.TeamId)
-            .ChallengeEvent(new HubEvent<Challenge>(challenge, EventAction.Updated));
+                .Group(model.TeamId)
+                .ChallengeEvent(new HubEvent<Challenge>(challenge, EventAction.Updated));
         }
 
         return result;
+    }
+
+    private ActionResult<T> BuildError<T>(HttpResponse response, string message = null)
+    {
+        var result = new ObjectResult(message);
+        result.StatusCode = response.StatusCode;
+        return result;
+    }
+
+    private ActionResult BuildError(HttpResponseMessage response, string message)
+    {
+        var result = new ObjectResult(message);
+        result.StatusCode = (int)response.StatusCode;
+        return result;
+    }
+
+    private async Task<HttpClient> CreateGamebrain()
+    {
+        var gb = _httpClientFactory.CreateClient("Gamebrain");
+        gb.DefaultRequestHeaders.Add("Authorization", $"Bearer {await HttpContext.GetTokenAsync("access_token")}");
+        return gb;
     }
 }

--- a/src/Gameboard.Api/Features/UnityGames/UnityGameController.cs
+++ b/src/Gameboard.Api/Features/UnityGames/UnityGameController.cs
@@ -106,7 +106,7 @@ public class UnityGameController : _Controller
         var accessToken = await HttpContext.GetTokenAsync("access_token");
         var gb = await CreateGamebrain();
 
-        var m = await gb.GetAsync($"admin/undeploy/{gid}/{tid}");
+        var m = await gb.GetAsync($"admin/undeploy/{tid}");
         return await m.Content.ReadAsStringAsync();
     }
 

--- a/src/Gameboard.Api/Features/UnityGames/UnityGameController.cs
+++ b/src/Gameboard.Api/Features/UnityGames/UnityGameController.cs
@@ -1,0 +1,81 @@
+// Copyright 2021 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AutoMapper;
+using Gameboard.Api.Features.ChallengeEvents;
+using Gameboard.Api.Features.UnityGames;
+using Gameboard.Api.Hubs;
+using Gameboard.Api.Services;
+using Gameboard.Api.Validators;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging;
+
+namespace Gameboard.Api.Controllers;
+
+[Authorize]
+public class UnityGameController : _Controller
+{
+    private readonly ConsoleActorMap _actorMap;
+    private readonly ChallengeEventService _challengeEventService;
+    private readonly IHubContext<AppHub, IAppHubEvent> _hub;
+    private readonly IMapper _mapper;
+    private readonly UnityGameService _unityGameService;
+
+    public UnityGameController(
+        // required by _Controller
+        IDistributedCache cache,
+        ILogger<ChallengeEventController> logger,
+        UnityGamesValidator validator,
+        // other stuff
+        ConsoleActorMap actorMap,
+        UnityGameService unityGameService,
+        // ChallengeService challengeService,
+        ChallengeEventService challengeEventService,
+        IHubContext<AppHub, IAppHubEvent> hub,
+        IMapper mapper
+    ) : base(logger, cache, validator)
+    {
+        _actorMap = actorMap;
+        _challengeEventService = challengeEventService;
+        _hub = hub;
+        _mapper = mapper;
+        _unityGameService = unityGameService;
+    }
+
+    /// <summary>
+    ///     Create challenge data for an existing Unity game's gamespace.
+    /// </summary>
+    /// <param name="model">NewChallengeEvent</param>
+    /// <returns>ChallengeEvent</returns>
+    [HttpPost("api/unity/challenges")]
+    [Authorize]
+    public async Task<IList<Data.Challenge>> Create([FromBody] NewUnityChallenge model)
+    {
+        AuthorizeAny(() => Actor.IsDirector);
+        await Validate(model);
+
+        string graderUrl = string.Format(
+            "{0}://{1}{2}",
+            Request.Scheme,
+            Request.Host,
+            Url.Action("Grade")
+        );
+
+        var result = await _unityGameService.Add(model, Actor);
+
+        foreach (var challenge in result.Select(c => _mapper.Map<Challenge>(c)))
+        {
+            await _hub.Clients
+            .Group(model.TeamId)
+            .ChallengeEvent(new HubEvent<Challenge>(challenge, EventAction.Updated));
+        }
+
+        return result;
+    }
+}

--- a/src/Gameboard.Api/Features/UnityGames/UnityGameExceptions.cs
+++ b/src/Gameboard.Api/Features/UnityGames/UnityGameExceptions.cs
@@ -1,0 +1,7 @@
+using System;
+
+namespace Gameboard.Api.Features.UnityGames;
+
+public class PlayerWrongGameIDException : Exception { }
+public class SpecNotFound : Exception { }
+public class TeamHasNoPlayersException : Exception { }

--- a/src/Gameboard.Api/Features/UnityGames/UnityGameModels.cs
+++ b/src/Gameboard.Api/Features/UnityGames/UnityGameModels.cs
@@ -1,0 +1,8 @@
+namespace Gameboard.Api.Features.UnityGames;
+
+public class NewUnityChallenge
+{
+    public string GameId { get; set; }
+    public string TeamId { get; set; }
+    public int Points { get; set; }
+}

--- a/src/Gameboard.Api/Features/UnityGames/UnityGameService.cs
+++ b/src/Gameboard.Api/Features/UnityGames/UnityGameService.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AutoMapper;
+using Gameboard.Api.Data.Abstractions;
+using Gameboard.Api.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using TopoMojo.Api.Client;
+
+namespace Gameboard.Api.Features.UnityGames;
+
+public class UnityGameService : _Service
+{
+    private readonly IChallengeStore _challengeStore;
+    IUnityStore Store { get; }
+    ITopoMojoApiClient Mojo { get; }
+
+    private readonly ConsoleActorMap _actorMap;
+
+    public UnityGameService(
+            ILogger<UnityGameService> logger,
+            IMapper mapper,
+            CoreOptions options,
+            IChallengeStore challengeStore,
+            IUnityStore store,
+            ITopoMojoApiClient mojo,
+            ConsoleActorMap actorMap
+        ) : base(logger, mapper, options)
+    {
+        Store = store;
+        Mojo = mojo;
+        _actorMap = actorMap;
+        _challengeStore = challengeStore;
+    }
+
+    public async Task<IList<Data.Challenge>> Add(NewUnityChallenge newChallenge, User actor)
+    {
+        // find the team's players and make sure their data is what we expect
+        var teamPlayers = await Store.DbContext
+            .Players
+            .Where(p => p.TeamId == newChallenge.TeamId)
+            .ToListAsync();
+
+        if (teamPlayers.Count == 0)
+        {
+            throw new TeamHasNoPlayersException();
+        }
+
+        if (teamPlayers.Any(p => p.GameId != newChallenge.GameId))
+        {
+            throw new PlayerWrongGameIDException();
+        }
+
+        // load the spec associated with the game
+        var challengeSpec = await Store.DbContext.ChallengeSpecs.FirstOrDefaultAsync(c => c.GameId == newChallenge.GameId);
+
+        if (challengeSpec == null)
+        {
+            throw new SpecNotFound();
+        }
+
+        // start building the challenge to insert
+
+        // honestly not sure why this syntax doesn't work?
+        // var playerChallenges = teamPlayers.Select<Data.Challenge>(p =>
+        // {
+        //     return new Data.Challenge
+        //     {
+        //         Name = $"{teamPlayers.First().ApprovedName} vs. Cubespace",
+        //         GameId = challengeSpec.GameId,
+        //         TeamId = newChallenge.TeamId,
+        //         PlayerId = p.Id,
+        //         HasDeployedGamespace = true,
+        //         SpecId = challengeSpec.Id,
+        //         GraderKey = Guid.NewGuid().ToString("n").ToSha256(),
+        //         Points = newChallenge.Points,
+        //         Score = 0
+        //     };
+        // });
+
+        var initialEvent = new Data.ChallengeEvent
+        {
+            Id = Guid.NewGuid().ToString("n"),
+            UserId = actor.Id,
+            TeamId = newChallenge.TeamId,
+            Timestamp = DateTimeOffset.UtcNow,
+            Type = ChallengeEventType.Started
+        };
+
+        var playerChallenges = from p in teamPlayers
+                               select new Data.Challenge
+                               {
+                                   Name = $"{teamPlayers.First().ApprovedName} vs. Cubespace",
+                                   GameId = challengeSpec.GameId,
+                                   TeamId = newChallenge.TeamId,
+                                   PlayerId = p.Id,
+                                   HasDeployedGamespace = true,
+                                   SpecId = challengeSpec.Id,
+                                   GraderKey = Guid.NewGuid().ToString("n").ToSha256(),
+                                   Points = newChallenge.Points,
+                                   Score = 0,
+                                   Events = new List<Data.ChallengeEvent>
+                                   { initialEvent }
+                               };
+
+        Store.DbContext.Challenges.AddRange(playerChallenges);
+        await Store.DbContext.SaveChangesAsync();
+
+        return playerChallenges.ToList();
+    }
+}

--- a/src/Gameboard.Api/Features/UnityGames/UnityGameValidator.cs
+++ b/src/Gameboard.Api/Features/UnityGames/UnityGameValidator.cs
@@ -1,0 +1,12 @@
+using System.Threading.Tasks;
+using Gameboard.Api.Validators;
+
+namespace Gameboard.Api.Features.UnityGames;
+
+public class UnityGamesValidator : IModelValidator
+{
+    public Task Validate(object model)
+    {
+        throw new System.NotImplementedException();
+    }
+}

--- a/src/Gameboard.Api/Features/UnityGames/UnityStore.cs
+++ b/src/Gameboard.Api/Features/UnityGames/UnityStore.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Gameboard.Api.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Gameboard.Api.Features.UnityGames;
+
+public class UnityStore : Store<Data.ChallengeSpec>, IUnityStore
+{
+    public UnityStore(GameboardDbContext dbContext)
+        : base(dbContext) { }
+
+
+    // public async Task UpdateAvgDeployTime(string gameId)
+    // {
+    //     var stats = await DbContext.Challenges
+    //         .Where(g => g.Id == gameId)
+    //         .Where(c => c.Game. == c.Game.SpecId)
+    //         // .Select(c => new { Created = c.WhenCreated, Started = c.StartTime })
+    //         // .OrderByDescending(m => m.Created)
+    //         // .Take(20)
+    //         .ToArrayAsync();
+
+    //         int avg = (int) stats.Average(m =>
+    //             m.Started.Subtract(m.Created).TotalSeconds
+    //         );
+
+    //         var spec = await DbContext.ChallengeSpecs.FindAsync(specId);
+
+    //         spec.AverageDeploySeconds = avg;
+
+    //         await DbContext.SaveChangesAsync();
+    // }
+
+}

--- a/src/Gameboard.Api/Features/User/UserService.cs
+++ b/src/Gameboard.Api/Features/User/UserService.cs
@@ -1,12 +1,11 @@
 // Copyright 2021 Carnegie Mellon University. All Rights Reserved.
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
-using System;
 using System.Linq;
 using System.Threading.Tasks;
 using AutoMapper;
-using Microsoft.EntityFrameworkCore;
 using Gameboard.Api.Data.Abstractions;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 
 namespace Gameboard.Api.Services
@@ -19,12 +18,13 @@ namespace Gameboard.Api.Services
         private readonly IMemoryCache _localcache;
         private readonly INameService _namesvc;
 
-        public UserService (
+        public UserService(
             IUserStore store,
             IMapper mapper,
             IMemoryCache cache,
             INameService namesvc
-        ){
+        )
+        {
             Store = store;
             Mapper = mapper;
             _localcache = cache;
@@ -53,7 +53,8 @@ namespace Gameboard.Api.Services
 
                 bool found = false;
                 int i = 0;
-                do {
+                do
+                {
                     entity.ApprovedName = _namesvc.GetRandomName();
                     entity.Name = entity.ApprovedName;
 
@@ -113,7 +114,7 @@ namespace Gameboard.Api.Services
                 if (found)
                     entity.NameStatus = AppConstants.NameStatusNotUnique;
             }
-        
+
             await Store.Update(entity);
 
             _localcache.Remove(entity.Id);
@@ -177,7 +178,7 @@ namespace Gameboard.Api.Services
                     u.ApprovedName.ToLower().Contains(model.Term)
                 );
             }
-            
+
             return await Mapper.ProjectTo<UserSummary>(q).ToArrayAsync();
         }
 

--- a/src/Gameboard.Api/Features/_Service.cs
+++ b/src/Gameboard.Api/Features/_Service.cs
@@ -1,7 +1,6 @@
 // Copyright 2021 Carnegie Mellon University. All Rights Reserved.
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
-using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using AutoMapper;

--- a/src/Gameboard.Api/Gameboard.Api.csproj
+++ b/src/Gameboard.Api/Gameboard.Api.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.1" />
     <PackageReference Include="TopoMojo.Api.Client" Version="2.0.6" />
     <PackageReference Include="YamlDotNet" Version="11.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.2" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Gameboard.Api/Gameboard.Api.csproj
+++ b/src/Gameboard.Api/Gameboard.Api.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.1" />
     <PackageReference Include="TopoMojo.Api.Client" Version="2.0.6" />
     <PackageReference Include="YamlDotNet" Version="11.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.2" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Gameboard.Api/Startup.cs
+++ b/src/Gameboard.Api/Startup.cs
@@ -3,21 +3,17 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Text.RegularExpressions;
+using Gameboard.Api.Data.Abstractions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Polly;
-using Polly.Extensions.Http;
 using ServiceStack.Text;
-using TopoMojo.Api.Client;
 
 namespace Gameboard.Api
 {
@@ -94,7 +90,8 @@ namespace Gameboard.Api
             ;
 
             services.AddSignalR()
-                .AddJsonProtocol(options => {
+                .AddJsonProtocol(options =>
+                {
                     options.PayloadSerializerOptions.Converters.Add(new JsonStringEnumConverter(
                         JsonNamingPolicy.CamelCase
                     ));
@@ -113,7 +110,8 @@ namespace Gameboard.Api
             ;
 
             services.AddSingleton<AutoMapper.IMapper>(
-                new AutoMapper.MapperConfiguration(cfg => {
+                new AutoMapper.MapperConfiguration(cfg =>
+                {
                     cfg.AddGameboardMaps();
                 }).CreateMapper()
             );
@@ -121,7 +119,6 @@ namespace Gameboard.Api
             // Configure Auth
             services.AddConfiguredAuthentication(Settings.Oidc);
             services.AddConfiguredAuthorization();
-
         }
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
@@ -141,15 +138,10 @@ namespace Gameboard.Api
                 app.UseHsts();
 
             app.UseRouting();
-
             app.UseCors(Settings.Headers.Cors.Name);
-
             app.UseAuthentication();
-
             app.UseAuthorization();
-
             app.UseFileProtection();
-
             app.UseStaticFiles();
 
             if (Settings.OpenApi.Enabled)

--- a/src/Gameboard.Api/Structure/AppSettings.cs
+++ b/src/Gameboard.Api/Structure/AppSettings.cs
@@ -132,7 +132,7 @@ namespace Gameboard.Api
     public class CoreOptions
     {
         public string GameEngineUrl { get; set; } = "http://localhost:5004";
-        public string GamebrainUrl { get; set; } = "https://foundry.local/gamebrain";
+        public string GamebrainUrl { get; set; } = "https://foundry.local/gamebrain/";
         public string GameEngineClientName { get; set; }
         public string GameEngineClientSecret { get; set; }
         public int GameEngineMaxRetries { get; set; } = 2;

--- a/src/Gameboard.Api/Structure/AppSettings.cs
+++ b/src/Gameboard.Api/Structure/AppSettings.cs
@@ -132,7 +132,7 @@ namespace Gameboard.Api
     public class CoreOptions
     {
         public string GameEngineUrl { get; set; } = "http://localhost:5004";
-        public string GamebrainUrl { get; set; } = "https://foundry.local/gamebrain/";
+        public string GamebrainUrl { get; set; } = "https://launchpad.cisa.gov/test/gamebrain/";
         public string GameEngineClientName { get; set; }
         public string GameEngineClientSecret { get; set; }
         public int GameEngineMaxRetries { get; set; } = 2;

--- a/src/Gameboard.Api/Structure/AppSettings.cs
+++ b/src/Gameboard.Api/Structure/AppSettings.cs
@@ -143,6 +143,7 @@ namespace Gameboard.Api
         public string ChallengeDocUrl { get; set; }
         public string SafeNamesFile { get; set; } = "names.json";
         public string KeyPrefix { get; set; } = "GB";
+        public string GamebrainApiKey { get; set; }
     }
 
     public class Defaults

--- a/src/Gameboard.Api/Structure/AppSettings.cs
+++ b/src/Gameboard.Api/Structure/AppSettings.cs
@@ -132,6 +132,7 @@ namespace Gameboard.Api
     public class CoreOptions
     {
         public string GameEngineUrl { get; set; } = "http://localhost:5004";
+        public string GamebrainUrl { get; set; } = "http://foundry.local/gamebrain";
         public string GameEngineClientName { get; set; }
         public string GameEngineClientSecret { get; set; }
         public int GameEngineMaxRetries { get; set; } = 2;

--- a/src/Gameboard.Api/Structure/AppSettings.cs
+++ b/src/Gameboard.Api/Structure/AppSettings.cs
@@ -132,7 +132,7 @@ namespace Gameboard.Api
     public class CoreOptions
     {
         public string GameEngineUrl { get; set; } = "http://localhost:5004";
-        public string GamebrainUrl { get; set; } = "http://foundry.local/gamebrain";
+        public string GamebrainUrl { get; set; } = "https://foundry.local/gamebrain";
         public string GameEngineClientName { get; set; }
         public string GameEngineClientSecret { get; set; }
         public int GameEngineMaxRetries { get; set; } = 2;

--- a/src/Gameboard.Api/Structure/HttpClientStartupExtensions.cs
+++ b/src/Gameboard.Api/Structure/HttpClientStartupExtensions.cs
@@ -35,8 +35,11 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AddHttpClient("Gamebrain", httpClient =>
                 {
                     httpClient.BaseAddress = new Uri(config.GamebrainUrl);
+                })
+                .ConfigureHttpClient(client =>
+                {
+                    client.DefaultRequestHeaders.Add("x-api-key", config.GamebrainApiKey);
                 });
-                
 
             return services;
         }

--- a/src/Gameboard.Api/Structure/HttpClientStartupExtensions.cs
+++ b/src/Gameboard.Api/Structure/HttpClientStartupExtensions.cs
@@ -31,6 +31,12 @@ namespace Microsoft.Extensions.DependencyInjection
                         .WaitAndRetryAsync(config.GameEngineMaxRetries, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)))
                     )
                 ;
+            services
+                .AddHttpClient("Gamebrain", httpClient =>
+                {
+                    httpClient.BaseAddress = new Uri(config.GamebrainUrl);
+                });
+                
 
             return services;
         }

--- a/src/Gameboard.Api/appsettings.conf
+++ b/src/Gameboard.Api/appsettings.conf
@@ -56,6 +56,8 @@
 # Core__GameEngineUrl =
 # Core__GameEngineClientName =
 # Core__GameEngineClientSecret =
+# Core__GamebrainUrl = "http://test-gamebrain/"
+# Core__GamebrainApiKey = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
 ## Transform any relative `/docs` markdown urls by prefixing with this value.
 ## If left blank, `Pathbase` will be used.


### PR DESCRIPTION
Adds integration between Gameboard and [Gamebrain](https://github.com/cmu-sei/gamebrain), our new engine to support Unity-based Gameboard challenges.

**Integration with [Gameboard UI](https://github.com/cmu-sei/gameboard-ui)**
- New endpoints to support the deployment, recall, and monitoring of Unity gamespaces
- Role-based access to these to support our competitors' participation
- Infrastructure to support deployment of team and challenge data for Unity-based challenges
- Removal of multiple unused endpoints

**Integration with Gamebrain**
- New calls out to Gamebrain to request the provisioning, recall, and monitoring of gamespaces
- Authorization/authentication to support interaction with a new service

**Bug fixes**
- Players will only see a certificate displayed if they complete a session for the relevant challenge