### PR TITLE
Add optional HTTP logging

### DIFF
--- a/src/Gameboard.Api/Extensions/WebApplicationBuilderExtensions.cs
+++ b/src/Gameboard.Api/Extensions/WebApplicationBuilderExtensions.cs
@@ -5,6 +5,7 @@ using System.Text.Json.Serialization;
 using Gameboard.Api.Services;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.HttpLogging;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using ServiceStack.Text;
@@ -97,5 +98,20 @@ internal static class WebApplicationBuilderExtensions
         // Configure Auth
         services.AddConfiguredAuthentication(settings.Oidc);
         services.AddConfiguredAuthorization();
+
+        if (settings.Logging.EnableHttpLogging)
+        {
+            services.AddHttpLogging(logging =>
+            {
+                logging.LoggingFields = HttpLoggingFields.ResponseStatusCode
+                    | HttpLoggingFields.ResponseBody
+                    | HttpLoggingFields.RequestPath
+                    | HttpLoggingFields.RequestQuery
+                    | HttpLoggingFields.RequestBody;
+                logging.RequestBodyLogLimit = settings.Logging.RequestBodyLogLimit;
+                logging.ResponseBodyLogLimit = settings.Logging.ResponseBodyLogLimit;
+                logging.MediaTypeOptions.AddText("application/json");
+            });
+        }
     }
 }

--- a/src/Gameboard.Api/Extensions/WebApplicationExtensions.cs
+++ b/src/Gameboard.Api/Extensions/WebApplicationExtensions.cs
@@ -34,6 +34,11 @@ internal static class WebApplicationExtensions
         app.UseFileProtection();
         app.UseStaticFiles();
 
+        if (settings.Logging.EnableHttpLogging)
+        {
+            app.UseHttpLogging();
+        }
+
         if (settings.OpenApi.Enabled)
             app.UseConfiguredSwagger(settings.OpenApi, settings.Oidc.Audience, settings.PathBase);
 

--- a/src/Gameboard.Api/Features/Player/PlayerController.cs
+++ b/src/Gameboard.Api/Features/Player/PlayerController.cs
@@ -23,8 +23,6 @@ namespace Gameboard.Api.Controllers
         IHubContext<AppHub, IAppHubEvent> Hub { get; }
         IMapper Mapper { get; }
 
-        private readonly CoreOptions _coreOptions;
-
         public PlayerController(
             ILogger<PlayerController> logger,
             IDistributedCache cache,

--- a/src/Gameboard.Api/Program.cs
+++ b/src/Gameboard.Api/Program.cs
@@ -33,24 +33,24 @@ if (dbOnly)
     builder
         .Build()
         .InitializeDatabase();
+
+    return;
 }
-else
-{
-    Console.WriteLine("Configuring Gameboard app...");
 
-    // load settings and configure services
-    var settings = builder.BuildAppSettings();
-    builder.ConfigureServices(settings);
+Console.WriteLine("Configuring Gameboard app...");
 
-    // build and configure app
-    var app = builder
-        .Build()
-        .InitializeDatabase()
-        .ConfigureGameboard(settings);
+// load settings and configure services
+var settings = builder.BuildAppSettings();
+builder.ConfigureServices(settings);
 
-    // start!
-    app.Run();
-}
+// build and configure app
+var app = builder
+    .Build()
+    .InitializeDatabase()
+    .ConfigureGameboard(settings);
+
+// start!
+app.Run();
 
 // required for integration tests
 public partial class Program { }

--- a/src/Gameboard.Api/Structure/AppSettings.cs
+++ b/src/Gameboard.Api/Structure/AppSettings.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using Microsoft.Extensions.Logging;
 using Microsoft.AspNetCore.Cors.Infrastructure;
 
 namespace Gameboard.Api
@@ -15,8 +16,25 @@ namespace Gameboard.Api
         public CoreOptions Core { get; set; } = new CoreOptions();
         public DatabaseOptions Database { get; set; } = new DatabaseOptions();
         public HeaderOptions Headers { get; set; } = new HeaderOptions();
+        public LoggingSettings Logging { get; set; } = new LoggingSettings();
         public OpenApiOptions OpenApi { get; set; } = new OpenApiOptions();
         public Defaults Defaults { get; set; } = new Defaults();
+    }
+
+    public class LoggingSettings
+    {
+        public LogLevel LogLevel { get; set; } = LogLevel.Error;
+        public Boolean EnableHttpLogging { get; set; } = false;
+
+        /// <summary>
+        /// The maximum number of bytes logged for the request body (in bytes).
+        /// </summary>
+        public int RequestBodyLogLimit { get; set; } = 32000;
+
+        /// <summary>
+        /// The maximum number of bytes logged for the response body (in bytes).
+        /// </summary>
+        public int ResponseBodyLogLimit { get; set; } = 32000;
     }
 
     public class OidcOptions

--- a/src/Gameboard.Api/Structure/LoggingExtensions.cs
+++ b/src/Gameboard.Api/Structure/LoggingExtensions.cs
@@ -1,0 +1,25 @@
+using System;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Logging;
+
+internal class GameboardLoggingBuilder
+{
+    public bool EnableHttpLogging { get; set; } = false;
+    public LogLevel LogLevel { get; set; }
+}
+
+internal static class LoggingExtensions
+{
+    public static IApplicationBuilder UseGameboardLogging(this IApplicationBuilder app, Action<GameboardLoggingBuilder> gameboardLoggingBuilder)
+    {
+        var loggingBuilder = new GameboardLoggingBuilder();
+        gameboardLoggingBuilder?.Invoke(loggingBuilder);
+
+        if (loggingBuilder.EnableHttpLogging)
+        {
+            app.UseHttpLogging();
+        }
+
+        return app;
+    }
+}

--- a/src/Gameboard.Api/appsettings.conf
+++ b/src/Gameboard.Api/appsettings.conf
@@ -71,7 +71,9 @@
 ####################
 ## Logging
 ####################
-## NOTE: we're doing logging via serilog now - see Startup.cs
+# Logging__EnableHttpLogging = true
+# Logging__RequestBodyLogLimit = 4096
+# Logging__ResponseBodyLogLimit = 4096
 
 ####################
 ## Headers


### PR DESCRIPTION
Gameboard can now be configured to log additional details about HTTP requests and responses to and from the API. New variables are visible in `appsettings.conf`.