### PR TITLE
Resolved ListTeams null ref

### DIFF
--- a/src/Gameboard.Api.Tests.Integration/Tests/Features/Players/PlayerControllerGetTeamsTests.cs
+++ b/src/Gameboard.Api.Tests.Integration/Tests/Features/Players/PlayerControllerGetTeamsTests.cs
@@ -1,0 +1,46 @@
+using Gameboard.Api.Common;
+using Gameboard.Api.Features.Teams;
+using Microsoft.EntityFrameworkCore;
+
+namespace Gameboard.Api.Tests.Integration;
+
+[Collection(TestCollectionNames.DbFixtureTests)]
+public class PlayerControllerGetTeamsTests
+{
+    private readonly GameboardTestContext _testContext;
+
+    public PlayerControllerGetTeamsTests(GameboardTestContext testContext)
+    {
+        _testContext = testContext;
+    }
+
+    [Theory, GbIntegrationAutoData]
+    public async Task GetTeams_OnNormalRequest_DoesntThrow(string gameId, IFixture fixture)
+    {
+        // given a game with a player with associated user and sponsor
+        await _testContext.WithDataState(async state =>
+        {
+            var sponsor = state.Build<Data.Sponsor>(fixture);
+
+            state.Add<Data.Game>(fixture, g =>
+            {
+                g.Id = gameId;
+                g.Players = state.Build<Data.Player>(fixture, p =>
+                {
+                    p.Sponsor = sponsor;
+                    p.User = state.Build<Data.User>(fixture, u => u.Sponsor = sponsor);
+                }).ToCollection();
+            });
+        });
+
+        // when the game's teams are requested
+        var result = await _testContext
+            .CreateHttpClientWithAuthRole(UserRole.Registrar)
+            .GetAsync($"/api/teams/{gameId}")
+            .WithContentDeserializedAs<TeamSummary[]>();
+
+        // then we should get a list with one team in it
+        result.ShouldNotBeNull();
+        result.Length.ShouldBe(1);
+    }
+}

--- a/src/Gameboard.Api.Tests.Integration/Tests/Features/Players/PlayerControllerGetTeamsTests.cs
+++ b/src/Gameboard.Api.Tests.Integration/Tests/Features/Players/PlayerControllerGetTeamsTests.cs
@@ -18,7 +18,7 @@ public class PlayerControllerGetTeamsTests
     public async Task GetTeams_OnNormalRequest_DoesntThrow(string gameId, IFixture fixture)
     {
         // given a game with a player with associated user and sponsor
-        await _testContext.WithDataState(async state =>
+        await _testContext.WithDataState(state =>
         {
             var sponsor = state.Build<Data.Sponsor>(fixture);
 

--- a/src/Gameboard.Api/Features/Player/PlayerService.cs
+++ b/src/Gameboard.Api/Features/Player/PlayerService.cs
@@ -545,6 +545,7 @@ public class PlayerService
     public async Task<TeamSummary[]> LoadTeams(string id, bool sudo)
     {
         var players = await PlayerStore.List()
+            .Include(p => p.Sponsor)
             .Where(p => p.GameId == id)
             .ToArrayAsync();
 

--- a/src/Gameboard.Api/Features/Player/PlayerStore.cs
+++ b/src/Gameboard.Api/Features/Player/PlayerStore.cs
@@ -26,6 +26,7 @@ public class PlayerStore : Store<Data.Player>, IPlayerStore
 
     public IQueryable<Player> ListTeam(string id) =>
         base.List()
+            .Include(player => player.Sponsor)
             .Include(player => player.User)
             .Include(player => player.Game)
             .Where(p => p.TeamId == id);


### PR DESCRIPTION
Resolved an issue that caused exceptions when the `api/teams/{gameId}` endpoint was invoked.