### PR TITLE
Hotfix/extend permissions on unity challenge creation

### DIFF
--- a/src/Gameboard.Api/Features/UnityGames/UnityGameController.cs
+++ b/src/Gameboard.Api/Features/UnityGames/UnityGameController.cs
@@ -123,9 +123,7 @@ public class UnityGameController : _Controller
     public async Task<Data.Challenge> CreateChallenge([FromBody] NewUnityChallenge model)
     {
         AuthorizeAny(
-            () => Actor.IsDirector,
-            () => Actor.IsAdmin,
-            () => Actor.IsDesigner
+            () => _gameService.UserIsTeamPlayer(Actor.Id, model.GameId, model.TeamId).Result
         );
 
         await Validate(model);


### PR DESCRIPTION
Any player who is on a team can now issue the call to create challenge data for the Cubespace game.