### PR TITLE
Changes to player endpoints/hub services session logic changes…

### DIFF
--- a/src/Gameboard.Api/Data/Entities/Challenge.cs
+++ b/src/Gameboard.Api/Data/Entities/Challenge.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
-using System.Text.Json.Serialization;
 
 namespace Gameboard.Api.Data
 {

--- a/src/Gameboard.Api/Data/Store/Store[TEntity].cs
+++ b/src/Gameboard.Api/Data/Store/Store[TEntity].cs
@@ -62,8 +62,7 @@ namespace Gameboard.Api.Data
             {
                 var query = includes(DbContext.Set<TEntity>());
                 return await query
-                    .Where(e => e.Id == id)
-                    .SingleOrDefaultAsync();
+                    .FirstOrDefaultAsync(e => e.Id == id);
             }
 
             return await DbContext.Set<TEntity>().FindAsync(id);

--- a/src/Gameboard.Api/Features/Challenge/ChallengeController.cs
+++ b/src/Gameboard.Api/Features/Challenge/ChallengeController.cs
@@ -69,7 +69,7 @@ namespace Gameboard.Api.Controllers
             var result = await ChallengeService.GetOrAdd(model, Actor.Id, graderUrl);
 
             await Hub.Clients.Group(result.TeamId).ChallengeEvent(
-                new HubEvent<Challenge>(result, EventAction.Updated)
+                new HubEvent<Challenge>(result, EventAction.Updated, Actor.Id)
             );
 
             return result;
@@ -164,7 +164,7 @@ namespace Gameboard.Api.Controllers
             var result = await ChallengeService.StartGamespace(model.Id, Actor.Id);
 
             await Hub.Clients.Group(result.TeamId).ChallengeEvent(
-                new HubEvent<Challenge>(result, EventAction.Updated)
+                new HubEvent<Challenge>(result, EventAction.Updated, Actor.Id)
             );
 
             return result;
@@ -189,7 +189,7 @@ namespace Gameboard.Api.Controllers
             var result = await ChallengeService.StopGamespace(model.Id, Actor.Id);
 
             await Hub.Clients.Group(result.TeamId).ChallengeEvent(
-                new HubEvent<Challenge>(result, EventAction.Updated)
+                new HubEvent<Challenge>(result, EventAction.Updated, Actor.Id)
             );
 
             return result;
@@ -215,7 +215,7 @@ namespace Gameboard.Api.Controllers
             var result = await ChallengeService.Grade(model, Actor.Id);
 
             await Hub.Clients.Group(result.TeamId).ChallengeEvent(
-                new HubEvent<Challenge>(result, EventAction.Updated)
+                new HubEvent<Challenge>(result, EventAction.Updated, Actor.Id)
             );
 
             return result;
@@ -239,7 +239,7 @@ namespace Gameboard.Api.Controllers
             var result = await ChallengeService.Regrade(model.Id);
 
             await Hub.Clients.Group(result.TeamId).ChallengeEvent(
-                new HubEvent<Challenge>(result, EventAction.Updated)
+                new HubEvent<Challenge>(result, EventAction.Updated, Actor.Id)
             );
 
             return result;

--- a/src/Gameboard.Api/Features/Challenge/ChallengeStore.cs
+++ b/src/Gameboard.Api/Features/Challenge/ChallengeStore.cs
@@ -5,17 +5,14 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Gameboard.Api.Data.Abstractions;
+using TopoMojo.Api.Client;
+using AutoMapper;
 
 namespace Gameboard.Api.Data
 {
-
-    public class ChallengeStore: Store<Challenge>, IChallengeStore
+    public class ChallengeStore : Store<Challenge>, IChallengeStore
     {
-        public ChallengeStore(GameboardDbContext dbContext)
-        :base(dbContext)
-        {
-
-        }
+        public ChallengeStore(GameboardDbContext dbContext) : base(dbContext) { }
 
         public override IQueryable<Challenge> List(string term)
         {
@@ -72,7 +69,7 @@ namespace Gameboard.Api.Data
                 .Take(20)
                 .ToArrayAsync();
 
-            int avg = (int) stats.Average(m =>
+            int avg = (int)stats.Average(m =>
                 m.Started.Subtract(m.Created).TotalSeconds
             );
 
@@ -87,9 +84,7 @@ namespace Gameboard.Api.Data
         {
             var challenges = await DbSet.Where(c => c.TeamId == id).ToArrayAsync();
 
-            // TODO: reconsider int vs double
             int score = (int)challenges.Sum(c => c.Score);
-
             long time = challenges.Sum(c => c.Duration);
             int complete = challenges.Count(c => c.Result == ChallengeResult.Success);
             int partial = challenges.Count(c => c.Result == ChallengeResult.Partial);

--- a/src/Gameboard.Api/Features/FeatureStartupExtensions.cs
+++ b/src/Gameboard.Api/Features/FeatureStartupExtensions.cs
@@ -38,6 +38,7 @@ namespace Microsoft.Extensions.DependencyInjection
             // TODO: Ben -> fix this
             services.AddHttpContextAccessor();
             services.AddScoped<IAccessTokenProvider, HttpContextAccessTokenProvider>();
+            services.AddScoped<IInternalHubBus, InternalHubBus>();
             services.AddScoped<ITeamService, TeamService>();
             services.AddScoped<IUnityGameService, UnityGameService>();
             services.AddScoped<IUnityStore, UnityStore>();

--- a/src/Gameboard.Api/Features/Hubs/AppHub.cs
+++ b/src/Gameboard.Api/Features/Hubs/AppHub.cs
@@ -44,7 +44,6 @@ namespace Gameboard.Api.Hubs
             Logger.LogDebug($"Session Disconnected: {Context.ConnectionId}");
 
             await base.OnDisconnectedAsync(ex);
-
             await Leave();
         }
 

--- a/src/Gameboard.Api/Features/Hubs/AppHub.cs
+++ b/src/Gameboard.Api/Features/Hubs/AppHub.cs
@@ -74,7 +74,7 @@ namespace Gameboard.Api.Hubs
             // add to group and broadcast
             await Groups.AddToGroupAsync(Context.ConnectionId, player.TeamId);
             await Clients.OthersInGroup(player.TeamId).PresenceEvent(
-                new HubEvent<TeamPlayer>(teamPlayer, EventAction.Arrived)
+                new HubEvent<TeamPlayer>(teamPlayer, EventAction.Arrived, player.UserId)
             );
         }
 
@@ -111,7 +111,7 @@ namespace Gameboard.Api.Hubs
                     Groups.RemoveFromGroupAsync(Context.ConnectionId, player.TeamId),
                     Groups.RemoveFromGroupAsync(Context.ConnectionId, AppConstants.InternalSupportChannel),
                     Clients.OthersInGroup(player.TeamId).PresenceEvent(
-                        new HubEvent<TeamPlayer>(player, EventAction.Departed)
+                        new HubEvent<TeamPlayer>(player, EventAction.Departed, string.Empty)
                     )
                 };
 
@@ -129,7 +129,7 @@ namespace Gameboard.Api.Hubs
                 return Task.CompletedTask;
 
             return Clients.OthersInGroup(player.TeamId).PresenceEvent(
-                new HubEvent<TeamPlayer>(player, EventAction.Greeted)
+                new HubEvent<TeamPlayer>(player, EventAction.Greeted, string.Empty)
             );
         }
     }

--- a/src/Gameboard.Api/Features/Hubs/HubEvent.cs
+++ b/src/Gameboard.Api/Features/Hubs/HubEvent.cs
@@ -7,12 +7,16 @@ namespace Gameboard.Api.Hubs
     {
         public HubEvent(
             T model,
-            EventAction action
-        ) {
+            EventAction action,
+            string actorUserId
+        )
+        {
             Action = action;
             Model = model;
+            ActorUserId = actorUserId;
         }
 
+        public string ActorUserId { get; set; }
         public EventAction Action { get; set; }
         public T Model { get; set; }
     }

--- a/src/Gameboard.Api/Features/Hubs/InternalHubBus.cs
+++ b/src/Gameboard.Api/Features/Hubs/InternalHubBus.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using AutoMapper;
+using Gameboard.Api;
+using Gameboard.Api.Hubs;
+using Microsoft.AspNetCore.SignalR;
+
+public interface IInternalHubBus
+{
+    Task SendPlayerLeft(Player p);
+    Task SendTeamDeleted(Player p, User actor);
+    Task SendTeamStarted(Player p, User actor);
+    Task SendTeamUpdated(Player p, User actor);
+}
+
+internal class InternalHubBus : IInternalHubBus
+{
+    private IHubContext<AppHub, IAppHubEvent> _hub;
+    private readonly IMapper _mapper;
+
+    public InternalHubBus(IHubContext<AppHub, IAppHubEvent> hub, IMapper mapper)
+    {
+        _hub = hub;
+        _mapper = mapper;
+    }
+
+    public async Task SendPlayerLeft(Player p)
+    {
+        await this._hub.Clients
+            .Group(p.TeamId)
+            .PresenceEvent(
+                new HubEvent<TeamPlayer>(_mapper.Map<TeamPlayer>(p), EventAction.Departed)
+            );
+    }
+
+    public async Task SendTeamDeleted(Player p, User actor)
+    {
+        var teamState = _mapper.Map<TeamState>(p, opts => opts.AfterMap((src, dest) =>
+        {
+            dest.Actor = actor;
+        }));
+
+        await this._hub.Clients.Group(p.TeamId).TeamEvent(new HubEvent<TeamState>(teamState, EventAction.Deleted));
+    }
+
+    public async Task SendTeamStarted(Player p, User actor)
+    {
+        var teamState = _mapper.Map<TeamState>(p, opts => opts.AfterMap((src, dest) =>
+        {
+            dest.Actor = actor;
+        }));
+
+        await this._hub.Clients
+            .Group(p.TeamId)
+            .TeamEvent(
+                new HubEvent<TeamState>(teamState, EventAction.Started)
+            );
+    }
+
+    public async Task SendTeamUpdated(Player p, User actor)
+    {
+        var teamState = _mapper.Map<TeamState>(p, opts => opts.AfterMap((src, dest) =>
+        {
+            dest.Actor = actor;
+        }));
+
+        await this._hub.Clients
+            .Group(p.TeamId)
+            .TeamEvent(
+                new HubEvent<TeamState>(teamState, EventAction.Updated)
+            );
+    }
+}

--- a/src/Gameboard.Api/Features/Hubs/InternalHubBus.cs
+++ b/src/Gameboard.Api/Features/Hubs/InternalHubBus.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.SignalR;
 
 public interface IInternalHubBus
 {
-    Task SendPlayerLeft(Player p);
+    Task SendPlayerLeft(Player p, User actor);
     Task SendTeamDeleted(Player p, User actor);
     Task SendTeamStarted(Player p, User actor);
     Task SendTeamUpdated(Player p, User actor);
@@ -25,12 +25,12 @@ internal class InternalHubBus : IInternalHubBus
         _mapper = mapper;
     }
 
-    public async Task SendPlayerLeft(Player p)
+    public async Task SendPlayerLeft(Player p, User actor)
     {
         await this._hub.Clients
             .Group(p.TeamId)
             .PresenceEvent(
-                new HubEvent<TeamPlayer>(_mapper.Map<TeamPlayer>(p), EventAction.Departed)
+                new HubEvent<TeamPlayer>(_mapper.Map<TeamPlayer>(p), EventAction.Departed, actor.Id)
             );
     }
 
@@ -41,7 +41,7 @@ internal class InternalHubBus : IInternalHubBus
             dest.Actor = actor;
         }));
 
