### PR TITLE
Revert use of Serilog

### DIFF
--- a/src/Gameboard.Api/Gameboard.Api.csproj
+++ b/src/Gameboard.Api/Gameboard.Api.csproj
@@ -14,7 +14,6 @@
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="6.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="6.0.1" />
     <PackageReference Include="ServiceStack.Text" Version="5.13.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.1" />

--- a/src/Gameboard.Api/Program.cs
+++ b/src/Gameboard.Api/Program.cs
@@ -7,8 +7,6 @@ using System.Linq;
 using Gameboard.Api.Extensions;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
-using Serilog;
-using Serilog.Formatting.Compact;
 
 namespace Gameboard.Api
 {
@@ -31,31 +29,33 @@ namespace Gameboard.Api
             {
                 try
                 {
-                    Log.Information("Starting Gameboard...");
+                    // Log.Information("Starting Gameboard...");
+                    System.Diagnostics.Debug.WriteLine("Starting Gameboard...");
                     hostBuilder.Run();
                 }
                 catch (Exception ex)
                 {
-                    Log.Fatal($"Gameboard terminated unexpectedly: {ex.GetType().Name} - {ex.Message}");
+                    System.Diagnostics.Debug.WriteLine($"Gameboard terminated unexpectedly: {ex.GetType().Name} - {ex.Message}");
+                    // Log.Fatal($"Gameboard terminated unexpectedly: {ex.GetType().Name} - {ex.Message}");
                 }
                 finally
                 {
-                    Log.CloseAndFlush();
+                    // Log.CloseAndFlush();
                 }
             }
         }
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
-                .UseSerilog((ctx, cfg) =>
-                {
-                    cfg
-                        .MinimumLevel.Override("Microsoft", Serilog.Events.LogEventLevel.Warning)
-                        .Enrich.FromLogContext()
-                        .Enrich.WithProperty("Application", ctx.HostingEnvironment.ApplicationName)
-                        .Enrich.WithProperty("Environment", ctx.HostingEnvironment.EnvironmentName)
-                        .WriteTo.Console(new RenderedCompactJsonFormatter());
-                })
+                // .UseSerilog((ctx, cfg) =>
+                // {
+                //     cfg
+                //         .MinimumLevel.Override("Microsoft", Serilog.Events.LogEventLevel.Warning)
+                //         .Enrich.FromLogContext()
+                //         .Enrich.WithProperty("Application", ctx.HostingEnvironment.ApplicationName)
+                //         .Enrich.WithProperty("Environment", ctx.HostingEnvironment.EnvironmentName)
+                //         .WriteTo.Console(new RenderedCompactJsonFormatter());
+                // })
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.UseStartup<Startup>();

--- a/src/Gameboard.Api/Startup.cs
+++ b/src/Gameboard.Api/Startup.cs
@@ -11,7 +11,6 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Serilog;
 using ServiceStack.Text;
 
 namespace Gameboard.Api
@@ -100,8 +99,6 @@ namespace Gameboard.Api
                 })
             ;
             services.AddSignalRHub();
-
-            services.AddLogging(loggingBuilder => loggingBuilder.AddSerilog(dispose: true));
 
             services
                 .AddSingleton<CoreOptions>(_ => Settings.Core)


### PR DESCRIPTION
Current logging practices depend on a pre-Serilog existing format. We're reverting use of Serilog until we can re-evaluate this implementation.