### PR TITLE
Bug/player cert availability

### DIFF
--- a/src/Gameboard.Api/Data/Store/IStore[TEntity].cs
+++ b/src/Gameboard.Api/Data/Store/IStore[TEntity].cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore;
 
 namespace Gameboard.Api.Data.Abstractions
 {
@@ -13,7 +12,7 @@ namespace Gameboard.Api.Data.Abstractions
         where TEntity : class, IEntity
     {
         GameboardDbContext DbContext { get; }
-        DbSet<TEntity> DbSet { get; }
+        IQueryable<TEntity> DbSet { get; }
 
         IQueryable<TEntity> List(string term = null);
         Task<TEntity> Create(TEntity entity);
@@ -23,5 +22,6 @@ namespace Gameboard.Api.Data.Abstractions
         Task Update(TEntity entity);
         Task Update(IEnumerable<TEntity> range);
         Task Delete(string id);
+        Task<int> CountAsync(Func<IQueryable<TEntity>, IQueryable<TEntity>> queryBuilder = null);
     }
 }

--- a/src/Gameboard.Api/Data/Store/Store[TEntity].cs
+++ b/src/Gameboard.Api/Data/Store/Store[TEntity].cs
@@ -16,12 +16,12 @@ namespace Gameboard.Api.Data
         public Store(GameboardDbContext dbContext)
         {
             DbContext = dbContext;
-            DbSet = dbContext.Set<TEntity>();
+            DbSet = dbContext.Set<TEntity>().AsQueryable();
         }
 
         public GameboardDbContext DbContext { get; private set; }
 
-        public DbSet<TEntity> DbSet { get; private set; }
+        public IQueryable<TEntity> DbSet { get; private set; }
 
         public virtual IQueryable<TEntity> List(string term = null)
         {
@@ -93,6 +93,18 @@ namespace Gameboard.Api.Data
 
                 await DbContext.SaveChangesAsync();
             }
+        }
+
+        public virtual async Task<int> CountAsync(Func<IQueryable<TEntity>, IQueryable<TEntity>> queryBuilder = null)
+        {
+            var query = DbContext.Set<TEntity>().AsNoTracking();
+
+            if (queryBuilder != null)
+            {
+                query = queryBuilder(query);
+            }
+
+            return await query.CountAsync();
         }
     }
 }

--- a/src/Gameboard.Api/Features/EntityExtensions.cs
+++ b/src/Gameboard.Api/Features/EntityExtensions.cs
@@ -1,0 +1,7 @@
+using System.Linq;
+
+internal static class PlayerExtensions
+{
+    public static IQueryable<Gameboard.Api.Data.Player> WhereIsScoringPlayer(this IQueryable<Gameboard.Api.Data.Player> query)
+        => query.Where(p => p.Score > 0);
+}

--- a/src/Gameboard.Api/Features/Player/PlayerController.cs
+++ b/src/Gameboard.Api/Features/Player/PlayerController.cs
@@ -23,8 +23,6 @@ namespace Gameboard.Api.Controllers
         IHubContext<AppHub, IAppHubEvent> Hub { get; }
         IMapper Mapper { get; }
 
