### PR TITLE
Cubespace scoring and logging updates

### DIFF
--- a/src/Gameboard.Api/Features/UnityGames/IUnityGameService.cs
+++ b/src/Gameboard.Api/Features/UnityGames/IUnityGameService.cs
@@ -1,13 +1,12 @@
-using System.Collections.Generic;
 using System.Threading.Tasks;
-using Gameboard.Api.Data;
 
 namespace Gameboard.Api.Features.UnityGames;
 
 public interface IUnityGameService
 {
-    Task<ChallengeEvent> AddChallengeEvent(NewUnityChallengeEvent model, string userId);
     Task<Data.Challenge> AddChallenge(NewUnityChallenge newChallenge, User actor);
-    Task CreateMissionEvent(UnityMissionUpdate model, Api.User actor);
+    Task<Data.ChallengeEvent> CreateMissionEvent(UnityMissionUpdate model, Api.User actor);
     Task DeleteChallengeData(string gameId);
+    bool IsUnityGame(Game game);
+    bool IsUnityGame(Data.Game game);
 }

--- a/src/Gameboard.Api/Features/UnityGames/UnityGameController.cs
+++ b/src/Gameboard.Api/Features/UnityGames/UnityGameController.cs
@@ -162,35 +162,25 @@ public class UnityGameController : _Controller
         return result;
     }
 
-    /// <summary>
-    ///     Log a challenge event for all members of the specified team.
-    /// </summary>
-    /// <param name="model">NewChallengeEvent</param>
-    /// <returns>ChallengeEvent</returns>
-    [HttpPost("api/unity/challengeEvent")]
-    [Authorize]
-    public async Task<Data.ChallengeEvent> CreateChallengeEvent([FromBody] NewUnityChallengeEvent model)
-    {
-        AuthorizeAny(
-            () => Actor.IsDirector,
-            () => Actor.IsAdmin,
-            () => Actor.IsDesigner
-        );
-
-        await Validate(model);
-        return await _unityGameService.AddChallengeEvent(model, Actor.Id);
-    }
-
     [HttpPost("api/unity/mission-update")]
     [Authorize]
-    public async Task CreateMissionEvent([FromBody] UnityMissionUpdate model)
+    public async Task<IActionResult> CreateMissionEvent([FromBody] UnityMissionUpdate model)
     {
         AuthorizeAny(
             () => Actor.IsAdmin
         );
 
         await Validate(model);
-        await _unityGameService.CreateMissionEvent(model, Actor);
+        var challengeEvent = await _unityGameService.CreateMissionEvent(model, Actor);
+
+        if (challengeEvent == null)
+        {
+            // this means that everything went fine, but that we've already been told the team completed this challenge
+            return Accepted();
+        }
+
+        // this means we actually created an event
+        return Ok(challengeEvent);
     }
 
     [Authorize]


### PR DESCRIPTION
- Fixed a bug that caused the team captain's name not to correctly show in the event log when finding a codex
- Slightly adjusted the event log text for Unity mission events
- Guarded against duplicate calls to `CreateMissionEvent` (calls subsequent to the first will receive a 202)
- Encapsulated the definition of a Unity game in the `UnityGameService`
- Removed a deprecated endpoint in the Unity controller