-        await this._hub.Clients.Group(p.TeamId).TeamEvent(new HubEvent<TeamState>(teamState, EventAction.Deleted));
+        await this._hub.Clients.Group(p.TeamId).TeamEvent(new HubEvent<TeamState>(teamState, EventAction.Deleted, actor.Id));
     }
 
     public async Task SendTeamStarted(Player p, User actor)
@@ -54,7 +54,7 @@ internal class InternalHubBus : IInternalHubBus
         await this._hub.Clients
             .Group(p.TeamId)
             .TeamEvent(
-                new HubEvent<TeamState>(teamState, EventAction.Started)
+                new HubEvent<TeamState>(teamState, EventAction.Started, actor.Id)
             );
     }
 
@@ -68,7 +68,7 @@ internal class InternalHubBus : IInternalHubBus
         await this._hub.Clients
             .Group(p.TeamId)
             .TeamEvent(
-                new HubEvent<TeamState>(teamState, EventAction.Updated)
+                new HubEvent<TeamState>(teamState, EventAction.Updated, actor.Id)
             );
     }
 }

--- a/src/Gameboard.Api/Features/Player/Player.cs
+++ b/src/Gameboard.Api/Features/Player/Player.cs
@@ -77,6 +77,11 @@ namespace Gameboard.Api
         public string Code { get; set; }
     }
 