-        private readonly CoreOptions _coreOptions;
-
         public PlayerController(
             ILogger<PlayerController> logger,
             IDistributedCache cache,
@@ -346,7 +344,7 @@ namespace Gameboard.Api.Controllers
         /// <returns> </returns>
         [HttpGet("/api/certificates")]
         [Authorize]
-        public async Task<PlayerCertificate[]> GetCertificates()
+        public async Task<IEnumerable<PlayerCertificate>> GetCertificates()
         {
             return await PlayerService.MakeCertificates(Actor.Id);
         }

--- a/src/Gameboard.Api/Features/Player/PlayerService.cs
+++ b/src/Gameboard.Api/Features/Player/PlayerService.cs
@@ -376,7 +376,7 @@ namespace Gameboard.Api.Services
                 q = q.Where(u => !string.IsNullOrEmpty(u.NameStatus) && !u.NameStatus.Equals(AppConstants.NameStatusPending));
 
             if (model.WantsScored)
-                q = q.Where(p => p.Score > 0);
+                q = q.WhereIsScoringPlayer();
 
             if (model.Term.NotEmpty())
             {
@@ -699,18 +699,21 @@ namespace Gameboard.Api.Services
             return CertificateFromTemplate(player, playerCount, teamCount);
         }
 
-        public async Task<PlayerCertificate[]> MakeCertificates(string uid)
+        public async Task<IEnumerable<PlayerCertificate>> MakeCertificates(string uid)
         {
             DateTimeOffset now = DateTimeOffset.UtcNow;
 
             var completedSessions = await Store.List()
                 .Include(p => p.Game)
                 .Include(p => p.User)
-                .Where(p => p.UserId == uid &&
+                .Where(
+                    p => p.UserId == uid &&
                     p.SessionEnd > DateTimeOffset.MinValue &&
                     p.Game.GameEnd < now &&
                     p.Game.CertificateTemplate != null &&
-                    p.Game.CertificateTemplate.Length > 0)
+                    p.Game.CertificateTemplate.Length > 0
+                )
+                .WhereIsScoringPlayer()
                 .OrderByDescending(p => p.Game.GameEnd)
                 .ToArrayAsync();
 
@@ -718,17 +721,18 @@ namespace Gameboard.Api.Services
                 Store.DbSet
                     .Where(p => p.Game == c.Game &&
                         p.SessionEnd > DateTimeOffset.MinValue)
+                    .WhereIsScoringPlayer()
                     .Count(),
                 Store.DbSet
                     .Where(p => p.Game == c.Game &&
                         p.SessionEnd > DateTimeOffset.MinValue)
+                    .WhereIsScoringPlayer()
                     .GroupBy(p => p.TeamId).Count()
             )).ToArray();
         }
 
         private Api.PlayerCertificate CertificateFromTemplate(Data.Player player, int playerCount, int teamCount)
         {
-
             string certificateHTML = player.Game.CertificateTemplate;
             if (certificateHTML.IsEmpty())
                 return null;
@@ -752,7 +756,7 @@ namespace Gameboard.Api.Services
                 Html = certificateHTML
             };
         }
-
     }
 
 }
+

--- a/src/Gameboard.Tests.Integration/Fixtures/Builders/DataStateBuilder.cs
+++ b/src/Gameboard.Tests.Integration/Fixtures/Builders/DataStateBuilder.cs
@@ -5,7 +5,6 @@ namespace Gameboard.Tests.Integration.Fixtures;
 internal class DataStateBuilder<TDbContext> : IDataStateBuilder where TDbContext : GameboardDbContext
 {
     private readonly TDbContext _DbContext;
-    private readonly IList<IEntity> _ToBeAdded = new List<IEntity>();
 
     public DataStateBuilder(TDbContext dbContext)
     {

--- a/src/Gameboard.Tests.Integration/Fixtures/Builders/IDataStateBuilder.cs
+++ b/src/Gameboard.Tests.Integration/Fixtures/Builders/IDataStateBuilder.cs
@@ -6,7 +6,4 @@ namespace Gameboard.Tests.Integration.Fixtures;
 public interface IDataStateBuilder
 {
     IDataStateBuilder Add<TEntity>(TEntity entity, Action<TEntity>? entityBuilder = null) where TEntity : class, IEntity;
-    // IDataStateBuilder Add<TEntity>(Func<IDataStateBuilder, TEntity> addFunction) where TEntity : class, IEntity;
-
-    // Task Build();
 }

--- a/src/Gameboard.Tests.Integration/Fixtures/Extensions/GameboardTestContextExtensions.cs
+++ b/src/Gameboard.Tests.Integration/Fixtures/Extensions/GameboardTestContextExtensions.cs
@@ -32,23 +32,18 @@ internal static class GameboardTestContextExtensions
             });
     }
 
-    public static HttpClient CreateHttpClientWithAuth(this GameboardTestContext<GameboardDbContextPostgreSQL> testContext)
+    public static HttpClient CreateHttpClientWithAuth(this GameboardTestContext<GameboardDbContextPostgreSQL> testContext, string userId = "integrationtester")
     {
         var client = testContext
-            .WithAuthentication()
+            .WithAuthentication(userId)
             .CreateClient(new WebApplicationFactoryClientOptions
             {
-                AllowAutoRedirect = false
+                AllowAutoRedirect = false,
             });
 
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(TestAuthenticationHandler.AuthenticationSchemeName);
         return client;
     }
