### PR TITLE
Reduce size of user models at `/api/users`

### DIFF
--- a/src/Gameboard.Api/Features/Ticket/Ticket.cs
+++ b/src/Gameboard.Api/Features/Ticket/Ticket.cs
@@ -10,8 +10,8 @@ namespace Gameboard.Api
 {
     public class Ticket
     {
-        public string Id { get; set; } 
-        public int Key { get; set; } 
+        public string Id { get; set; }
+        public int Key { get; set; }
         public string FullKey { get; set; }
         public string RequesterId { get; set; }
         public string AssigneeId { get; set; }
@@ -29,11 +29,11 @@ namespace Gameboard.Api
         public DateTimeOffset LastUpdated { get; set; }
 
         public string[] Attachments { get; set; }
-        
-        public UserSummary Requester { get; set; }
-        public UserSummary Assignee { get; set; }
-        public UserSummary Creator { get; set; }
-        public ChallengeOverview Challenge { get; set; } 
+
+        public UserSimple Requester { get; set; }
+        public UserSimple Assignee { get; set; }
+        public UserSimple Creator { get; set; }
+        public ChallengeOverview Challenge { get; set; }
         public PlayerOverview Player { get; set; }
 
         public List<TicketActivity> Activity { get; set; } = new List<TicketActivity>();
@@ -41,9 +41,9 @@ namespace Gameboard.Api
 
     public class TicketSummary
     {
-        public string Id { get; set; } 
-        public int Key { get; set; } 
-        public string FullKey { get; set; } 
+        public string Id { get; set; }
+        public int Key { get; set; }
+        public string FullKey { get; set; }
         public string RequesterId { get; set; }
         public string AssigneeId { get; set; }
         public string CreatorId { get; set; }
@@ -57,15 +57,15 @@ namespace Gameboard.Api
 
         public DateTimeOffset Created { get; set; }
         public DateTimeOffset LastUpdated { get; set; }
-        
-        public UserSummary Requester { get; set; }
-        public UserSummary Assignee { get; set; }
-        public UserSummary Creator { get; set; }
+
+        public UserSimple Requester { get; set; }
+        public UserSimple Assignee { get; set; }
+        public UserSimple Creator { get; set; }
         public ChallengeSummary Challenge { get; set; }
 
     }
 
-    public class SelfTicketSubmission 
+    public class SelfTicketSubmission
     {
         public string ChallengeId { get; set; }
         public string Summary { get; set; }
@@ -94,7 +94,7 @@ namespace Gameboard.Api
     {
         public List<IFormFile> Uploads { get; set; }
     }
-    
+
     public class SelfChangedTicket : SelfTicketSubmission
     {
         public string Id { get; set; }
@@ -125,17 +125,17 @@ namespace Gameboard.Api
         public DateTimeOffset Timestamp { get; set; }
         public DateTimeOffset LastUpdated { get; set; }
         public string[] Attachments { get; set; }
-        public UserSummary User { get; set; }
-        public UserSummary Assignee { get; set; }
+        public UserSimple User { get; set; }
+        public UserSimple Assignee { get; set; }
     }
 
-    public class UploadFile 
+    public class UploadFile
     {
         public string FileName { get; set; }
         public IFormFile File { get; set; }
     }
 
-    public class TicketSearchFilter: SearchFilter
+    public class TicketSearchFilter : SearchFilter
     {
         public const string OpenFilter = "open";
         public const string InProgressFilter = "in progress";
@@ -157,7 +157,7 @@ namespace Gameboard.Api
         public const string StatusOrderString = "status";
         public const string CreatedOrderString = "created";
         public const string UpdatedOrderString = "updated";
-        
+
         // Ordering by column
         public bool WantsOrderingByKey => OrderItem.Equals(KeyOrderString);
         public bool WantsOrderingBySummary => OrderItem.Equals(SummaryOrderString);
@@ -170,7 +170,7 @@ namespace Gameboard.Api
         public bool WantsOrderingByAsc => IsDescending.Equals(false);
     }
 
-    public class TicketReportFilter: TicketSearchFilter
+    public class TicketReportFilter : TicketSearchFilter
     {
         public string GameId { get; set; }
         public bool WantsGame => !GameId.IsEmpty();

--- a/src/Gameboard.Api/Features/User/User.cs
+++ b/src/Gameboard.Api/Features/User/User.cs
@@ -5,7 +5,7 @@ using System.Linq;
 
 namespace Gameboard.Api
 {
-    public class User
+    public class User : IUserViewModel
     {
         public string Id { get; set; }
         public string Name { get; set; }
@@ -28,8 +28,6 @@ namespace Gameboard.Api
         public string Id { get; set; }
         public string Name { get; set; }
         public string Sponsor { get; set; }
-        // public string Username { get; set; }
-        // public string Email { get; set; }
     }
 
     public class ChangedUser
@@ -56,7 +54,7 @@ namespace Gameboard.Api
         public PlayerRole Role { get; set; }
     }
 
-    public class UserSearch: SearchFilter
+    public class UserSearch : SearchFilter
     {
         public const string UserRoleFilter = "roles";
         public const string NamePendingFilter = "pending";
@@ -65,8 +63,8 @@ namespace Gameboard.Api
         public bool WantsPending => Filter.Contains(NamePendingFilter);
         public bool WantsDisallowed => Filter.Contains(NameDisallowedFilter);
     }
-    
-    public class UserSummary 
+
+    public class UserSimple : IUserViewModel
     {
         public string Id { get; set; }
         public string ApprovedName { get; set; }
@@ -76,5 +74,22 @@ namespace Gameboard.Api
     {
         public string TeamId { get; set; }
         public string Message { get; set; }
+    }
+
+    public class UserOnly : IUserViewModel
+    {
+        public string Id { get; set; }
+        public string Email { get; set; }
+        public string Name { get; set; }
+        public string NameStatus { get; set; }
+        public string ApprovedName { get; set; }
+        public string Sponsor { get; set; }
+        public UserRole Role { get; set; }
+    }
+
+    public interface IUserViewModel
+    {
+        public string Id { get; set; }
+        public string ApprovedName { get; set; }
     }
 }

--- a/src/Gameboard.Api/Features/User/UserController.cs
+++ b/src/Gameboard.Api/Features/User/UserController.cs
@@ -16,6 +16,7 @@ using System.IO;
 using System.Linq;
 using Microsoft.AspNetCore.SignalR;
 using Gameboard.Api.Hubs;
+using System.Collections.Generic;
 
 namespace Gameboard.Api.Controllers
 {
@@ -132,14 +133,14 @@ namespace Gameboard.Api.Controllers
         /// <returns>User[]</returns>
         [HttpGet("/api/users")]
         [Authorize]
-        public async Task<User[]> List([FromQuery] UserSearch model)
+        public async Task<IEnumerable<UserOnly>> List([FromQuery] UserSearch model)
         {
             AuthorizeAny(
                 () => Actor.IsRegistrar,
                 () => Actor.IsObserver
             );
 
-            return await UserService.List(model);
+            return await UserService.List<UserOnly>(model);
         }
 
         /// <summary>
@@ -149,7 +150,7 @@ namespace Gameboard.Api.Controllers
         /// <returns>User[]</returns>
         [HttpGet("/api/users/support")]
         [Authorize]
-        public async Task<UserSummary[]> ListSupport([FromQuery] SearchFilter model)
+        public async Task<UserSimple[]> ListSupport([FromQuery] SearchFilter model)
         {
             AuthorizeAny(
                 () => Actor.IsObserver,

--- a/src/Gameboard.Api/Features/User/UserMapper.cs
+++ b/src/Gameboard.Api/Features/User/UserMapper.cs
@@ -11,21 +11,14 @@ namespace Gameboard.Api.Services
         public UserMapper()
         {
             CreateMap<string, string>().ConvertUsing(str => str == null ? null : str.Trim());
-
             CreateMap<Data.User, User>();
-
             CreateMap<Data.User, TeamMember>();
-
-            CreateMap<Data.User, UserSummary>();
-
+            CreateMap<Data.User, UserSimple>();
+            CreateMap<Data.User, UserOnly>();
             CreateMap<User, Data.User>();
-
             CreateMap<NewUser, Data.User>();
-
             CreateMap<ChangedUser, SelfChangedUser>();
-
             CreateMap<ChangedUser, Data.User>();
-
             CreateMap<SelfChangedUser, Data.User>();
         }
     }

--- a/src/Gameboard.Api/Features/User/UserService.cs
+++ b/src/Gameboard.Api/Features/User/UserService.cs
@@ -2,6 +2,7 @@
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using AutoMapper;
@@ -135,7 +136,7 @@ public class UserService
 
     }
 
-    public async Task<User[]> List(UserSearch model)
+    public async Task<IEnumerable<TProject>> List<TProject>(UserSearch model) where TProject : class, IUserViewModel
     {
         var q = Store.List(model.Term);
 
@@ -165,10 +166,12 @@ public class UserService
         if (model.Take > 0)
             q = q.Take(model.Take);
 
-        return await Mapper.ProjectTo<User>(q).ToArrayAsync();
+        return await Mapper
+            .ProjectTo<TProject>(q)
+            .ToArrayAsync();
     }
 
-    public async Task<UserSummary[]> ListSupport(SearchFilter model)
+    public async Task<UserSimple[]> ListSupport(SearchFilter model)
     {
         var q = Store.List(model.Term);
 
@@ -185,7 +188,7 @@ public class UserService
             );
         }
 
-        return await Mapper.ProjectTo<UserSummary>(q).ToArrayAsync();
+        return await Mapper.ProjectTo<UserSimple>(q).ToArrayAsync();
     }
 
     internal string ResolveRandomName(IUserStore store, INameService nameSvc, User entity)


### PR DESCRIPTION
User models obtained from `/api/users` no longer contain relational data by default. The API has been revised to enable simple hydration of other user models as needed from `UserService.List`. Resolves #116.