### PR TITLE
Update Gamebrain/Topo clients default timeout.

### DIFF
--- a/src/Gameboard.Api/Structure/HttpClientStartupExtensions.cs
+++ b/src/Gameboard.Api/Structure/HttpClientStartupExtensions.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Extensions.DependencyInjection
                         client.BaseAddress = new Uri(config.GameEngineUrl);
                         client.DefaultRequestHeaders.Add("x-api-key", config.GameEngineClientSecret);
                         client.DefaultRequestHeaders.Add("x-api-client", config.GameEngineClientName);
+                        client.Timeout = TimeSpan.FromSeconds(300);
                     })
                     .AddPolicyHandler(
                         HttpPolicyExtensions.HandleTransientHttpError()
@@ -41,6 +42,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .ConfigureHttpClient(client =>
                 {
                     client.DefaultRequestHeaders.Add("x-api-key", config.GamebrainApiKey);
+                    client.Timeout = TimeSpan.FromSeconds(300);
                 });
 
             services.AddHttpClient("identity", client =>


### PR DESCRIPTION
Gamebrain and Topo HTTP clients now have default timeouts of 300 sec (up from the default of 100 sec).