+    public class PlayerUnenrollRequest
+    {
+        public string PlayerId { get; set; }
+    }
+
     public class Standing
     {
         public string TeamId { get; set; }
@@ -228,6 +233,7 @@ namespace Gameboard.Api
         public string NameStatus { get; set; }
         public DateTimeOffset SessionBegin { get; set; }
         public DateTimeOffset SessionEnd { get; set; }
+        public User Actor { get; set; }
     }
 
     public class PlayerCertificate

--- a/src/Gameboard.Api/Features/Player/PlayerController.cs
+++ b/src/Gameboard.Api/Features/Player/PlayerController.cs
@@ -10,7 +10,6 @@ using Gameboard.Api.Services;
 using Gameboard.Api.Validators;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Logging;
 
@@ -90,8 +89,7 @@ namespace Gameboard.Api.Controllers
                 () => PlayerService.MapId(model.Id).Result == Actor.Id
             );
 
-            var result = await PlayerService.Update(model, Actor.IsRegistrar);
-            await Hub.SendTeamUpdated(result, Actor);
+            var result = await PlayerService.Update(model, Actor, Actor.IsRegistrar);
             return Mapper.Map<PlayerUpdatedViewModel>(result);
         }
 
@@ -110,8 +108,7 @@ namespace Gameboard.Api.Controllers
                 () => Actor.IsRegistrar
             );
 
