### PR TITLE
3.6.20

### DIFF
--- a/src/Gameboard.Api/Features/CubespaceScoreboard/CubespaceScoreboardModels.cs
+++ b/src/Gameboard.Api/Features/CubespaceScoreboard/CubespaceScoreboardModels.cs
@@ -22,6 +22,7 @@ public class CubespaceScoreboardPlayer
 public class CubespaceScoreboardTeam
 {
     public string Id { get; set; }
+    public string CubespaceTeamId { get; set; }
     public string Name { get; set; }
     public IEnumerable<CubespaceScoreboardPlayer> Players { get; set; } = new List<CubespaceScoreboardPlayer>();
     public long Day1Playtime { get; set; }

--- a/src/Gameboard.Api/Features/CubespaceScoreboard/CubespaceScoreboardModels.cs
+++ b/src/Gameboard.Api/Features/CubespaceScoreboard/CubespaceScoreboardModels.cs
@@ -75,6 +75,7 @@ public class CubespaceScoreboardCacheChallenge
     public string TeamName { get; set; }
     public long StartTime { get; set; }
     public long EndTime { get; set; }
+    public long SessionEnd { get; set; }
     public int Score { get; set; }
 
     public long GetDuration()

--- a/src/Gameboard.Api/Features/CubespaceScoreboard/CubespaceScoreboardService.cs
+++ b/src/Gameboard.Api/Features/CubespaceScoreboard/CubespaceScoreboardService.cs
@@ -68,7 +68,6 @@ public class CubespaceScoreboardService : ICubespaceScoreboardService
                 // ignore name for now - we'll resolve it later
                 Day1Score = Math.Floor(p.Challenges.Sum(c => c.Score)),
                 Day1Playtime = p.Time,
-                GameOverAt = p.SessionEnd.ToUnixTimeMilliseconds()
             })
                 .DistinctBy(team => team.Id)
                 .ToList();
@@ -168,7 +167,7 @@ public class CubespaceScoreboardService : ICubespaceScoreboardService
                 else
                 {
                     t.CubespaceStartTime = cachedTeam.CubespaceChallenge.StartTime;
-                    t.GameOverAt = cachedTeam.GameOverAt;
+                    t.GameOverAt = cachedTeam.CubespaceChallenge.SessionEnd;
                     // if they have a challenge, they have a player name for cubespace
                     t.Name = cachedTeam.CubespaceChallenge.TeamName;
 
@@ -249,6 +248,7 @@ public class CubespaceScoreboardService : ICubespaceScoreboardService
             TeamName = model.Player.ApprovedName,
             StartTime = model.StartTime.ToUnixTimeMilliseconds(),
             EndTime = model.EndTime.ToUnixTimeMilliseconds(),
+            SessionEnd = model.Player.SessionEnd.ToUnixTimeMilliseconds(),
             Score = (int)Math.Floor(model.Score)
         };
 

--- a/src/Gameboard.Api/Features/CubespaceScoreboard/CubespaceScoreboardService.cs
+++ b/src/Gameboard.Api/Features/CubespaceScoreboard/CubespaceScoreboardService.cs
@@ -133,7 +133,7 @@ public class CubespaceScoreboardService : ICubespaceScoreboardService
                 }
             }
 
-            // ASSIGN players to teams
+            // compute final scoreboard update by unifying cache with hot data
             foreach (var t in day1Teams)
             {
                 // load what we know about the team from cache to save calls
@@ -166,9 +166,9 @@ public class CubespaceScoreboardService : ICubespaceScoreboardService
                 }
                 else
                 {
+                    t.CubespaceTeamId = cachedTeam.CubespaceChallenge.TeamId;
                     t.CubespaceStartTime = cachedTeam.CubespaceChallenge.StartTime;
                     t.GameOverAt = cachedTeam.CubespaceChallenge.SessionEnd;
-                    // if they have a challenge, they have a player name for cubespace
                     t.Name = cachedTeam.CubespaceChallenge.TeamName;
 
                     // build info about their scored codexes based on challenge events
@@ -231,7 +231,6 @@ public class CubespaceScoreboardService : ICubespaceScoreboardService
         var dict = new Dictionary<string, CubespaceScoreboardCacheChallenge>();
         foreach (var challenge in challenges)
         {
-            Console.WriteLine($"Challenge for team {challenge.TeamId} has {challenge.StartTime.ToUnixTimeMilliseconds()}");
             // note that not all teams may have a cubespace challenge
             dict[challenge.TeamId] = CacheChallengeFromApiModel(challenge);
         }

--- a/src/Gameboard.Api/Features/CubespaceScoreboard/CubespaceScoreboardService.cs
+++ b/src/Gameboard.Api/Features/CubespaceScoreboard/CubespaceScoreboardService.cs
@@ -66,9 +66,8 @@ public class CubespaceScoreboardService : ICubespaceScoreboardService
             {
                 Id = p.TeamId,
                 // ignore name for now - we'll resolve it later
-                Day1Score = Math.Floor(p.Challenges.Sum(c => c.Score)),
+                Day1Score = p.Score,
                 Day1Playtime = p.Time,
-                GameOverAt = p.SessionEnd.ToUnixTimeMilliseconds()
             })
                 .DistinctBy(team => team.Id)
                 .ToList();
@@ -168,7 +167,7 @@ public class CubespaceScoreboardService : ICubespaceScoreboardService
                 else
                 {
                     t.CubespaceStartTime = cachedTeam.CubespaceChallenge.StartTime;
-                    t.GameOverAt = cachedTeam.GameOverAt;
+                    t.GameOverAt = cachedTeam.CubespaceChallenge.SessionEnd;
                     // if they have a challenge, they have a player name for cubespace
                     t.Name = cachedTeam.CubespaceChallenge.TeamName;
 
@@ -249,6 +248,7 @@ public class CubespaceScoreboardService : ICubespaceScoreboardService
             TeamName = model.Player.ApprovedName,
             StartTime = model.StartTime.ToUnixTimeMilliseconds(),
             EndTime = model.EndTime.ToUnixTimeMilliseconds(),
+            SessionEnd = model.Player.SessionEnd.ToUnixTimeMilliseconds(),
             Score = (int)Math.Floor(model.Score)
         };
 


### PR DESCRIPTION
**Cubescore endpoint adjustments**

- Pull SessionEnd from the correct player identity (was previously pulling from the Day 1 player rather than the Cubespace player)
- Restore point computation fix
- Add cubespace team ID to output of Cubescore endpoint