### PR TITLE
Add topomojo doc url to the GET endpoint for gameboards

### DIFF
--- a/src/Gameboard.Api/Data/Entities/Player.cs
+++ b/src/Gameboard.Api/Data/Entities/Player.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Gameboard.Api.Data

--- a/src/Gameboard.Api/Features/Player/Player.cs
+++ b/src/Gameboard.Api/Features/Player/Player.cs
@@ -144,7 +144,7 @@ namespace Gameboard.Api
         public string ApprovedName { get; set; }
     }
 
-    public class PlayerDataFilter: SearchFilter
+    public class PlayerDataFilter : SearchFilter
     {
 
         public const string FilterActiveOnly = "active";
@@ -199,6 +199,7 @@ namespace Gameboard.Api
         public int CorrectCount { get; set; }
         public int PartialCount { get; set; }
         public BoardGame Game { get; set; }
+        public string ChallengeDocUrl { get; set; }
         public ICollection<Challenge> Challenges { get; set; } = new List<Challenge>();
         public bool IsManager => Role == PlayerRole.Manager;
     }
@@ -227,7 +228,7 @@ namespace Gameboard.Api
         public DateTimeOffset SessionEnd { get; set; }
     }
 
-    public class PlayerCertificate 
+    public class PlayerCertificate
     {
         public Game Game { get; set; }
         public Player Player { get; set; }

--- a/src/Gameboard.Api/Features/Player/PlayerController.cs
+++ b/src/Gameboard.Api/Features/Player/PlayerController.cs
@@ -22,6 +22,8 @@ namespace Gameboard.Api.Controllers
         IHubContext<AppHub, IAppHubEvent> Hub { get; }
         IMapper Mapper { get; }
 
+        private readonly CoreOptions _coreOptions;
+
         public PlayerController(
             ILogger<PlayerController> logger,
             IDistributedCache cache,

--- a/src/Gameboard.Api/Features/Player/PlayerService.cs
+++ b/src/Gameboard.Api/Features/Player/PlayerService.cs
@@ -15,6 +15,7 @@ namespace Gameboard.Api.Services
 {
     public class PlayerService
     {
+        CoreOptions CoreOptions { get; }
         IPlayerStore Store { get; }
         IGameStore GameStore { get; }
         IUserStore UserStore { get; }
@@ -24,6 +25,7 @@ namespace Gameboard.Api.Services
         ITopoMojoApiClient Mojo { get; }
 
         public PlayerService(
+            CoreOptions coreOptions,
             IPlayerStore store,
             IUserStore userStore,
             IGameStore gameStore,
@@ -32,6 +34,7 @@ namespace Gameboard.Api.Services
             ITopoMojoApiClient mojo
         )
         {
+            CoreOptions = coreOptions;
             Store = store;
             GameStore = gameStore;
             UserStore = userStore;
@@ -420,9 +423,12 @@ namespace Gameboard.Api.Services
 
         public async Task<BoardPlayer> LoadBoard(string id)
         {
-            return Mapper.Map<BoardPlayer>(
+            var mapped = Mapper.Map<BoardPlayer>(
                 await Store.LoadBoard(id)
             );
+
+            mapped.ChallengeDocUrl = CoreOptions.ChallengeDocUrl;
+            return mapped;
         }
 
         public async Task<TeamInvitation> GenerateInvitation(string id)


### PR DESCRIPTION
Supports a bug fix that enables images embedded in challenge text created on Topo to appear in GB.