-            var result = await PlayerService.ExtendSession(model);
-            await Hub.SendTeamUpdated(result, Actor);
+            var result = await PlayerService.ExtendSession(model, Actor);
         }
 
         /// <summary>
@@ -134,18 +131,6 @@ namespace Gameboard.Api.Controllers
             await Hub.SendTeamStarted(result, Actor);
             return result;
         }
-
-        // [HttpDelete("/api/player/{playerId}")]
-        // [Authorize]
-        // public async Task Unenroll([FromRoute] string playerId)
-        // {
-        //     AuthorizeAny(
-        //         () => Actor.IsRegistrar,
-        //         () => IsSelf(playerId).Result
-        //     );
-
-        //     await Validate(new PlayerUnenrollRequest { PlayerId = playerId });
-        // }
 
         /// <summary>
         /// Delete a player enrollment
@@ -302,7 +287,6 @@ namespace Gameboard.Api.Controllers
             );
 
             await Validate(model);
-
             return await PlayerService.Enlist(model, Actor.IsRegistrar);
         }
 

--- a/src/Gameboard.Api/Features/Player/PlayerController.cs
+++ b/src/Gameboard.Api/Features/Player/PlayerController.cs
@@ -127,7 +127,7 @@ namespace Gameboard.Api.Controllers
 
             await Validate(model);
 
