### PR TITLE
v3.13.1

### DIFF
--- a/src/Gameboard.Api/Features/Game/GameExceptions.cs
+++ b/src/Gameboard.Api/Features/Game/GameExceptions.cs
@@ -29,6 +29,12 @@ internal class CantStartNonReadySynchronizedGame : GameboardValidationException
         => state.Teams.SelectMany(t => t.Players).Where(p => !p.IsReady);
 }
 
+internal class CantStartGameInIneligiblePlayState : GameboardValidationException
+{
+    public CantStartGameInIneligiblePlayState(string gameId, GamePlayState state)
+        : base($"Can't start game {gameId} in ineligible play state {state}.") { }
+}
+
 internal class CantStartStandardGameWithoutActingUserParameter : GameboardValidationException
 {
     public CantStartStandardGameWithoutActingUserParameter(string gameId) : base($"""Game start failure (gameId "{gameId}"): Game is a standard game, so the `actingUser` parameter is required.""") { }

--- a/src/Gameboard.Api/Features/Game/GameStart/ExternalSyncGameStartService.cs
+++ b/src/Gameboard.Api/Features/Game/GameStart/ExternalSyncGameStartService.cs
@@ -110,6 +110,14 @@ internal class ExternalSyncGameStartService : IExternalSyncGameStartService
                 ctx.AddValidationException(new CantStartNonReadySynchronizedGame(syncStartState));
         });
 
+        _validator.AddValidator(async (req, ctx) =>
+        {
+            var gamePlayState = await GetGamePlayState(req.Game.Id, cancellationToken);
+
+            if (gamePlayState == GamePlayState.GameOver)
+                ctx.AddValidationException(new CantStartGameInIneligiblePlayState(req.Game.Id, gamePlayState));
+        });
+
         await _validator.Validate(request, cancellationToken);
         Log($"Validation complete.", request.Game.Id);
     }

--- a/src/Gameboard.Api/Features/Game/GameStart/ExternalSyncGameStartService.cs
+++ b/src/Gameboard.Api/Features/Game/GameStart/ExternalSyncGameStartService.cs
@@ -277,6 +277,7 @@ internal class ExternalSyncGameStartService : IExternalSyncGameStartService
                 {
                     _logger.LogInformation($"Game {gameId} is not in Started state because we couldn't find a challenge for team {teamIdIterated} / spec {specId}.");
                     allDeployed = false;
+                    break;
                 }
 
                 if (!challenge.HasDeployedGamespace && challenge.Score < challenge.Points)

--- a/src/Gameboard.Api/Features/Game/GameStart/ExternalSyncGameStartService.cs
+++ b/src/Gameboard.Api/Features/Game/GameStart/ExternalSyncGameStartService.cs
@@ -110,14 +110,6 @@ internal class ExternalSyncGameStartService : IExternalSyncGameStartService
                 ctx.AddValidationException(new CantStartNonReadySynchronizedGame(syncStartState));
         });
 
-        _validator.AddValidator(async (req, ctx) =>
-        {
-            var gamePlayState = await GetGamePlayState(req.Game.Id, cancellationToken);
-
-            if (gamePlayState == GamePlayState.Started || gamePlayState == GamePlayState.GameOver)
-                ctx.AddValidationException(new CantStartGameInIneligiblePlayState(req.Game.Id, gamePlayState));
-        });
-
         await _validator.Validate(request, cancellationToken);
         Log($"Validation complete.", request.Game.Id);
     }
@@ -229,8 +221,8 @@ internal class ExternalSyncGameStartService : IExternalSyncGameStartService
     {
         // unlike normal games, the playability of external + sync-start games is a function of _all_ registered teams,
         // not just the one passed here. We actually don't need the team parameter at all for this configuration.
-        // We define an external/sync-start game to be ready if all teams have all challenges with deployed 
-        // gamespaces.
+        // We define an external/sync-start game to be ready if all registered players are sync'd and all teams have 
+        // all challenges with deployed gamespaces.
         var game = await _store
             .WithNoTracking<Data.Game>()
                 .Include(g => g.Challenges)

--- a/src/Gameboard.Api/Features/Game/GameStart/ExternalSyncGameStartService.cs
+++ b/src/Gameboard.Api/Features/Game/GameStart/ExternalSyncGameStartService.cs
@@ -110,6 +110,14 @@ internal class ExternalSyncGameStartService : IExternalSyncGameStartService
                 ctx.AddValidationException(new CantStartNonReadySynchronizedGame(syncStartState));
         });
 
+        _validator.AddValidator(async (req, ctx) =>
+        {
+            var gamePlayState = await GetGamePlayState(req.Game.Id, cancellationToken);
+
+            if (gamePlayState == GamePlayState.Started || gamePlayState == GamePlayState.GameOver)
+                ctx.AddValidationException(new CantStartGameInIneligiblePlayState(req.Game.Id, gamePlayState));
+        });
+
         await _validator.Validate(request, cancellationToken);
         Log($"Validation complete.", request.Game.Id);
     }

--- a/src/Gameboard.Api/Features/Game/GameStart/GameStartService.cs
+++ b/src/Gameboard.Api/Features/Game/GameStart/GameStartService.cs
@@ -83,6 +83,7 @@ internal class GameStartService : IGameStartService
             .LockAsync(cancellationToken);
 
         var startRequest = await LoadGameModeStartRequest(game, null, cancellationToken);
+        await gameModeService.ValidateStart(startRequest, cancellationToken);
 
         try
         {

--- a/src/Gameboard.Api/Program.cs
+++ b/src/Gameboard.Api/Program.cs
@@ -46,7 +46,7 @@ if (dbOnly)
 
     var dbOnlyApp = builder.Build();
     dbOnlyApp.Logger.LogInformation("Starting the app in dbonly mode...");
-    dbOnlyApp.Logger.LogInformation($"Connection string: ", settings.Database.ConnectionString);
+    dbOnlyApp.Logger.LogInformation($"Connection string: {settings.Database.ConnectionString}");
     dbOnlyApp.InitializeDatabase(settings, dbOnlyApp.Logger);
     dbOnlyApp.Logger.LogInformation("DB initialized.");
 


### PR DESCRIPTION
Version 3.13.1 of Gameboard contains minor bug fixes and infrastructure improvements.

# Enhancements

- The external game launch system no longer accepts start requests for games that have started or ended. 
- The "I'm ready" button for synchronized games now disables itself upon all players reaching ready status.

# Bug fixes

- Resolved an issue that could cause the web client to log an error when an external game launches.
- Fixed an incorrect link on the Sponsor Select screen