### PR TITLE
v3.14.6-beta0

### DIFF
--- a/src/Gameboard.Api.Tests.Unit/Tests/Features/Player/PlayerServiceTestHelpers.cs
+++ b/src/Gameboard.Api.Tests.Unit/Tests/Features/Player/PlayerServiceTestHelpers.cs
@@ -8,6 +8,7 @@ using Gameboard.Api.Features.Teams;
 using Gameboard.Api.Services;
 using MediatR;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
 
 namespace Gameboard.Api.Tests.Unit;
 
@@ -21,6 +22,7 @@ internal static class PlayerServiceTestHelpers
         IGameStore? gameStore = null,
         IGuidService? guidService = null,
         IInternalHubBus? hubBus = null,
+        ILogger<PlayerService>? logger = null,
         IMapper? mapper = null,
         IMemoryCache? memCache = null,
         INowService? now = null,
@@ -38,6 +40,7 @@ internal static class PlayerServiceTestHelpers
             gameStore ?? A.Fake<IGameStore>(),
             guidService ?? A.Fake<IGuidService>(),
             hubBus ?? A.Fake<IInternalHubBus>(),
+            logger ?? A.Fake<ILogger<PlayerService>>(),
             mapper ?? A.Fake<IMapper>(),
             memCache ?? A.Fake<IMemoryCache>(),
             now ?? A.Fake<INowService>(),

