### PR TITLE
v3.15.0

### DIFF
--- a/src/Gameboard.Api/Data/Entities/Game.cs
+++ b/src/Gameboard.Api/Data/Entities/Game.cs
@@ -50,6 +50,7 @@ public class Game : IEntity
     public string Mode { get; set; }
     public PlayerMode PlayerMode { get; set; }
     public bool RequireSynchronizedStart { get; set; } = false;
+    public bool ShowOnHomePageInPracticeMode { get; set; } = false;
 
     public ICollection<ChallengeSpec> Specs { get; set; } = new List<ChallengeSpec>();
     public ICollection<ExternalGameTeam> ExternalGameTeams { get; set; } = new List<ExternalGameTeam>();

--- a/src/Gameboard.Api/Data/Migrations/PostgreSQL/GameboardDb/20240124144740_AddShowGameOnHomePageInPracticeMode.Designer.cs
+++ b/src/Gameboard.Api/Data/Migrations/PostgreSQL/GameboardDb/20240124144740_AddShowGameOnHomePageInPracticeMode.Designer.cs
@@ -3,52 +3,54 @@ using System;
 using Gameboard.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
-namespace Gameboard.Api.Data.Migrations.SqlServer.GameboardDb
+namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
 {
-    [DbContext(typeof(GameboardDbContextSqlServer))]
-    partial class GameboardDbContextSqlServerModelSnapshot : ModelSnapshot
+    [DbContext(typeof(GameboardDbContextPostgreSQL))]
+    [Migration("20240124144740_AddShowGameOnHomePageInPracticeMode")]
+    partial class AddShowGameOnHomePageInPracticeMode
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
                 .HasAnnotation("ProductVersion", "7.0.8")
-                .HasAnnotation("Relational:MaxIdentifierLength", 128);
+                .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
-            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
+            NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
             modelBuilder.Entity("Gameboard.Api.Data.ApiKey", b =>
                 {
                     b.Property<string>("Id")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<DateTimeOffset?>("ExpiresOn")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetimeoffset")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("NULL");
 
                     b.Property<DateTimeOffset>("GeneratedOn")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetimeoffset")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("NOW()");
 
                     b.Property<string>("Key")
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("character varying(100)");
 
                     b.Property<string>("Name")
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("character varying(50)");
 
                     b.Property<string>("OwnerId")
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.HasKey("Id");
 
@@ -61,79 +63,79 @@ namespace Gameboard.Api.Data.Migrations.SqlServer.GameboardDb
                 {
                     b.Property<string>("Id")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<long>("Duration")
                         .HasColumnType("bigint");
 
                     b.Property<DateTimeOffset>("EndTime")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Events")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("GameId")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<string>("GameName")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<bool>("HasGamespaceDeployed")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<DateTimeOffset>("LastScoreTime")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTimeOffset>("LastSyncTime")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Name")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("PlayerId")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<int>("PlayerMode")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("PlayerName")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<int>("Points")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<int>("Result")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<int>("Score")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<DateTimeOffset>("StartTime")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("State")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Submissions")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Tag")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("TeamId")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<string>("TeamMembers")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("UserId")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.HasKey("Id");
 
@@ -152,22 +154,22 @@ namespace Gameboard.Api.Data.Migrations.SqlServer.GameboardDb
                 {
                     b.Property<string>("Id")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<string>("ChallengeBonusId")
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<string>("ChallengeId")
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<DateTimeOffset>("EnteredOn")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetimeoffset")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("NOW()");
 
                     b.Property<string>("InternalSummary")
                         .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
+                        .HasColumnType("character varying(200)");
 
                     b.HasKey("Id");
 
@@ -182,73 +184,73 @@ namespace Gameboard.Api.Data.Migrations.SqlServer.GameboardDb
                 {
                     b.Property<string>("Id")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<DateTimeOffset>("EndTime")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("ExternalId")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<int>("GameEngineType")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("GameId")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<string>("GraderKey")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<bool>("HasDeployedGamespace")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<DateTimeOffset>("LastScoreTime")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTimeOffset>("LastSyncTime")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Name")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("PendingSubmission")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("PlayerId")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<int>("PlayerMode")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<int>("Points")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<double>("Score")
-                        .HasColumnType("float");
+                        .HasColumnType("double precision");
 
                     b.Property<string>("SpecId")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<DateTimeOffset>("StartTime")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("State")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Tag")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("TeamId")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<DateTimeOffset>("WhenCreated")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("Id");
 
@@ -265,20 +267,20 @@ namespace Gameboard.Api.Data.Migrations.SqlServer.GameboardDb
                 {
                     b.Property<string>("Id")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<int>("ChallengeBonusType")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("ChallengeSpecId")
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<string>("Description")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<double>("PointValue")
-                        .HasColumnType("float");
+                        .HasColumnType("double precision");
 
                     b.HasKey("Id");
 
@@ -295,29 +297,29 @@ namespace Gameboard.Api.Data.Migrations.SqlServer.GameboardDb
                 {
                     b.Property<string>("Id")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<string>("ChallengeId")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<string>("TeamId")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<string>("Text")
                         .HasMaxLength(1024)
-                        .HasColumnType("nvarchar(1024)");
+                        .HasColumnType("character varying(1024)");
 
                     b.Property<DateTimeOffset>("Timestamp")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<int>("Type")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("UserId")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.HasKey("Id");
 
@@ -330,22 +332,22 @@ namespace Gameboard.Api.Data.Migrations.SqlServer.GameboardDb
                 {
                     b.Property<string>("Id")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<string>("GameId")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<string>("RequiredId")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<double>("RequiredScore")
-                        .HasColumnType("float");
+                        .HasColumnType("double precision");
 
                     b.Property<string>("TargetId")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.HasKey("Id");
 
@@ -358,52 +360,52 @@ namespace Gameboard.Api.Data.Migrations.SqlServer.GameboardDb
                 {
                     b.Property<string>("Id")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<int>("AverageDeploySeconds")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("Description")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<bool>("Disabled")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("ExternalId")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<int>("GameEngineType")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("GameId")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<string>("Name")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<int>("Points")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<float>("R")
                         .HasColumnType("real");
 
                     b.Property<bool>("ShowSolutionGuideInCompetitiveMode")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("SolutionGuideUrl")
                         .HasMaxLength(1000)
-                        .HasColumnType("nvarchar(1000)");
+                        .HasColumnType("character varying(1000)");
 
                     b.Property<string>("Tag")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Tags")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Text")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<float>("X")
                         .HasColumnType("real");
@@ -421,23 +423,23 @@ namespace Gameboard.Api.Data.Migrations.SqlServer.GameboardDb
             modelBuilder.Entity("Gameboard.Api.Data.ChallengeSubmission", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Answers")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("ChallengeId")
                         .IsRequired()
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<double>("Score")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("float")
+                        .HasColumnType("double precision")
                         .HasDefaultValue(0.0);
 
                     b.Property<DateTimeOffset>("SubmittedOn")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("Id");
 
@@ -450,22 +452,22 @@ namespace Gameboard.Api.Data.Migrations.SqlServer.GameboardDb
                 {
                     b.Property<string>("Id")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<int>("DeployStatus")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("ExternalGameUrl")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("GameId")
                         .IsRequired()
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<string>("TeamId")
                         .IsRequired()
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.HasKey("Id");
 
@@ -480,36 +482,36 @@ namespace Gameboard.Api.Data.Migrations.SqlServer.GameboardDb
                 {
                     b.Property<string>("Id")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<string>("Answers")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("ChallengeId")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<string>("ChallengeSpecId")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<string>("GameId")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<string>("PlayerId")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<bool>("Submitted")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<DateTimeOffset>("Timestamp")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("UserId")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.HasKey("Id");
 
@@ -530,140 +532,140 @@ namespace Gameboard.Api.Data.Migrations.SqlServer.GameboardDb
                 {
                     b.Property<string>("Id")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<bool>("AllowPreview")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("AllowReset")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("Background")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("CardText1")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("CardText2")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("CardText3")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("CertificateTemplate")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Competition")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("Division")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("ExternalGameClientUrl")
                         .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
+                        .HasColumnType("character varying(200)");
 
                     b.Property<string>("ExternalGameStartupUrl")
                         .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
+                        .HasColumnType("character varying(200)");
 
                     b.Property<string>("FeedbackConfig")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<DateTimeOffset>("GameEnd")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("GameMarkdown")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<DateTimeOffset>("GameStart")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<int>("GamespaceLimitPerSession")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<bool>("IsPublished")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("Key")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("Logo")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<int>("MaxAttempts")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<int>("MaxTeamSize")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<int>("MinTeamSize")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("Mode")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<string>("Name")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<int>("PlayerMode")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<DateTimeOffset>("RegistrationClose")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("RegistrationConstraint")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("RegistrationMarkdown")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<DateTimeOffset>("RegistrationOpen")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<int>("RegistrationType")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<bool>("RequireSponsoredTeam")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("RequireSynchronizedStart")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("Season")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<int>("SessionLimit")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<int>("SessionMinutes")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<bool>("ShowOnHomePageInPracticeMode")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("Sponsor")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<string>("TestCode")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("Track")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.HasKey("Id");
 
@@ -674,25 +676,25 @@ namespace Gameboard.Api.Data.Migrations.SqlServer.GameboardDb
                 {
                     b.Property<string>("Id")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<string>("ChallengeId")
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<string>("Description")
                         .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
+                        .HasColumnType("character varying(200)");
 
                     b.Property<string>("EnteredByUserId")
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<DateTimeOffset>("EnteredOn")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetimeoffset")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("NOW()");
 
                     b.Property<double>("PointValue")
-                        .HasColumnType("float");
+                        .HasColumnType("double precision");
 
                     b.HasKey("Id");
 
@@ -707,78 +709,78 @@ namespace Gameboard.Api.Data.Migrations.SqlServer.GameboardDb
                 {
                     b.Property<string>("Id")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<bool>("Advanced")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("ApprovedName")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<int>("CorrectCount")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("GameId")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<string>("InviteCode")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<bool>("IsReady")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<int>("Mode")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("Name")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("NameStatus")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<int>("PartialCount")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<int>("Rank")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<int>("Role")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<int>("Score")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<DateTimeOffset>("SessionBegin")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTimeOffset>("SessionEnd")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<int>("SessionMinutes")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("SponsorId")
                         .IsRequired()
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<string>("TeamId")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<long>("Time")
                         .HasColumnType("bigint");
 
                     b.Property<string>("UserId")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<DateTimeOffset>("WhenCreated")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("Id");
 
@@ -797,38 +799,37 @@ namespace Gameboard.Api.Data.Migrations.SqlServer.GameboardDb
                 {
                     b.Property<string>("Id")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<string>("CertificateHtmlTemplate")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<int>("DefaultPracticeSessionLengthMinutes")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("IntroTextMarkdown")
                         .HasMaxLength(4000)
-                        .HasColumnType("nvarchar(4000)");
+                        .HasColumnType("character varying(4000)");
 
                     b.Property<int?>("MaxConcurrentPracticeSessions")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<int?>("MaxPracticeSessionLengthMinutes")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("SuggestedSearches")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("UpdatedByUserId")
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<DateTimeOffset?>("UpdatedOn")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("Id");
 
                     b.HasIndex("UpdatedByUserId")
-                        .IsUnique()
-                        .HasFilter("[UpdatedByUserId] IS NOT NULL");
+                        .IsUnique();
 
                     b.ToTable("PracticeModeSettings");
                 });
@@ -836,16 +837,16 @@ namespace Gameboard.Api.Data.Migrations.SqlServer.GameboardDb
             modelBuilder.Entity("Gameboard.Api.Data.PublishedCertificate", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.Property<int>("Mode")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("OwnerUserId")
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<DateTimeOffset>("PublishedOn")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("Id");
 
@@ -860,20 +861,20 @@ namespace Gameboard.Api.Data.Migrations.SqlServer.GameboardDb
                 {
                     b.Property<string>("Id")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<bool>("Approved")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("Logo")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Name")
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("ParentSponsorId")
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.HasKey("Id");
 
@@ -886,32 +887,32 @@ namespace Gameboard.Api.Data.Migrations.SqlServer.GameboardDb
                 {
                     b.Property<string>("Id")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<string>("CreatedByUserId")
                         .IsRequired()
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<DateTimeOffset?>("EndsOn")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("MarkdownContent")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<int>("NotificationType")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<DateTimeOffset?>("StartsOn")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Title")
                         .IsRequired()
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.HasKey("Id");
 
@@ -923,24 +924,24 @@ namespace Gameboard.Api.Data.Migrations.SqlServer.GameboardDb
             modelBuilder.Entity("Gameboard.Api.Data.SystemNotificationInteraction", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.Property<DateTimeOffset?>("DismissedOn")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTimeOffset?>("SawCalloutOn")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTimeOffset?>("SawFullNotificationOn")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("SystemNotificationId")
                         .IsRequired()
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<string>("UserId")
                         .IsRequired()
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.HasKey("Id");
 
@@ -955,62 +956,64 @@ namespace Gameboard.Api.Data.Migrations.SqlServer.GameboardDb
                 {
                     b.Property<string>("Id")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<string>("AssigneeId")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<string>("Attachments")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("ChallengeId")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<DateTimeOffset>("Created")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("CreatorId")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<string>("Description")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<int>("Key")
-                        .HasColumnType("int")
-                        .HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.SerialColumn);
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("integer");
+
+                    NpgsqlPropertyBuilderExtensions.UseSerialColumn(b.Property<int>("Key"));
 
                     b.Property<string>("Label")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<DateTimeOffset>("LastUpdated")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("PlayerId")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<string>("RequesterId")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<bool>("StaffCreated")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("Status")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("Summary")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("TeamId")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.HasKey("Id");
 
@@ -1033,35 +1036,35 @@ namespace Gameboard.Api.Data.Migrations.SqlServer.GameboardDb
             modelBuilder.Entity("Gameboard.Api.Data.TicketActivity", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("AssigneeId")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<string>("Attachments")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Message")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Status")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("TicketId")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<DateTimeOffset>("Timestamp")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<int>("Type")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("UserId")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.HasKey("Id");
 
@@ -1078,53 +1081,53 @@ namespace Gameboard.Api.Data.Migrations.SqlServer.GameboardDb
                 {
                     b.Property<string>("Id")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<string>("ApprovedName")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTimeOffset>("CreatedOn")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Email")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<bool>("HasDefaultSponsor")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<DateTimeOffset?>("LastLoginDate")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<int>("LoginCount")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int")
+                        .HasColumnType("integer")
                         .HasDefaultValueSql("0");
 
                     b.Property<string>("Name")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("NameStatus")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<bool>("PlayAudioOnBrowserNotification")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("bit")
+                        .HasColumnType("boolean")
                         .HasDefaultValue(false);
 
                     b.Property<int>("Role")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("SponsorId")
                         .IsRequired()
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.Property<string>("Username")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.HasKey("Id");
 
@@ -1138,7 +1141,7 @@ namespace Gameboard.Api.Data.Migrations.SqlServer.GameboardDb
                     b.HasBaseType("Gameboard.Api.Data.ChallengeBonus");
 
                     b.Property<int>("SolveRank")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.HasDiscriminator().HasValue(0);
                 });
@@ -1149,7 +1152,7 @@ namespace Gameboard.Api.Data.Migrations.SqlServer.GameboardDb
 
                     b.Property<string>("GameId")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.HasIndex("GameId");
 
@@ -1164,7 +1167,7 @@ namespace Gameboard.Api.Data.Migrations.SqlServer.GameboardDb
 
                     b.Property<string>("ChallengeSpecId")
                         .HasMaxLength(40)
-                        .HasColumnType("nvarchar(40)");
+                        .HasColumnType("character varying(40)");
 
                     b.HasIndex("ChallengeSpecId");
 

--- a/src/Gameboard.Api/Data/Migrations/PostgreSQL/GameboardDb/20240124144740_AddShowGameOnHomePageInPracticeMode.cs
+++ b/src/Gameboard.Api/Data/Migrations/PostgreSQL/GameboardDb/20240124144740_AddShowGameOnHomePageInPracticeMode.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
+{
+    /// <inheritdoc />
+    public partial class AddShowGameOnHomePageInPracticeMode : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "ShowOnHomePageInPracticeMode",
+                table: "Games",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ShowOnHomePageInPracticeMode",
+                table: "Games");
+        }
+    }
+}

--- a/src/Gameboard.Api/Data/Migrations/PostgreSQL/GameboardDb/GameboardDbContextPostgreSQLModelSnapshot.cs
+++ b/src/Gameboard.Api/Data/Migrations/PostgreSQL/GameboardDb/GameboardDbContextPostgreSQLModelSnapshot.cs
@@ -649,6 +649,9 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
                     b.Property<int>("SessionMinutes")
                         .HasColumnType("integer");
 
+                    b.Property<bool>("ShowOnHomePageInPracticeMode")
+                        .HasColumnType("boolean");
+
                     b.Property<string>("Sponsor")
                         .HasMaxLength(40)
                         .HasColumnType("character varying(40)");

--- a/src/Gameboard.Api/Data/Migrations/SqlServer/GameboardDb/20240124144749_AddShowGameOnHomePageInPracticeMode.Designer.cs
+++ b/src/Gameboard.Api/Data/Migrations/SqlServer/GameboardDb/20240124144749_AddShowGameOnHomePageInPracticeMode.Designer.cs
@@ -4,6 +4,7 @@ using Gameboard.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Gameboard.Api.Data.Migrations.SqlServer.GameboardDb
 {
     [DbContext(typeof(GameboardDbContextSqlServer))]
-    partial class GameboardDbContextSqlServerModelSnapshot : ModelSnapshot
+    [Migration("20240124144749_AddShowGameOnHomePageInPracticeMode")]
+    partial class AddShowGameOnHomePageInPracticeMode
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Gameboard.Api/Data/Migrations/SqlServer/GameboardDb/20240124144749_AddShowGameOnHomePageInPracticeMode.cs
+++ b/src/Gameboard.Api/Data/Migrations/SqlServer/GameboardDb/20240124144749_AddShowGameOnHomePageInPracticeMode.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Gameboard.Api.Data.Migrations.SqlServer.GameboardDb
+{
+    /// <inheritdoc />
+    public partial class AddShowGameOnHomePageInPracticeMode : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "ShowOnHomePageInPracticeMode",
+                table: "Games",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ShowOnHomePageInPracticeMode",
+                table: "Games");
+        }
+    }
+}

--- a/src/Gameboard.Api/Extensions/WebApplicationExtensions.cs
+++ b/src/Gameboard.Api/Extensions/WebApplicationExtensions.cs
@@ -5,7 +5,6 @@ using Gameboard.Api.Features.Games;
 using Gameboard.Api.Features.Hubs;
 using Gameboard.Api.Hubs;
 using Gameboard.Api.Services;
-using Gameboard.Api.Structure;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;

--- a/src/Gameboard.Api/Features/Admin/AdminController.cs
+++ b/src/Gameboard.Api/Features/Admin/AdminController.cs
@@ -1,0 +1,20 @@
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Gameboard.Api.Features.Admin;
+
+[Route("api/admin")]
+public class AdminController : ControllerBase
+{
+    private readonly IMediator _mediator;
+
+    public AdminController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    [HttpGet("stats")]
+    public Task<GetSiteOverviewStatsResponse> GetSiteOverviewStats()
+        => _mediator.Send(new GetSiteOverviewStatsQuery());
+}

--- a/src/Gameboard.Api/Features/Admin/Requests/GetSiteOverviewStats.cs
+++ b/src/Gameboard.Api/Features/Admin/Requests/GetSiteOverviewStats.cs
@@ -1,0 +1,10 @@
+using MediatR;
+
+namespace Gameboard.Api.Features.Admin;
+
+public sealed class GetSiteOverviewStatsResponse
+{
+
+}
+
+public record GetSiteOverviewStatsQuery() : IRequest<GetSiteOverviewStatsResponse>;

--- a/src/Gameboard.Api/Features/Game/Game.cs
+++ b/src/Gameboard.Api/Features/Game/Game.cs
@@ -48,6 +48,7 @@ public class GameDetail
     public string CardText3 { get; set; }
     public string Mode { get; set; }
     public PlayerMode PlayerMode { get; set; }
+    public bool ShowOnHomePageInPracticeMode { get; set; }
 }
 
 public class Game : GameDetail

--- a/src/Gameboard.Api/Features/Game/GameService.cs
+++ b/src/Gameboard.Api/Features/Game/GameService.cs
@@ -166,7 +166,7 @@ public class GameService : _Service, IGameService
             q = q.Where(g => g.IsPublished);
 
         if (model.WantsCompetitive)
-            q = q.Where(g => g.PlayerMode == PlayerMode.Competition);
+            q = q.Where(g => g.PlayerMode == PlayerMode.Competition || g.ShowOnHomePageInPracticeMode);
         if (model.WantsPresent)
             q = q.Where(g => g.GameEnd > now && g.GameStart < now);
         if (model.WantsFuture)

--- a/src/Gameboard.Api/Features/Practice/UpdatePracticeModeSettings.cs
+++ b/src/Gameboard.Api/Features/Practice/UpdatePracticeModeSettings.cs
@@ -43,7 +43,7 @@ internal class UpdatePracticeModeSettingsValidator : IGameboardRequestValidator<
 
         _validatorService.AddValidator((request, context) =>
         {
-            if (request.Settings.MaxConcurrentPracticeSessions.HasValue && request.Settings.MaxConcurrentPracticeSessions <= 0)
+            if (request.Settings.MaxConcurrentPracticeSessions.HasValue && request.Settings.MaxConcurrentPracticeSessions < 0)
                 context.AddValidationException(new PracticeModeSettingsInvalid(nameof(PracticeModeSettings.MaxConcurrentPracticeSessions), request.Settings.MaxConcurrentPracticeSessions.Value.ToString(), "Max concurrent practice sessions must be either null or non-negative."));
 
             return Task.CompletedTask;
@@ -52,7 +52,7 @@ internal class UpdatePracticeModeSettingsValidator : IGameboardRequestValidator<
         _validatorService.AddValidator((request, context) =>
         {
             if (request.Settings.MaxPracticeSessionLengthMinutes.HasValue && request.Settings.MaxPracticeSessionLengthMinutes <= 0)
-                context.AddValidationException(new PracticeModeSettingsInvalid(nameof(PracticeModeSettings.MaxPracticeSessionLengthMinutes), request.Settings.MaxPracticeSessionLengthMinutes.Value.ToString(), "Max practice session length must be either null or non-negative."));
+                context.AddValidationException(new PracticeModeSettingsInvalid(nameof(PracticeModeSettings.MaxPracticeSessionLengthMinutes), request.Settings.MaxPracticeSessionLengthMinutes.Value.ToString(), "Max practice session length must be either null or positive."));
 
             return Task.CompletedTask;
         });

--- a/src/Gameboard.Api/Features/Reports/Queries/PracticeMode/PracticeModeReportService.cs
+++ b/src/Gameboard.Api/Features/Reports/Queries/PracticeMode/PracticeModeReportService.cs
@@ -43,7 +43,7 @@ internal class PracticeModeReportService : IPracticeModeReportService
             .ToArrayAsync(cancellationToken);
 
         // process parameters
-        DateTimeOffset? startDate = parameters.PracticeDateStart.HasValue ? parameters.PracticeDateStart.Value.ToEndDate().ToUniversalTime() : null;
+        DateTimeOffset? startDate = parameters.PracticeDateStart.HasValue ? parameters.PracticeDateStart.Value.ToUniversalTime() : null;
         DateTimeOffset? endDate = parameters.PracticeDateEnd.HasValue ? parameters.PracticeDateEnd.Value.ToEndDate().ToUniversalTime() : null;
         var gameIds = _reportsService.ParseMultiSelectCriteria(parameters.Games);
         var sponsorIds = _reportsService.ParseMultiSelectCriteria(parameters.Sponsors);

--- a/src/Gameboard.Api/Features/Teams/Requests/GetTeamEventHorizon/GetTeamEventHorizon.cs
+++ b/src/Gameboard.Api/Features/Teams/Requests/GetTeamEventHorizon/GetTeamEventHorizon.cs
@@ -1,0 +1,68 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Gameboard.Api.Common.Services;
+using Gameboard.Api.Data;
+using Gameboard.Api.Structure.MediatR;
+using Gameboard.Api.Structure.MediatR.Authorizers;
+using Gameboard.Api.Structure.MediatR.Validators;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Gameboard.Api.Features.Teams;
+
+public record GetTeamEventHorizonQuery(string TeamId) : IRequest<EventHorizon>;
+
+internal class GetTeamEventHorizonHandler : IRequestHandler<GetTeamEventHorizonQuery, EventHorizon>
+{
+    private readonly IActingUserService _actingUserService;
+    private readonly IStore _store;
+    private readonly TeamExistsValidator<GetTeamEventHorizonQuery> _teamExists;
+    private readonly UserRoleAuthorizer _userRoleAuthorizer;
+    private readonly IValidatorService<GetTeamEventHorizonQuery> _validator;
+
+    public GetTeamEventHorizonHandler
+    (
+        IActingUserService actingUserService,
+        IStore store,
+        TeamExistsValidator<GetTeamEventHorizonQuery> teamExists,
+        UserRoleAuthorizer userRoleAuthorizer,
+        IValidatorService<GetTeamEventHorizonQuery> validator
+    )
+    {
+        _actingUserService = actingUserService;
+        _store = store;
+        _teamExists = teamExists;
+        _userRoleAuthorizer = userRoleAuthorizer;
+        _validator = validator;
+    }
+
+    public async Task<EventHorizon> Handle(GetTeamEventHorizonQuery request, CancellationToken cancellationToken)
+    {
+        // validate
+        var actingUserId = _actingUserService.Get().Id;
+
+        await _validator
+            .AddValidator(_teamExists.UseProperty(r => r.TeamId))
+            .AddValidator(async (req, ctx) =>
+            {
+                // people with elevated roles can always see this, but regular players can't
+                // unless they're on the team
+                _userRoleAuthorizer.AllowRoles(UserRole.Admin, UserRole.Support, UserRole.Designer);
+                if (!_userRoleAuthorizer.WouldAuthorize())
+                {
+                    var isUserOnTeam = await _store
+                        .WithNoTracking<Data.Player>()
+                        .Where(p => p.TeamId == req.TeamId && p.UserId == actingUserId)
+                        .AnyAsync();
+
+                    if (!isUserOnTeam)
+                        ctx.AddValidationException(new UserIsntOnTeam(actingUserId, req.TeamId));
+                }
+            })
+            .Validate(request, cancellationToken);
+
+        // and awaaaaay we go
+
+    }
+}

--- a/src/Gameboard.Api/Features/Teams/Requests/GetTeamEventHorizon/GetTeamEventHorizonModels.cs
+++ b/src/Gameboard.Api/Features/Teams/Requests/GetTeamEventHorizon/GetTeamEventHorizonModels.cs
@@ -1,18 +1,22 @@
 using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace Gameboard.Api.Features.Teams;
 
 public enum EventHorizonEventType
 {
-    ChallengeDeployed,
-    GamespaceStarted,
-    GamespaceStopped,
+    ChallengeStarted,
+    GamespaceOnOff,
     SolveComplete,
     SubmissionRejected,
     SubmissionScored
 }
 
+[JsonDerivedType(typeof(EventHorizonEvent))]
+[JsonDerivedType(typeof(EventHorizonGamespaceOnOffEvent))]
+[JsonDerivedType(typeof(EventHorizonSolveCompleteEvent))]
+[JsonDerivedType(typeof(EventHorizonSubmissionScoredEvent))]
 public interface IEventHorizonEvent
 {
     public string Id { get; set; }
@@ -29,13 +33,23 @@ public class EventHorizonEvent : IEventHorizonEvent
     public required DateTimeOffset Timestamp { get; set; }
 }
 
+public sealed class EventHorizonGamespaceOnOffEvent : EventHorizonEvent, IEventHorizonEvent
+{
+    public required EventHorizonGamespaceOnOffEventData EventData { get; set; }
+}
+
+public sealed class EventHorizonGamespaceOnOffEventData
+{
+    public required DateTimeOffset OffAt { get; set; }
+}
+
 public sealed class EventHorizonSolveCompleteEventData
 {
     public required int AttemptsUsed { get; set; }
     public required double FinalScore { get; set; }
 }
 
-public sealed class EventHorizonSolveCompleteEvent : EventHorizonEvent
+public sealed class EventHorizonSolveCompleteEvent : EventHorizonEvent, IEventHorizonEvent
 {
     public required EventHorizonSolveCompleteEventData EventData { get; set; }
 }
@@ -71,7 +85,7 @@ public sealed class EventHorizonTeam
 
 public sealed class EventHorizonSession
 {
-    public required DateTimeOffset Begin { get; set; }
+    public required DateTimeOffset Start { get; set; }
     public required DateTimeOffset? End { get; set; }
 }
 

--- a/src/Gameboard.Api/Features/Teams/Requests/GetTeamEventHorizon/GetTeamEventHorizonModels.cs
+++ b/src/Gameboard.Api/Features/Teams/Requests/GetTeamEventHorizon/GetTeamEventHorizonModels.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+
+namespace Gameboard.Api.Features.Teams;
+
+public enum EventHorizonEventType
+{
+    ChallengeDeployed,
+    GamespaceStarted,
+    GamespaceStopped,
+    SolveComplete,
+    SubmissionRejected,
+    SubmissionScored
+}
+
+public interface IEventHorizonEvent
+{
+    public string Id { get; set; }
+    public string ChallengeId { get; set; }
+    public EventHorizonEventType Type { get; set; }
+    public DateTimeOffset Timestamp { get; set; }
+}
+
+public class EventHorizonEvent : IEventHorizonEvent
+{
+    public required string Id { get; set; }
+    public required string ChallengeId { get; set; }
+    public required EventHorizonEventType Type { get; set; }
+    public required DateTimeOffset Timestamp { get; set; }
+}
+
+public sealed class EventHorizonSolveCompleteEventData
+{
+    public required int AttemptsUsed { get; set; }
+    public required double FinalScore { get; set; }
+}
+
+public sealed class EventHorizonSolveCompleteEvent : EventHorizonEvent
+{
+    public required EventHorizonSolveCompleteEventData EventData { get; set; }
+}
+
+public sealed class EventHorizonSubmissionScoredEventData
+{
+    public required IEnumerable<string> Answers { get; set; }
+    public required int AttemptNumber { get; set; }
+    public required double Score { get; set; }
+}
+
+public sealed class EventHorizonSubmissionScoredEvent : EventHorizonEvent
+{
+    public required EventHorizonSubmissionScoredEventData EventData { get; set; }
+}
+
+public sealed class EventHorizonGame
+{
+    public required string Id { get; set; }
+    public required string Name { get; set; }
+    public required IEnumerable<EventHorizonChallengeSpec> ChallengeSpecs { get; set; }
+}
+
+public sealed class EventHorizonTeam
+{
+    public required string Id { get; set; }
+    public required string Name { get; set; }
+    public required EventHorizonSession Session { get; set; }
+    public required IEnumerable<EventHorizonTeamChallenge> Challenges { get; set; }
+    public required IEnumerable<IEventHorizonEvent> Events { get; set; }
+
+}
+
+public sealed class EventHorizonSession
+{
+    public required DateTimeOffset Begin { get; set; }
+    public required DateTimeOffset? End { get; set; }
+}
+
+public sealed class EventHorizonChallengeSpec
+{
+    public required string Id { get; set; }
+    public required string Name { get; set; }
+    public required int MaxAttempts { get; set; }
+    public required double MaxPossibleScore { get; set; }
+}
+
+public sealed class EventHorizonTeamChallenge
+{
+    public required string Id { get; set; }
+    public required string SpecId { get; set; }
+}
+
+public sealed class EventHorizon
+{
+    public required EventHorizonGame Game { get; set; }
+    public required EventHorizonTeam Team { get; set; }
+}

--- a/src/Gameboard.Api/Features/Teams/Requests/ResetTeamSesssion/ResetTeamSessionCommandValidator.cs
+++ b/src/Gameboard.Api/Features/Teams/Requests/ResetTeamSesssion/ResetTeamSessionCommandValidator.cs
@@ -15,7 +15,6 @@ namespace Gameboard.Api.Features.Player;
 
 internal class ResetSessionCommandValidator : IGameboardRequestValidator<ResetTeamSessionCommand>
 {
-    private readonly PlayerService _playerService;
     private readonly IStore _store;
     private readonly TeamExistsValidator<ResetTeamSessionCommand> _teamExistsValidator;
     private readonly UserRoleAuthorizer _userRoleAuthorizer;
@@ -23,14 +22,12 @@ internal class ResetSessionCommandValidator : IGameboardRequestValidator<ResetTe
 
     public ResetSessionCommandValidator
     (
-        PlayerService playerService,
         IStore store,
         TeamExistsValidator<ResetTeamSessionCommand> teamExistsValidator,
         UserRoleAuthorizer userRoleAuthorizer,
         IValidatorService<ResetTeamSessionCommand> validatorService
     )
     {
-        _playerService = playerService;
         _store = store;
         _teamExistsValidator = teamExistsValidator;
         _userRoleAuthorizer = userRoleAuthorizer;

--- a/src/Gameboard.Api/Features/Teams/TeamController.cs
+++ b/src/Gameboard.Api/Features/Teams/TeamController.cs
@@ -58,6 +58,10 @@ public class TeamController : ControllerBase
             );
     }
 
+    [HttpGet("{teamId}/timeline")]
+    public Task<EventHorizon> GetTeamEventHorizon([FromRoute] string teamId)
+        => _mediator.Send(new GetTeamEventHorizonQuery(teamId));
+
     [HttpPost("{teamId}/session")]
     public async Task ResetSession([FromRoute] string teamId, [FromBody] ResetTeamSessionCommand request, CancellationToken cancellationToken)
     {

--- a/src/Gameboard.Api/Features/Teams/TeamExceptions.cs
+++ b/src/Gameboard.Api/Features/Teams/TeamExceptions.cs
@@ -1,8 +1,13 @@
 using System.Collections.Generic;
-using Gameboard.Api.Common;
 using Gameboard.Api.Structure;
 
 namespace Gameboard.Api.Features.Teams;
+
+internal class CantExtendUnstartedSession : GameboardValidationException
+{
+    internal CantExtendUnstartedSession(string teamId)
+        : base($"Can't extend session for team {teamId}: Their session hasn't started.") { }
+}
 
 internal class CaptainResolutionFailure : GameboardException
 {

--- a/src/Gameboard.Api/Features/Ticket/TicketService.cs
+++ b/src/Gameboard.Api/Features/Ticket/TicketService.cs
@@ -410,6 +410,17 @@ namespace Gameboard.Api.Services
                 {
                     entity.TeamId = challenge.TeamId;
                     entity.PlayerId = challenge.PlayerId;
+                    entity.Label = "";
+
+                    // auto-add the "practice-challenge" tag - should be there if this is a practice challenge
+                    if (challenge.PlayerMode == PlayerMode.Practice)
+                    {
+                        if (!entity.Label.Split(LABELS_DELIMITER, StringSplitOptions.RemoveEmptyEntries).Contains("practice-challenge"))
+                        {
+                            entity.Label += entity.Label + " practice-challenge".Trim();
+                        }
+                    }
+
                     return;
                 }
             }

--- a/src/Gameboard.Api/Structure/MediatR/Authorizers/UserRoleAuthorizer.cs
+++ b/src/Gameboard.Api/Structure/MediatR/Authorizers/UserRoleAuthorizer.cs
@@ -6,7 +6,7 @@ namespace Gameboard.Api.Structure.MediatR.Authorizers;
 internal class UserRoleAuthorizer : IAuthorizer
 {
     private readonly IActingUserService _actingUserService;
-    private IEnumerable<UserRole> _allowedRoles { get; set; } = new List<UserRole> { UserRole.Admin };
+    private IEnumerable<UserRole> _allowedRoles = new List<UserRole> { UserRole.Admin };
     private string _allowUserId;
 
     public UserRoleAuthorizer(IActingUserService actingUserService)


### PR DESCRIPTION
v3.15.0 of Gameboard contains enhanced features, stability improvements, and bug fixes.

# New features

- **Player Timeline (beta):** The Admin -> Game -> Players screen now includes a prototype of this new feature. It shows important events which have occurred during the player's session, including challenge launches, submissions, solves, and gamespace activations. We'll continue to refine this feature over the coming releases.
- **Admin Overview** - A new submenu called "Overview" has been added to the Admin area. It shows simple summary information about current activity on Gameboard. We've also moved the global **Announcements** tool from the Games submenu to this new Overview submenu to improve its visibility.

# Enhancements

- Generating an invite code in team creation now automatically copies the code to the clipboard. A notification is shown when this happens.
- The "Copy to Markdown" feature for Support tickets now includes the challenge support code and a link to the Admin -> Challenges view scoped to the challenge (#338).
- Support tickets created from challenges in the Practice Area are now automatically tagged with "practice-challenge".
- The Practice Area can now be completely deactivated in the web client by setting its "Maximum Concurrent Users" setting in Admin -> Practice Area to zero.
- The Admin -> Game -> Players screen no longer automatically refreshes while a player panel has been expanded. When this happens, the autorefresh button will indicate that it is paused.
- The Game edit screen has a new "Show On Homepage When In Practice Mode" that allows admins to optionally display practice games on Gameboard's home screen.
- The suggested searches shown in the Practice Area now correctly match the corresponding labels on practice challenges.

# Bug fixes

- Fixed an issue that could cause the team name listed in Admin -> Challenges -> Observe Challenges to be incorrect (#334)
- Fixed an issue that caused the Admin -> Observe screens to fail to correctly show console user pills (#335)
- Fixed an issue that caused the Gameboard page to automatically navigate to a challenge upon deploy (#339)
- Fixed an issue that caused the number of total and complete solves to be reversed on the Challenges Report
- Fixed an issue that could cause the Game hub to fail to connect for external/sync games.
- The per-team deploy button in Admin -> Game -> Deployment now correctly disables itself while deploys are executing.
- The error message shown when the global practice session limit has been exceeded has been clarified (#343).
- Fixed an issue that caused use of the "Games" filter on the Players Report to exclude all records (#346).
- Attempt to extend a player or team's session when it hasn't started will now correctly throw a visible error.
- Extending a session or using the Announcements feature will now show a toast notification to indicate success.
- Fixed an issue that caused the Practice Area report to exclude some records when the Start Date filter was used.
- The New Ticket page now disables its submit button during a submission to reduce the likelihood of accidental duplicate submissions (#319).

# Stability

- Updated some package dependencies