-
-    // public static IDataStateBuilder WithDataState(this GameboardTestContext<GameboardDbContextPostgreSQL> context)
-    // {
-    //     return new DataStateBuilder<GameboardDbContextPostgreSQL>(context);
-    // }
 
     public static async Task WithDataState(this GameboardTestContext<GameboardDbContextPostgreSQL> context, Action<IDataStateBuilder> builderAction)
     {

--- a/src/Gameboard.Tests.Integration/Tests/Features/Players/PlayerControllerTests.cs
+++ b/src/Gameboard.Tests.Integration/Tests/Features/Players/PlayerControllerTests.cs
@@ -59,4 +59,99 @@ public class PlayerControllerTests : IClassFixture<GameboardTestContext<Gameboar
         // assert
         updatedPlayer.NameStatus.ShouldBe(AppConstants.NameStatusNotUnique);
     }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    public async Task GetCertificates_WhenScoreConstrained_ReturnsExpectedCount(int score)
+    {
+        // given
+        var now = DateTimeOffset.UtcNow;
+        var userId = TestIds.Generate();
+
+        await _testContext.WithDataState(state =>
+        {
+            state.AddGame(g =>
+            {
+                g.GameEnd = now - TimeSpan.FromDays(1);
+                g.CertificateTemplate = "This is a template with a {{player_count}}.";
+                g.Players = new Api.Data.Player[]
+                {
+                    state.BuildPlayer(p =>
+                    {
+                        p.Id = TestIds.Generate();
+                        p.User = new Api.Data.User { Id = userId };
+                        p.UserId = userId;
+                        p.SessionEnd = now - TimeSpan.FromDays(-2);
+                        p.TeamId = "teamId";
+                        p.Score = score;
+                    })
+                };
+            });
+        });
+
+        var httpClient = _testContext.CreateHttpClientWithAuth(userId);
+
+        // when
+        var certs = await httpClient
+            .GetAsync("/api/certificates")
+            .WithContentDeserializedAs<IEnumerable<PlayerCertificate>>(_testContext.GetJsonSerializerOptions());
+
+        // then
+        certs?.Count().ShouldBe(score == 0 ? 0 : 1);
+    }
+
+    [Fact]
+    public async Task GetCertificates_WithTeamsAndNonScorers_ReturnsExpected()
+    {
+        // given
+        var now = DateTimeOffset.UtcNow;
+        var userId = TestIds.Generate();
+        var playerId = TestIds.Generate();
+        var recentDate = DateTime.UtcNow.AddDays(-1);
+
+        await _testContext.WithDataState(state =>
+        {
+            var allPlayers = new List<Api.Data.Player>();
+
+            allPlayers.Add(state.BuildPlayer(p =>
+            {
+                p.Id = TestIds.Generate();
+                p.User = new Api.Data.User { Id = userId };
+                p.UserId = userId;
+                p.SessionEnd = recentDate;
+                p.Score = 20;
+            }));
+
+            allPlayers.AddRange(state.BuildTeam(playerBuilder: p =>
+            {
+                p.Score = 5;
+                p.SessionEnd = recentDate;
+            }));
+
+            allPlayers.Add(state.BuildPlayer(p =>
+            {
+                p.SessionEnd = recentDate;
+                p.Score = 0;
+            }));
+
+            state.AddGame(g =>
+            {
+                g.GameEnd = now - TimeSpan.FromDays(1);
+                g.CertificateTemplate = "This is a template with a {{player_count}} and a {{team_count}}.";
+                g.Players = allPlayers;
+            });
+        });
+
+        var httpClient = _testContext.CreateHttpClientWithAuth(userId);
+
+        // when
+        var certs = await httpClient
+            .GetAsync("/api/certificates")
+            .WithContentDeserializedAs<IEnumerable<PlayerCertificate>>(_testContext.GetJsonSerializerOptions());
+
+        // then
+        certs?.Count().ShouldBe(1);
+        certs?.First().Html.ShouldBe("This is a template with a 6 and a 2.");
+    }
 }

--- a/src/Gameboard.Tests.Unit/Tests/Features/Player/PlayerServiceTests.cs
+++ b/src/Gameboard.Tests.Unit/Tests/Features/Player/PlayerServiceTests.cs
@@ -1,10 +1,36 @@
+using AutoMapper;
 using Gameboard.Api;
+using Gameboard.Api.Data.Abstractions;
 using Gameboard.Api.Services;