--- a/src/Gameboard.Api/Features/Challenge/Challenge.cs
+++ b/src/Gameboard.Api/Features/Challenge/Challenge.cs
@@ -146,6 +146,7 @@ public class ObserveChallenge
 {
     public string Id { get; set; }
     public string TeamId { get; set; }
+    public string TeamName { get; set; }
     public string Name { get; set; }
     public string Tag { get; set; }
     public string PlayerId { get; set; }

--- a/src/Gameboard.Api/Features/Challenge/ChallengeController.cs
+++ b/src/Gameboard.Api/Features/Challenge/ChallengeController.cs
@@ -275,9 +275,7 @@ namespace Gameboard.Api.Controllers
         [Authorize]
         public async Task<IEnumerable<GameEngineSectionSubmission>> Audit([FromRoute] string id)
         {
-            AuthorizeAny(
-                () => Actor.IsDirector
-            );
+            AuthorizeAny(() => Actor.IsDirector);
 
             await Validate(new Entity { Id = id });
 

--- a/src/Gameboard.Api/Features/Challenge/ConsoleActorMap.cs
+++ b/src/Gameboard.Api/Features/Challenge/ConsoleActorMap.cs
@@ -11,7 +11,7 @@ namespace Gameboard.Api.Services
 {
     public class ConsoleActorMap
     {
-        private readonly ConcurrentDictionary<string, ConsoleActor> _cache = new();
+        private static readonly ConcurrentDictionary<string, ConsoleActor> _cache = new();
 
         public ConsoleActorMap()
         {
@@ -52,21 +52,6 @@ namespace Gameboard.Api.Services
             ;
 
             return q.ToArray();
-        }
-
-        public Dictionary<string, List<string>> ReverseLookup(string gid)
-        {
-            var actorMap = _cache.Values.Where(a => a.GameId == gid).ToArray();
-            var vmToActor = new Dictionary<string, List<string>>();
-            foreach (var a in actorMap)
-            {
-                string key = $"{a.ChallengeId}#{a.VmName}";
-                if (vmToActor.ContainsKey(key))
-                    vmToActor[key].Add(a.UserName);
-                else
-                    vmToActor.Add(key, new List<string> { a.UserName });
-            }
-            return vmToActor;
         }
 
         public ConsoleActor FindActor(string uid)

--- a/src/Gameboard.Api/Features/Challenge/Services/ChallengeService.cs
+++ b/src/Gameboard.Api/Features/Challenge/Services/ChallengeService.cs
@@ -112,7 +112,9 @@ public partial class ChallengeService : _Service
         if (locked != lockval)
             throw new ChallengeStartPending();
 
-        var spec = await _store.WithNoTracking<Data.ChallengeSpec>().SingleAsync(s => s.Id == model.SpecId);
+        var spec = await _store
+            .WithNoTracking<Data.ChallengeSpec>()
+            .SingleAsync(s => s.Id == model.SpecId, cancellationToken);
 
         int playerCount = 1;
         if (game.AllowTeam)

--- a/src/Gameboard.Api/Features/Challenge/Services/ChallengeService.cs
+++ b/src/Gameboard.Api/Features/Challenge/Services/ChallengeService.cs
@@ -18,7 +18,6 @@ using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
-using System.Security.Cryptography.Xml;
 
 namespace Gameboard.Api.Services;
 
@@ -564,15 +563,28 @@ public partial class ChallengeService : _Service
 
     public async Task<List<ObserveChallenge>> GetChallengeConsoles(string gameId)
     {
+        // retrieve challenges to list
         var q = _challengeStore.DbContext.Challenges
             .Where(c => c.GameId == gameId && c.HasDeployedGamespace)
             .Include(c => c.Player)
             .OrderBy(c => c.Player.Name)
             .ThenBy(c => c.Name);
         var challenges = Mapper.Map<ObserveChallenge[]>(await q.ToArrayAsync());
+
+        // resolve the name of the captain.
+        // (we used to depend on the name of all players being that of the captain, but
+        // we don't anymore because that was super unstable and weird)
+        var teamIds = challenges.Select(c => c.TeamId).ToArray();
+        var captains = await _teamService.ResolveCaptains(teamIds, CancellationToken.None);
+
         var result = new List<ObserveChallenge>();
         foreach (var challenge in challenges.Where(c => c.IsActive))
         {
+            // attempt to grab the captain's name if we were able to resolve it from the
+            // teamservice
+            var captain = captains.ContainsKey(challenge.TeamId) ? captains[challenge.TeamId] : null;
+            challenge.TeamName = captain?.ApprovedName ?? challenge.PlayerName;
+
             challenge.Consoles = challenge.Consoles
                 .Where(v => v.IsVisible)
                 .ToArray();

--- a/src/Gameboard.Api/Features/Game/GameExceptions.cs
+++ b/src/Gameboard.Api/Features/Game/GameExceptions.cs
@@ -74,7 +74,7 @@ public class PlayerWrongGameIDException : Exception { }
 
 internal class PracticeSessionLimitReached : GameboardValidationException
 {
-    public PracticeSessionLimitReached(string userId, int userSessionCount, int practiceSessionLimit) : base($"Can't start a new practice session. User \"{userId}\" has \"{userSessionCount}\" practice sessions, and the limit is \"{practiceSessionLimit}\".") { }
+    public PracticeSessionLimitReached() : base($"No practice sessions are available right now. Try again later.") { }
 }
 
 internal class SessionLimitReached : GameboardValidationException

--- a/src/Gameboard.Api/Features/Game/GameStart/ExternalSyncGameStartService.cs
+++ b/src/Gameboard.Api/Features/Game/GameStart/ExternalSyncGameStartService.cs
@@ -564,7 +564,7 @@ internal class ExternalSyncGameStartService : IExternalSyncGameStartService
                 {
                     Id = gs.Id,
                     VmUris = _gameEngineService.GetGamespaceVms(gs).Select(vm => vm.Url),
-                    IsDeployed = gs.IsActive
+                    IsDeployed = gs.HasDeployedGamespace
                 }),
                 Players = teamPlayers
             };

--- a/src/Gameboard.Api/Features/Reports/Queries/ChallengesReport/ChallengesReportService.cs
+++ b/src/Gameboard.Api/Features/Reports/Queries/ChallengesReport/ChallengesReportService.cs
@@ -139,9 +139,9 @@ internal class ChallengesReportService : IChallengesReportService
                 DeployCompetitiveCount = aggregations is not null ? aggregations.DeployCompetitiveCount : 0,
                 DeployPracticeCount = aggregations is not null ? aggregations.DeployPracticeCount : 0,
                 DistinctPlayerCount = aggregations is not null ? aggregations.DistinctPlayerCount : 0,
-                SolveCompleteCount = aggregations is not null ? aggregations.SolveZeroCount : 0,
+                SolveZeroCount = aggregations is not null ? aggregations.SolveZeroCount : 0,
                 SolvePartialCount = aggregations is not null ? aggregations.SolvePartialCount : 0,
-                SolveZeroCount = aggregations is not null ? aggregations.SolveCompleteCount : 0
+                SolveCompleteCount = aggregations is not null ? aggregations.SolveCompleteCount : 0
             };
         })
         .OrderBy(r => r.ChallengeSpec.Name)

--- a/src/Gameboard.Api/Features/Reports/Queries/PlayersReport/PlayersReportService.cs
+++ b/src/Gameboard.Api/Features/Reports/Queries/PlayersReport/PlayersReportService.cs
@@ -56,7 +56,7 @@ internal class PlayersReportService : IPlayersReportService
 
         if (gamesCriteria.Any())
             query = query
-                .Where(u => u.Enrollments.Any(g => gamesCriteria.Contains(g.Id)));
+                .Where(u => u.Enrollments.Any(p => gamesCriteria.Contains(p.GameId)));
 
         if (parameters.LastPlayedDateStart is not null)
             query = query

--- a/src/Gameboard.Api/Features/Teams/TeamService.cs
+++ b/src/Gameboard.Api/Features/Teams/TeamService.cs
@@ -30,6 +30,7 @@ public interface ITeamService
     Task<bool> IsOnTeam(string teamId, string userId);
     Task<Data.Player> ResolveCaptain(string teamId, CancellationToken cancellationToken);
     Data.Player ResolveCaptain(IEnumerable<Data.Player> players);
+    Task<IDictionary<string, Data.Player>> ResolveCaptains(IEnumerable<string> teamIds, CancellationToken cancellationToken);
     Task PromoteCaptain(string teamId, string newCaptainPlayerId, User actingUser, CancellationToken cancellationToken);
     Task UpdateSessionStartAndEnd(string teamId, DateTimeOffset? sessionStart, DateTimeOffset? sessionEnd, CancellationToken cancellationToken);
 }
