### PR TITLE
Enable score reporting from Gamebrain

### DIFF
--- a/src/Gameboard.Api/Features/UnityGames/UnityGameController.cs
+++ b/src/Gameboard.Api/Features/UnityGames/UnityGameController.cs
@@ -88,7 +88,6 @@ public class UnityGameController : _Controller
     public async Task<string> DeployUnitySpace([FromRoute] string gid, [FromRoute] string tid)
     {
         AuthorizeAny(
-            () => Actor.IsDirector,
             () => _gameService.UserIsTeamPlayer(Actor.Id, gid, tid).Result
         );
 
@@ -103,6 +102,7 @@ public class UnityGameController : _Controller
     {
         AuthorizeAny(
             () => Actor.IsAdmin,
+            () => Actor.IsSupport,
             () => _gameService.UserIsTeamPlayer(Actor.Id, gid, tid).Result
         );
 
@@ -153,13 +153,11 @@ public class UnityGameController : _Controller
         {
             Console.Write("Calling gamebrain failed with", ex);
         }
-        finally
-        {
-            // notify the hub (if there is one)
-            await _hub.Clients
-                .Group(model.TeamId)
-                .ChallengeEvent(new HubEvent<Challenge>(_mapper.Map<Challenge>(result), EventAction.Updated));
-        }
+
+        // notify the hub (if there is one)
+        await _hub.Clients
+            .Group(model.TeamId)
+            .ChallengeEvent(new HubEvent<Challenge>(_mapper.Map<Challenge>(result), EventAction.Updated));
 
         return result;
     }
@@ -188,13 +186,10 @@ public class UnityGameController : _Controller
     public async Task CreateMissionEvent([FromBody] UnityMissionUpdate model)
     {
         AuthorizeAny(
-            () => Actor.IsDirector,
-            () => Actor.IsAdmin,
-            () => Actor.IsDesigner
+            () => Actor.IsAdmin
         );
 
         await Validate(model);
-
         await _unityGameService.CreateMissionEvent(model, Actor);
     }
 

--- a/src/Gameboard.Api/Features/UnityGames/UnityGameExceptions.cs
+++ b/src/Gameboard.Api/Features/UnityGames/UnityGameExceptions.cs
@@ -7,7 +7,7 @@ public class TeamHasNoPlayersException : Exception { }
 
 internal class ChallengeResolutionFailure : GameboardException
 {
-    public ChallengeResolutionFailure(string teamId) : base($"Couldn't resolve the challenge for team ${teamId}.") { }
+    public ChallengeResolutionFailure(string teamId) : base($"Couldn't resolve a Unity challenge for team {teamId}") { }
 }
 
 internal class SemaphoreLockFailure : GameboardException

--- a/src/Gameboard.Api/Features/UnityGames/UnityGameService.cs
+++ b/src/Gameboard.Api/Features/UnityGames/UnityGameService.cs
@@ -194,30 +194,34 @@ internal class UnityGameService : _Service, IUnityGameService
 
     public async Task CreateMissionEvent(UnityMissionUpdate model, Api.User actor)
     {
-        var player = await Store.DbContext
-            .Players
-            .Include(p => p.Challenges)
-            // TODO: need to think about how we ensure, across this service, that
-            // we're loading the unity game (or the right one when we get more than one)
-            .Include(p => p.Game)
-            .FirstOrDefaultAsync(p => p.Game.Mode == "unity" && p.TeamId == model.TeamId);
+        var challenge = await Store.DbContext
+            .Challenges
+            .Include(c => c.Game)
+            .Include(c => c.Events)
+            .Include(c => c.Player)
+            .Where(c => c.TeamId == model.TeamId && c.Game.Mode.ToLowerInvariant() == "unity")
+            .FirstOrDefaultAsync();
 
-        if (player.Challenges.Count() != 1)
+        if (challenge == null)
         {
             throw new ChallengeResolutionFailure(model.TeamId);
         }
 
-        var challengeEvent = new Data.ChallengeEvent()
+        // record an event for this challenge
+        challenge.Events.Add(new Data.ChallengeEvent
         {
-            ChallengeId = player.Challenges.First().Id,
+            ChallengeId = challenge.Id,
             UserId = actor.Id,
             TeamId = model.TeamId,
-            Text = $"{player.ApprovedName} has found the codex for {model.MissionName}!",
+            Text = $"{challenge.Player} has found the codex for {model.MissionName}!",
             Type = ChallengeEventType.Submission,
             Timestamp = DateTimeOffset.UtcNow
-        };
+        });
 
-        await Store.DbContext.ChallengeEvents.AddAsync(challengeEvent);
+        // also update the score of the challenge
+        challenge.Score += model.PointsScored;
+
+        // save it up
         await Store.DbContext.SaveChangesAsync();
     }
 


### PR DESCRIPTION
Gameboard now has an endpoint that allows Gamebrain to report score updates for the active Unity game. Gamebrain will call this endpoint when the players secure a codex and pass a point value, which Gameboard add's to the team's point total for the challenge.