### PR TITLE
v3.14.1

### DIFF
--- a/src/Gameboard.Api.Tests.Unit/Tests/Features/Reports/EnrollmentReportServiceTests.cs
+++ b/src/Gameboard.Api.Tests.Unit/Tests/Features/Reports/EnrollmentReportServiceTests.cs
@@ -56,13 +56,15 @@ public class EnrollmentReportServiceTests
         // given 
         var sponsors = new List<Data.Sponsor>
         {
-            new() {
+            new()
+            {
                 Id = "good-people",
                 Name = "The Good People",
                 Logo = "good-people.jpg",
                 Approved = true
             },
-            new() {
+            new()
+            {
                 Id = "bad-eggs",
                 Name = "The Bad Eggs",
                 Logo = "bad-eggs.jpg",
@@ -116,7 +118,7 @@ public class EnrollmentReportServiceTests
         // given 
         var sponsors = new List<Data.Sponsor>
         {
-            new Data.Sponsor
+            new()
             {
                 Id = "good-people",
                 Name = "The Good People",
@@ -153,4 +155,42 @@ public class EnrollmentReportServiceTests
         // then
         results.Count().ShouldBe(1);
     }
+
+    [Theory, GameboardAutoData]
+    public async Task GetResults_WithPlayerWithNoChallenges_IsIncluded(IFixture fixture)
+    {
+        // given 
+        var sponsors = new List<Data.Sponsor>
+        {
+            new()
+            {
+                Id = "good-people",
+                Name = "The Good People",
+                Logo = "good-people.jpg"
+            }
+        }.BuildMock();
+
+        var player = fixture.Create<Data.Player>();
+        player.Challenges = Array.Empty<Data.Challenge>();
+        player.Sponsor = sponsors.First();
+        var players = player.ToEnumerable().BuildMock();
+
+        var reportsService = A.Fake<IReportsService>();
+        A.CallTo(() => reportsService.ParseMultiSelectCriteria(string.Empty))
+            .WithAnyArguments()
+            .Returns(Array.Empty<string>());
+
+        var store = A.Fake<IStore>();
+        A.CallTo(() => store.List<Data.Sponsor>(false)).Returns(sponsors);
+        A.CallTo(() => store.List<Data.Player>(false)).Returns(players);
+
+        var sut = new EnrollmentReportService(reportsService, store);
+
+        // when
+        var results = await sut.GetRawResults(new EnrollmentReportParameters(), CancellationToken.None);
+
+        // then
+        results.Count().ShouldBe(1);
+    }
+
 }

--- a/src/Gameboard.Api/Features/Challenge/Requests/GetChallengeSubmissions.cs
+++ b/src/Gameboard.Api/Features/Challenge/Requests/GetChallengeSubmissions.cs
@@ -63,7 +63,7 @@ internal class GetChallengeSubmissionsHandler : IRequestHandler<GetChallengeSubm
                 PendingSubmissionData = c.PendingSubmission,
                 c.Submissions
             })
-            .SingleAsync(c => c.ChallengeId == request.ChallengeId);
+            .SingleAsync(c => c.ChallengeId == request.ChallengeId, cancellationToken);
 
         ChallengeSubmissionAnswers pendingAnswers = null;
         var submittedAnswers = Array.Empty<ChallengeSubmissionViewModel>();

--- a/src/Gameboard.Api/Features/Reports/Queries/EnrollmentReport/EnrollmentReportService.cs
+++ b/src/Gameboard.Api/Features/Reports/Queries/EnrollmentReport/EnrollmentReportService.cs
@@ -50,7 +50,9 @@ internal class EnrollmentReportService : IEnrollmentReportService
             .Include(p => p.Challenges.Where(c => c.PlayerMode == PlayerMode.Competition))
             .Include(p => p.User)
             .Include(p => p.Sponsor)
-            .Where(p => p.Challenges.Any(c => c.PlayerMode == PlayerMode.Competition))
+            // to be included in this report, the player record must have either no challenges OR have
+            // all of their challenges be in competitive mode
+            .Where(p => p.Challenges.Count() == 0 || p.Challenges.All(c => c.PlayerMode == PlayerMode.Competition))
             .Where(p => p.TeamId != null && p.TeamId != string.Empty);
 
         if (enrollDateStart != null)

--- a/src/Gameboard.Api/Features/Reports/Queries/PlayersReport/PlayersReportService.cs
+++ b/src/Gameboard.Api/Features/Reports/Queries/PlayersReport/PlayersReportService.cs
@@ -89,14 +89,12 @@ internal class PlayersReportService : IPlayersReportService
                 LogoFileName = u.Sponsor.Logo,
             },
             CreatedOn = u.CreatedOn,
-            LastPlayedOn = u
-                .Enrollments
-                .OrderByDescending(p => p.SessionBegin)
-                .FirstOrDefault() != null ? u
-                    .Enrollments
+            LastPlayedOn = u.Enrollments.Where(p => p.SessionBegin > DateTimeOffset.MinValue).Any() ?
+                u.Enrollments
+                    .Where(p => p.SessionBegin > DateTimeOffset.MinValue)
                     .OrderByDescending(p => p.SessionBegin)
                     .First().SessionBegin :
-                    null,
+                null,
             CompletedCompetitiveChallengesCount = u
                 .Enrollments
                 .SelectMany(p => p.Challenges)


### PR DESCRIPTION
Version 3.14.1 of Gameboard contains minor bug fixes and improvements.

# Enhancements

- The Players menu in Admin now displays the user ID for players who have a pending name change request. Admins can click this ID to copy it to the clipboard.
- The alert which displays when a user issues a name change request has been clarified to indicate that a pending name change does not prevent players from enrolling in/playing games.

# Bug fixes

- Improved readability for links in ticket activity when generated by application support personnel.
- Resolved an issue that prevented players who have enrolled but not yet begun a challenge from appearing in the Enrollment Report. 
- Resolved an issue that caused the Last Played On value in the Players report to display inaccurately for inactive players.
- Resolved an issue that caused previously-submitted responses to a challenge to fail to display in some cases.