### PR TITLE
Practice Area Report - Per-Player tab crash fix

### DIFF
--- a/src/Gameboard.Api/Features/Reports/ReportsService.cs
+++ b/src/Gameboard.Api/Features/Reports/ReportsService.cs
@@ -141,16 +141,6 @@ public class ReportsService : IReportsService
     /// <returns></returns>
     public async Task<IDictionary<string, ReportTeamViewModel>> GetTeamsByPlayerIds(IEnumerable<string> playerIds, CancellationToken cancellationToken)
     {
-        var sponsors = await _store
-            .List<Data.Sponsor>()
-            .Select(s => new ReportSponsorViewModel
-            {
-                Id = s.Id,
-                Name = s.Name,
-                LogoFileName = s.Logo
-            })
-            .ToDictionaryAsync(s => s.LogoFileName, s => s, cancellationToken);
-
         var teamPlayers = await _store
             .List<Data.Player>()
                 .Include(p => p.Sponsor)


### PR DESCRIPTION
Fixed an issue in the Practice Area report which caused it to crash if two sponsors had the same logo file name.