### PR TITLE
Allow admin seeding from helm chart

### DIFF
--- a/src/Gameboard.Api/Program.cs
+++ b/src/Gameboard.Api/Program.cs
@@ -44,7 +44,7 @@ if (dbOnly)
 
     var dbOnlyApp = builder.Build();
     dbOnlyApp.Logger.LogInformation("Starting the app in dbonly mode...");
-    dbOnlyApp.InitializeDatabase(dbOnlyApp.Logger);
+    dbOnlyApp.InitializeDatabase(settings, dbOnlyApp.Logger);
     dbOnlyApp.Logger.LogInformation("DB initialized.");
 
     return;
@@ -53,7 +53,7 @@ if (dbOnly)
 // build and configure app
 var app = builder.Build();
 app
-    .InitializeDatabase(app.Logger)
+    .InitializeDatabase(settings, app.Logger)
     .ConfigureGameboard(settings);
 
 // start!

--- a/src/Gameboard.Api/Structure/AppSettings.cs
+++ b/src/Gameboard.Api/Structure/AppSettings.cs
@@ -87,11 +87,13 @@ namespace Gameboard.Api
 
     public class DatabaseOptions
     {
+        public string AdminId { get; set; }
+        public string AdminName { get; set; } = "Gameboard Admin";
+        public UserRole AdminRole { get; set; } = UserRole.Admin;
         public string Provider { get; set; } = "InMemory";
         public string ConnectionString { get; set; } = "gameboard_db";
         public string SeedFile { get; set; } = "seed-data.json";
     }
-
 
     public class HeaderOptions
     {

--- a/src/Gameboard.Api/appsettings.conf
+++ b/src/Gameboard.Api/appsettings.conf
@@ -22,6 +22,11 @@
 # Database__Provider = InMemory
 # Database__ConnectionString = gameboard_db
 
+# # Seed an admin user
+# Database__AdminId = f56c167f-d3f4-484a-8ee9-d230ceb5f734
+# Database__AdminName = Ben, Seeder of Entities
+
+
 ## File containing any seed data.
 # Database__SeedFile = seed-data.json
 


### PR DESCRIPTION
- Allows seeding of a single administrator user from Helm chart values or by manipulating `appsettings.conf`. The relevant keys are:
  - `Database__AdminId` (GUID)
  - `Database__AdminName` (the user's friendly name)

Users seeded this way automatically receive the administrator role (and all otheres) and will only be added if they are not present in the database at application startup. 