-            var result = await PlayerService.Start(model, Actor.IsRegistrar);
+            var result = await PlayerService.Start(model, Actor, Actor.IsRegistrar);
             await Hub.SendTeamStarted(result, Actor);
             return result;
         }

--- a/src/Gameboard.Api/Features/Player/PlayerService.cs
+++ b/src/Gameboard.Api/Features/Player/PlayerService.cs
@@ -207,13 +207,13 @@ namespace Gameboard.Api.Services
 
             // notify hub that the team is deleted /players left so the client can respond
             var playerModel = Mapper.Map<Player>(player);
-            await HubBus.SendPlayerLeft(playerModel);
+            await HubBus.SendPlayerLeft(playerModel, actor);
             await HubBus.SendTeamDeleted(playerModel, actor);
 
             return playerModel;
         }
 
-        public async Task<Player> Start(SessionStartRequest model, bool sudo)
+        public async Task<Player> Start(SessionStartRequest model, User actor, bool sudo)
         {
             var team = await Store.ListTeamByPlayer(model.Id);
 

--- a/src/Gameboard.Api/Features/Ticket/TicketController.cs
+++ b/src/Gameboard.Api/Features/Ticket/TicketController.cs
@@ -235,7 +235,7 @@ namespace Gameboard.Api.Controllers
 
         private Task Notify(TicketNotification notification, EventAction action)
         {
-            var ev = new HubEvent<TicketNotification>(notification, action);
+            var ev = new HubEvent<TicketNotification>(notification, action, Actor.Id);
 
             var tasks = new List<Task>();
 

--- a/src/Gameboard.Api/Features/UnityGames/UnityGameController.cs
+++ b/src/Gameboard.Api/Features/UnityGames/UnityGameController.cs
@@ -160,7 +160,7 @@ public class UnityGameController : _Controller
         // notify the hub (if there is one)
         await _hub.Clients
             .Group(model.TeamId)
-            .ChallengeEvent(new HubEvent<Challenge>(_mapper.Map<Challenge>(challengeData), EventAction.Updated));
+            .ChallengeEvent(new HubEvent<Challenge>(_mapper.Map<Challenge>(challengeData), EventAction.Updated, Actor.Id));
 
         return Ok(_mapper.Map<UnityGameChallengeViewModel>(challengeData));
     }

--- a/src/Gameboard.Api/Features/User/UserController.cs
+++ b/src/Gameboard.Api/Features/User/UserController.cs
@@ -231,7 +231,7 @@ namespace Gameboard.Api.Controllers
                 : Hub.Clients.All
             ;
 
-            await audience.Announcement(new HubEvent<Announcement>(model, EventAction.Created));
+            await audience.Announcement(new HubEvent<Announcement>(model, EventAction.Created, Actor.Id));
         }
     }
 }


### PR DESCRIPTION
Multiple backend changes to facilitate clarified logic around session reset / unenroll
- General code cleanup
- Refactored service/controller access into a new service that abstracts the implementation details of the SignalR hub
- In previous versions, a player leaving a session did not always correctly notify their teammates' clients when doing so, leaving them stranded in their lobbies with no player record. (This _always_ occurred if the player used the "unenroll" button while on a team.) Resetting the session or now correctly destroys all player records and more reliably kicks everyone on their team out of the player lobby.
- While implementing this, we confirmed that, in the current version, "Unenroll" has the same effect as "Reset session", which has the effect of unenrolling the entire team and not notifying users. Future work will focus on better differentiating these functions and determining their separate value.