### PR TITLE
v3.9.3

### DIFF
--- a/src/Gameboard.Api.Tests.Unit/Tests/Features/GameEngine/GameEngineMapsTests.cs
+++ b/src/Gameboard.Api.Tests.Unit/Tests/Features/GameEngine/GameEngineMapsTests.cs
@@ -118,4 +118,40 @@ public class GameEngineMapsTests
         mapped.Vms.FirstOrDefault(vm => vm.IsolationId == "vm2").ShouldNotBeNull();
         mapped.Challenge.Questions.First().IsCorrect.ShouldBeFalse();
     }
+
+    [Theory, GameboardAutoData]
+    public void MapStateToChallenge_WithIsActiveTrueAndNoVms_YieldsHasActiveGamespaceFalse(IFixture fixture)
+    {
+        // given
+        var state = new GameEngineGameState
+        {
+            Id = fixture.Create<string>(),
+            Name = fixture.Create<string>(),
+            ManagerId = fixture.Create<string>(),
+            ManagerName = fixture.Create<string>(),
+            IsActive = true,
+            Players = new GameEnginePlayer[]
+            {
+                new GameEnginePlayer
+                {
+                    SubjectId = fixture.Create<string>(),
+                    IsManager = true
+                }
+            },
+            WhenCreated = fixture.Create<DateTimeOffset>(),
+            StartTime = fixture.Create<DateTimeOffset>(),
+            EndTime = fixture.Create<DateTimeOffset>(),
+            ExpirationTime = fixture.Create<DateTimeOffset>(),
+            Vms = new GameEngineVmState[] { }
+        };
+
+        var mapperConfig = new MapperConfiguration(cfg => cfg.AddProfile(new GameEngineMaps()));
+        var mapper = new Mapper(mapperConfig);
+
+        // when
+        var mapped = mapper.Map<Data.Challenge>(state);
+
+        // then
+        mapped.HasDeployedGamespace.ShouldBeFalse();
+    }
 }

--- a/src/Gameboard.Api/Extensions/IWebHostEnvironment.cs
+++ b/src/Gameboard.Api/Extensions/IWebHostEnvironment.cs
@@ -16,4 +16,7 @@ internal static class IWebHostEnvironmentExtensions
     {
         return env.EnvironmentName == _envDev;
     }
+
+    public static bool IsTest(this IWebHostEnvironment env)
+        => env.EnvironmentName == _envTest;
 }

--- a/src/Gameboard.Api/Extensions/WebApplicationBuilderExtensions.cs
+++ b/src/Gameboard.Api/Extensions/WebApplicationBuilderExtensions.cs
@@ -84,9 +84,12 @@ internal static class WebApplicationBuilderExtensions
             .AddGameboardData(settings.Database.Provider, settings.Database.ConnectionString)
             .AddGameboardServices(settings)
             .AddConfiguredHttpClients(settings.Core)
-            .AddHostedService<JobService>()
             .AddDefaults(settings.Defaults, builder.Environment.ContentRootPath)
             .AddGameboardMediatR();
+
+        // don't add the job service during test - we don't want it to interfere with CI
+        if (!builder.Environment.IsTest())
+            services.AddHostedService<JobService>();
 
         services.AddSingleton<AutoMapper.IMapper>(
             new AutoMapper.MapperConfiguration(cfg =>

--- a/src/Gameboard.Api/Features/Challenge/ChallengeService.cs
+++ b/src/Gameboard.Api/Features/Challenge/ChallengeService.cs
@@ -368,7 +368,8 @@ namespace Gameboard.Api.Services
                 Type = ChallengeEventType.GamespaceOff
             });
 