@@ -278,6 +279,28 @@ internal class TeamService : ITeamService
         }
 
         return players.OrderBy(p => p.ApprovedName).First();
+    }
+
+    public async Task<IDictionary<string, Data.Player>> ResolveCaptains(IEnumerable<string> teamIds, CancellationToken cancellationToken)
+    {
+        var teamMap = await _store
+            .WithNoTracking<Data.Player>()
+            .Where(p => teamIds.Contains(p.TeamId))
+            .GroupBy(p => p.TeamId)
+            .ToDictionaryAsync(gr => gr.Key, gr => gr.ToList(), cancellationToken);
+
+        var retVal = new Dictionary<string, Data.Player>();
+        foreach (var teamId in teamIds)
+        {
+            Data.Player captain = null;
+
+            if (teamMap.TryGetValue(teamId, out List<Data.Player> value))
+                captain = ResolveCaptain(value);
+
+            retVal.Add(teamId, captain);
+        }
+
+        return retVal;
     }
 
     private async Task<TeamState> GetTeamState(string teamId, SimpleEntity actor, CancellationToken cancellationToken)

--- a/src/Gameboard.Api/Features/Teams/TeamService.cs
+++ b/src/Gameboard.Api/Features/Teams/TeamService.cs
@@ -283,6 +283,7 @@ internal class TeamService : ITeamService
 
     public async Task<IDictionary<string, Data.Player>> ResolveCaptains(IEnumerable<string> teamIds, CancellationToken cancellationToken)
     {
+        var distinctTeamIds = teamIds.Distinct().ToArray();
         var teamMap = await _store
             .WithNoTracking<Data.Player>()
             .Where(p => teamIds.Contains(p.TeamId))
@@ -290,7 +291,7 @@ internal class TeamService : ITeamService
             .ToDictionaryAsync(gr => gr.Key, gr => gr.ToList(), cancellationToken);
 
         var retVal = new Dictionary<string, Data.Player>();
-        foreach (var teamId in teamIds)
+        foreach (var teamId in distinctTeamIds)
         {
             Data.Player captain = null;
 

--- a/src/Gameboard.Api/Features/Ticket/Ticket.cs
+++ b/src/Gameboard.Api/Features/Ticket/Ticket.cs
@@ -218,7 +218,6 @@ namespace Gameboard.Api
     {
         public required string Id { get; set; }
         public required string ApprovedName { get; set; }
-        public required UserRole Role { get; set; }
         public required bool IsSupportPersonnel { get; set; }
     }
 }

--- a/src/Gameboard.Api/Features/Ticket/TicketService.cs
+++ b/src/Gameboard.Api/Features/Ticket/TicketService.cs
@@ -122,7 +122,6 @@ namespace Gameboard.Api.Services
             {
                 Id = actingUser.Id,
                 ApprovedName = actingUser.ApprovedName,
-                Role = actingUser.Role,
                 IsSupportPersonnel = actingUser.IsAdmin || actingUser.IsSupport
             };
 


### PR DESCRIPTION
v3.14.6-beta0 of Gameboard contains enhanced features, stability improvements, and bug fixes.

# Enhancements

- The "Copy to Markdown" feature for Support tickets now includes the challenge support code and a link to the Admin -> Challenges view scoped to the challenge (#338).

# Bug fixes

- Fixed an issue that could cause the team name listed in Admin -> Challenges -> Observe Challenges to be incorrect (#334)
- Fixed an issue that caused the Admin -> Observe screens to fail to correctly show console user pills (#335)
- Fixed an issue that caused the Gameboard page to automatically navigate to a challenge upon deploy (#339)
- Fixed an issue that caused the number of total and complete solves to be reversed on the Challenges Report
- Fixed an issue that could cause the Game hub to fail to connect for external/sync games.
- The per-team deploy button in Admin -> Game -> Deployment now correctly disables itself while deploys are executing.
- The error message shown when the global practice session limit has been exceeded has been clarified (#343).
- Fixed an issue that caused use of the "Games" filter on the Players Report to exclude all records (#346).

# Stability

- Updated some package dependencies