### PR TITLE
New: clarify Unity challenge resolution exceptions

### DIFF
--- a/src/Gameboard.Api/Features/UnityGames/UnityGameExceptions.cs
+++ b/src/Gameboard.Api/Features/UnityGames/UnityGameExceptions.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Gameboard.Api.Features.UnityGames;
 
@@ -7,7 +9,7 @@ public class TeamHasNoPlayersException : Exception { }
 
 internal class ChallengeResolutionFailure : GameboardException
 {
-    public ChallengeResolutionFailure(string teamId) : base($"Couldn't resolve a Unity challenge for team {teamId}") { }
+    public ChallengeResolutionFailure(string teamId, IEnumerable<string> challengeIds) : base($"Couldn't resolve a Unity challenge for team {teamId}. They have {challengeIds.Count()} challenges ({String.Join(" | ", challengeIds)})") { }
 }
 
 internal class SemaphoreLockFailure : GameboardException

--- a/src/Gameboard.Api/Features/UnityGames/UnityGameService.cs
+++ b/src/Gameboard.Api/Features/UnityGames/UnityGameService.cs
@@ -197,7 +197,7 @@ internal class UnityGameService : _Service, IUnityGameService
 
         if (challengeCandidates.Count() != 1)
         {
-            throw new ChallengeResolutionFailure(model.TeamId);
+            throw new ChallengeResolutionFailure(model.TeamId, challengeCandidates.Select(c => c.Id));
         }
 
         // if we return null to the controller above, it interprets this as an "ok cool, we already have this one"


### PR DESCRIPTION
Improved reporting of the exception that is thrown if a Cubespace team ends up with multiple challenges.