-            await Sync(
+            await Sync
+            (
                 entity,
                 GameEngine.StopGamespace(entity)
             );

--- a/src/Gameboard.Api/Features/ChallengeBonuses/ChallengeBonusMaps.cs
+++ b/src/Gameboard.Api/Features/ChallengeBonuses/ChallengeBonusMaps.cs
@@ -1,6 +1,6 @@
 using AutoMapper;
 using Gameboard.Api.Data;
-using Gameboard.Api.Structure;
+using Gameboard.Api.Features.Common;
 
 namespace Gameboard.Api.Features.ChallengeBonuses;
 

--- a/src/Gameboard.Api/Features/ChallengeBonuses/ChallengeBonusModels.cs
+++ b/src/Gameboard.Api/Features/ChallengeBonuses/ChallengeBonusModels.cs
@@ -1,6 +1,5 @@
 using System;
-using Gameboard.Api;
-using Gameboard.Api.Structure;
+using Gameboard.Api.Features.Common;
 
 public class CreateManualChallengeBonus
 {

--- a/src/Gameboard.Api/Features/Common/CommonModels.cs
+++ b/src/Gameboard.Api/Features/Common/CommonModels.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Gameboard.Api.Features.Common;
+
+public class SimpleEntity
+{
+    public string Id { get; set; }
+    public string Name { get; set; }
+}
+
+public sealed class DateRange
+{
+    public DateTimeOffset Start { get; set; }
+    public DateTimeOffset End { get; set; }
+}

--- a/src/Gameboard.Api/Features/ExternalGames/ExternalGamesModels.cs
+++ b/src/Gameboard.Api/Features/ExternalGames/ExternalGamesModels.cs
@@ -1,0 +1,18 @@
+using Gameboard.Api.Features.Common;
+
+namespace Gameboard.Api.Features.ExternalGames;
+
+// public sealed class ExternalGameMetaData
+// {
+//     public required SimpleEntity Game { get; set; }
+
+// }
+
+// public sealed class ExternalGameMetaDataTeam
+// {
+//     public required string Id { get; set; }
+//     public required string Name { get; set; }
+//     public required DateRange Session { get; set; }
+// }
+
+// public sealed class 

--- a/src/Gameboard.Api/Features/Game/GameService.cs
+++ b/src/Gameboard.Api/Features/Game/GameService.cs
@@ -12,8 +12,8 @@ using YamlDotNet.Serialization.NamingConventions;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
+using Gameboard.Api.Features.Common;
 using Gameboard.Api.Features.Games;
-using Gameboard.Api.Structure;
 
 namespace Gameboard.Api.Services;
 

--- a/src/Gameboard.Api/Features/Game/SyncStartModels.cs
+++ b/src/Gameboard.Api/Features/Game/SyncStartModels.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using Gameboard.Api.Structure;
+using Gameboard.Api.Features.Common;
 
 namespace Gameboard.Api.Features.Games;
 

--- a/src/Gameboard.Api/Features/GameEngine/GameEngineMaps.cs
+++ b/src/Gameboard.Api/Features/GameEngine/GameEngineMaps.cs
@@ -29,24 +29,24 @@ public class GameEngineMaps : Profile
             .ForSourceMember(gep => gep.Permission, o => o.DoNotValidate())
             .ForSourceMember(gep => gep.GamespaceId, o => o.DoNotValidate());
 
-        CreateMap<GameEngineGameState, Api.Data.Challenge>(MemberList.Destination)
+        CreateMap<GameEngineGameState, Api.Data.Challenge>()
+            .ForMember(c => c.EndTime, o => o.MapFrom(s => s.ExpirationTime))
+            .ForMember(c => c.HasDeployedGamespace, o => o.MapFrom(s => s.HasDeployedGamespace))
+            .ForMember(c => c.LastScoreTime, o => o.MapFrom(s => s.Challenge.LastScoreTime))
             .ForMember(c => c.ExternalId, o => o.MapFrom(s => s.Id))
             .ForMember(c => c.PlayerId, o => o.MapFrom(p => p.Players.Where(p => p.IsManager).First().SubjectId))
-            .ForMember(c => c.HasDeployedGamespace, o => o.MapFrom(s => s.IsActive))
-            .ForMember(c => c.EndTime, o => o.MapFrom(s => s.ExpirationTime))
             .ForMember(c => c.Points, o => o.MapFrom(s => s.Challenge.MaxPoints))
-            .ForMember(c => c.LastScoreTime, o => o.MapFrom(s => s.Challenge.LastScoreTime))
             .ForMember(c => c.Score, o => o.MapFrom(s => s.Challenge.Score))
             .ForMember(c => c.State, o => o.MapFrom(s => jsonService.Serialize(s)))
-            .ForMember(c => c.Events, o => o.Ignore())
-            .ForMember(c => c.Feedback, o => o.Ignore())
-            .ForMember(c => c.Game, o => o.Ignore())
             // ignore entity properties because we don't want EF to think that we're trying to insert new ones
             .ForMember(c => c.Player, o => o.Ignore())
             // game engine type will need to be resolved using an aftermap expression during mapping
             .ForMember(c => c.GameEngineType, o => o.Ignore())
             // similarly, engines don't know about things like games, tickets, and bonuses
+            .ForMember(c => c.Events, o => o.Ignore())
+            .ForMember(c => c.Feedback, o => o.Ignore())
             .ForMember(c => c.GameId, o => o.Ignore())
+            .ForMember(c => c.Game, o => o.Ignore())
             .ForMember(c => c.GraderKey, o => o.Ignore())
             .ForMember(c => c.LastSyncTime, o => o.Ignore())
             .ForMember(c => c.SpecId, o => o.Ignore())

--- a/src/Gameboard.Api/Features/GameEngine/Models/GameEngineModels.cs
+++ b/src/Gameboard.Api/Features/GameEngine/Models/GameEngineModels.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Gameboard.Api.Features.GameEngine;
 
@@ -33,6 +34,11 @@ public class GameEngineGameState
     public DateTimeOffset ExpirationTime { get; set; }
     public IEnumerable<GameEngineVmState> Vms { get; set; }
     public GameEngineChallengeView Challenge { get; set; }
+
+    public bool HasDeployedGamespace
+    {
+        get => Vms != null && Vms.Count() > 0;
+    }
 }
 
 public class GameEnginePlayer

--- a/src/Gameboard.Api/Features/Scores/ScoringModels.cs
+++ b/src/Gameboard.Api/Features/Scores/ScoringModels.cs
@@ -1,5 +1,5 @@
 using System.Collections.Generic;
-using Gameboard.Api.Structure;
+using Gameboard.Api.Features.Common;
 
 public class TeamChallengeScoreSummary
 {

--- a/src/Gameboard.Api/Features/Scores/ScoringService.cs
+++ b/src/Gameboard.Api/Features/Scores/ScoringService.cs
@@ -5,8 +5,8 @@ using System.Threading.Tasks;
 using AutoMapper;
 using Gameboard.Api.Data;
 using Gameboard.Api.Data.Abstractions;
+using Gameboard.Api.Features.Common;
 using Gameboard.Api.Features.Teams;
-using Gameboard.Api.Structure;
 using Microsoft.EntityFrameworkCore;
 
 namespace Gameboard.Api.Features.Scores;

--- a/src/Gameboard.Api/Structure/Models/SimpleEntity.cs
+++ b/src/Gameboard.Api/Structure/Models/SimpleEntity.cs
@@ -1,7 +1,0 @@
-namespace Gameboard.Api.Structure;
-
-public class SimpleEntity
-{
-    public string Id { get; set; }
-    public string Name { get; set; }
-}


### PR DESCRIPTION
Version 3.9.3 of Gameboard resolves multiple issues, adds additional configuration flexibility, and improves infrastructure and application health.

**Bug fixes**
- Resolved an issue that could cause the player presence widget to fail to display for non-sync-start games.
- Resolved an issue that resulted in Gameboard incorrectly assessing whether a challenge has a deployed gamespace, causing some players to prematurely hit the board-level gamespace cap.

**Configuration improvements**
- The location of `settings.json` is now configurable per Angular environment (but remains in the same location for the production Angular env config).

**Infrastructure / App Health**
- Gameboard now only looks for settings.json when it is built in a configuration that contains a `settingsJson` entry in its `environment.ts`. Currently, this means that it will not attempt to load a `settings.json` file in dev environments, but it will in a production build. This is mainly to slim down console clutter in dev builds.
- The background `JobService` no longer runs during integration tests.
- Removed extraneous logging and code