+using Microsoft.Extensions.Caching.Memory;
+using TopoMojo.Api.Client;
 
 namespace Gameboard.Tests.Unit;
 
 public class PlayerServiceTests
 {
+    class PlayerServiceTestable : PlayerService
+    {
+        private PlayerServiceTestable(CoreOptions coreOptions, IPlayerStore store, IUserStore userStore, IGameStore gameStore, IMapper mapper, IMemoryCache localCache, ITopoMojoApiClient mojo) : base(coreOptions, store, userStore, gameStore, mapper, localCache, mojo)
+        {
+        }
+
+        // TODO: reflection helper
+        internal static PlayerService GetTestable(CoreOptions? coreOptions = null, IPlayerStore? store = null, IUserStore? userStore = null, IGameStore? gameStore = null, IMapper? mapper = null, IMemoryCache? localCache = null, ITopoMojoApiClient? mojo = null)
+        {
+            return new PlayerService
+            (
+                coreOptions ?? A.Fake<CoreOptions>(),
+                store ?? A.Fake<IPlayerStore>(),
+                userStore ?? A.Fake<IUserStore>(),
+                gameStore ?? A.Fake<IGameStore>(),
+                mapper ?? A.Fake<IMapper>(),
+                localCache ?? A.Fake<IMemoryCache>(),
+                mojo ?? A.Fake<ITopoMojoApiClient>()
+            );
+        }
+    }
+
     [Theory, GameboardAutoData]
     public async Task Standings_WhenGameIdIsEmpty_ReturnsEmptyArray(IFixture fixture)
     {
@@ -17,5 +43,74 @@ public class PlayerServiceTests
 
         // assert
         result.ShouldBe(new Standing[] { });
+    }
+
+    [Theory, GameboardAutoData]
+    public async Task MakeCertificates_WhenScoreZero_ReturnsEmptyArray(IFixture fixture)
+    {
+        // arrange
+        var userId = fixture.Create<string>();
+        var fakeStore = A.Fake<IPlayerStore>();
+        var fakePlayers = new Api.Data.Player[]
+        {
+            new Api.Data.Player
+            {
+                PartialCount = 1,
+                Game = new Api.Data.Game
+                {
+                    CertificateTemplate = fixture.Create<string>(),
+                    GameEnd = DateTimeOffset.Now - TimeSpan.FromDays(1)
+                },
+                Score = 0,
+                SessionEnd = DateTimeOffset.Now - TimeSpan.FromDays(2),
+                User = new Api.Data.User { Id = userId }
+            }
+        }.ToList().BuildMock();
+
+        A.CallTo(() => fakeStore.List(null)).Returns(fakePlayers);
+        A.CallTo(() => fakeStore.DbSet).Returns(fakePlayers);
+
+        var sut = PlayerServiceTestable.GetTestable(store: fakeStore);
+
+        // act
+        var result = await sut.MakeCertificates(userId);
+
+        // assert
+        result.ShouldBe(new PlayerCertificate[] { });
+    }
+
+    [Theory, GameboardAutoData]
+    public async Task MakeCertificates_WhenScore1_ReturnsOneCertificate(IFixture fixture)
+    {
+        // arrange
+        var userId = fixture.Create<string>();
+        var fakeStore = A.Fake<IPlayerStore>();
+        var fakePlayers = new Api.Data.Player[]
+        {
+            new Api.Data.Player
+            {
+                PartialCount = 0,
+                Game = new Api.Data.Game
+                {
+                    CertificateTemplate = fixture.Create<string>(),
+                    GameEnd = DateTimeOffset.Now - TimeSpan.FromDays(1)
+                },
+                Score = 1,
+                SessionEnd = DateTimeOffset.Now - TimeSpan.FromDays(2),
+                UserId = userId,
+                User = new Api.Data.User { Id = userId }
+            }
+        }.ToList().BuildMock();
+
+        A.CallTo(() => fakeStore.List(null)).Returns(fakePlayers);
+        A.CallTo(() => fakeStore.DbSet).Returns(fakePlayers);
+
+        var sut = PlayerServiceTestable.GetTestable(store: fakeStore);
+
+        // act
+        var result = await sut.MakeCertificates(userId);
+
+        // assert
+        result.Count().ShouldBe(1);
     }
 }


### PR DESCRIPTION
- Certificates are now only available for players who have a completed session and who have a score greater than zero.
- Player and team counts used in certificates now ignore other players and teams which scored zero.
- Logic unified with public scoreboard.
- Integration test added to confirm.