### PR TITLE
v3.15.3-beta0

### DIFF
--- a/src/Gameboard.Api.Tests.Integration/Fixtures/Services/TestGradingResultService.cs
+++ b/src/Gameboard.Api.Tests.Integration/Fixtures/Services/TestGradingResultService.cs
@@ -4,6 +4,7 @@ namespace Gameboard.Api.Tests.Integration.Fixtures;
 
 public sealed class TestGradingResultServiceConfiguration
 {
+    public bool IncrementAttempts { get; set; } = true;
     public Action<GameEngineGameState>? GameStateBuilder { get; set; }
     public Exception? ThrowsOnGrading { get; set; }
 }
@@ -54,7 +55,7 @@ internal class TestGradingResultService : ITestGradingResultService
             WhenCreated = challenge.StartTime,
             Challenge = new GameEngineChallengeView
             {
-
+                Attempts = _config.IncrementAttempts ? 1 : 0,
                 MaxPoints = challenge.Points,
                 Score = challenge.Score
             }

--- a/src/Gameboard.Api.Tests.Integration/Tests/Features/Challenges/ChallengeControllerGradeTests.cs
+++ b/src/Gameboard.Api.Tests.Integration/Tests/Features/Challenges/ChallengeControllerGradeTests.cs
@@ -91,6 +91,7 @@ public class ChallengeControllerGradeTests : IClassFixture<GameboardTestContext>
     [Theory, GbIntegrationAutoData]
     public async Task Grade_WithGamespaceExpired_ThrowsAndLogsEvent
     (
+        string gameId,
         string challengeId,
         string challengeSpecId,
         string sponsorId,
@@ -108,6 +109,7 @@ public class ChallengeControllerGradeTests : IClassFixture<GameboardTestContext>
             state.Add<Data.Sponsor>(fixture, s => s.Id = sponsorId);
             state.Add<Data.Game>(fixture, g =>
             {
+                g.Id = gameId;
                 g.Players = new List<Data.Player>
                 {
                     new()
@@ -121,6 +123,7 @@ public class ChallengeControllerGradeTests : IClassFixture<GameboardTestContext>
                                 EndTime = challengeEndTime,
                                 StartTime = challengeStartTime,
                                 SpecId = challengeSpecId,
+                                GameId = gameId
                             }
                         },
                         SponsorId = sponsorId,

--- a/src/Gameboard.Api.Tests.Integration/Tests/Features/Challenges/ChallengeControllerGradeTests.cs
+++ b/src/Gameboard.Api.Tests.Integration/Tests/Features/Challenges/ChallengeControllerGradeTests.cs
@@ -41,6 +41,7 @@ public class ChallengeControllerGradeTests : IClassFixture<GameboardTestContext>
                     g.Challenges = state.Build<Data.Challenge>(fixture, c =>
                     {
                         c.Id = challengeId;
+                        c.GameId = gameId;
                         c.GraderKey = graderKey.ToSha256();
                         c.Points = 0;
                         c.Score = 0;

--- a/src/Gameboard.Api.Tests.Integration/Tests/Features/Challenges/ChallengeControllerGradeTests.cs
+++ b/src/Gameboard.Api.Tests.Integration/Tests/Features/Challenges/ChallengeControllerGradeTests.cs
@@ -159,10 +159,10 @@ public class ChallengeControllerGradeTests : IClassFixture<GameboardTestContext>
             .ChallengeEvents
             .AsNoTracking()
             .Where(ev => ev.ChallengeId == challengeId)
+            .Where(ev => ev.Type == ChallengeEventType.SubmissionRejectedGamespaceExpired)
             .OrderByDescending(ev => ev.Timestamp)
             .ToArrayAsync();
 
-        challengeEvents.Length.ShouldBeGreaterThan(0);
-        challengeEvents.First().Type.ShouldBe(ChallengeEventType.SubmissionRejectedGamespaceExpired);
+        challengeEvents.Length.ShouldBe(1);
     }
 }

--- a/src/Gameboard.Api.Tests.Integration/Tests/Features/Challenges/ChallengeControllerGradeTests.cs
+++ b/src/Gameboard.Api.Tests.Integration/Tests/Features/Challenges/ChallengeControllerGradeTests.cs
@@ -18,6 +18,7 @@ public class ChallengeControllerGradeTests : IClassFixture<GameboardTestContext>
     (
         string challengeId,
         string challengeSpecId,
+        string gameId,
         string graderKey,
         string teamId,
         IFixture fixture
@@ -30,6 +31,7 @@ public class ChallengeControllerGradeTests : IClassFixture<GameboardTestContext>
             {
                 state.Add<Data.Game>(fixture, g =>
                 {
+                    g.Id = gameId;
                     g.Specs = state.Build<Data.ChallengeSpec>(fixture, spec =>
                     {
                         spec.Id = challengeSpecId;

--- a/src/Gameboard.Api.Tests.Unit/Tests/Features/Player/PlayerServiceCalculateSessionWindowTests.cs
+++ b/src/Gameboard.Api.Tests.Unit/Tests/Features/Player/PlayerServiceCalculateSessionWindowTests.cs
@@ -1,0 +1,89 @@
+namespace Gameboard.Api.Tests.Unit;
+
+public class PlayerServiceCalculateSessionWindowTests
+{
+    [Theory, GameboardAutoData]
+    public void CalculateSessionWindow_WithLateStart_ShortensSession(DateTimeOffset sessionStart)
+    {
+        // given a session starting now for a game with a longer session time
+        // than is remaining in the execution period
+        var gameEnd = sessionStart.AddHours(1);
+
+        var game = new Data.Game
+        {
+            GameEnd = gameEnd,
+            SessionMinutes = 120
+        };
+        var sut = PlayerServiceTestHelpers.GetTestableSut();
+
+        // when the session length properties are calculated
+        var result = sut.CalculateSessionWindow(game, sessionStart);
+
+        // then session end should be equal to the game end
+        result.End.ShouldBe(gameEnd);
+    }
+
+    [Theory, GameboardAutoData]
+    public void CalculateSessionWindow_WithNoLateStart_PreservesSessionLength(DateTimeOffset sessionStart)
+    {
+        // given a session starting now for a game with a longer session time
+        // than is remaining in the execution period
+        var gameEnd = sessionStart.AddHours(2);
+        var sessionEnd = sessionStart.AddHours(1);
+
+        var game = new Data.Game
+        {
+            GameEnd = gameEnd,
+            SessionMinutes = 60
+        };
+        var sut = PlayerServiceTestHelpers.GetTestableSut();
+
+        // when the session length properties are calculated
+        var result = sut.CalculateSessionWindow(game, sessionStart);
+
+        // then session end should be equal to the game end
+        result.End.ShouldBe(sessionEnd);
+    }
+
+    [Theory, GameboardAutoData]
+    public void CalculateSessionWindow_WithLateStart_MarksLateStart(DateTimeOffset sessionStart)
+    {
+        // given a session starting now for a game with a longer session time
+        // than is remaining in the execution period
+        var gameEnd = sessionStart.AddHours(1);
+
+        var game = new Data.Game
+        {
+            GameEnd = gameEnd,
+            SessionMinutes = 120
+        };
+        var sut = PlayerServiceTestHelpers.GetTestableSut();
+
+        // when the session length properties are calculated
+        var result = sut.CalculateSessionWindow(game, sessionStart);
+
+        // the session end should be equal to the game end
+        result.IsLateStart.ShouldBeTrue();
+    }
+
+    [Theory, GameboardAutoData]
+    public void CalculateSessionWindow_WithNoLateStart_MarksNoLateStart(DateTimeOffset sessionStart)
+    {
+        // given a session starting now for a game with a longer session time
+        // than is remaining in the execution period
+        var gameEnd = sessionStart.AddHours(2);
+
+        var game = new Data.Game
+        {
+            GameEnd = gameEnd,
+            SessionMinutes = 60
+        };
+        var sut = PlayerServiceTestHelpers.GetTestableSut();
+
+        // when the session length properties are calculated
+        var result = sut.CalculateSessionWindow(game, sessionStart);
+
+        // the session end should be equal to the game end
+        result.IsLateStart.ShouldBeFalse();
+    }
+}

--- a/src/Gameboard.Api/Data/Entities/Player.cs
+++ b/src/Gameboard.Api/Data/Entities/Player.cs
@@ -21,7 +21,7 @@ public class Player : IEntity
     public PlayerRole Role { get; set; }
     public DateTimeOffset SessionBegin { get; set; }
     public DateTimeOffset SessionEnd { get; set; }
-    public int SessionMinutes { get; set; }
+    public double SessionMinutes { get; set; }
     public int Rank { get; set; }
     public int Score { get; set; }
     public long Time { get; set; }
@@ -32,6 +32,7 @@ public class Player : IEntity
     public User User { get; set; }
     public Game Game { get; set; }
     public DateTimeOffset WhenCreated { get; set; }
+    public bool IsLateStart { get; set; }
 
     // navigation properties
     public ICollection<Challenge> Challenges { get; set; } = new List<Challenge>();

--- a/src/Gameboard.Api/Data/Enumerations.cs
+++ b/src/Gameboard.Api/Data/Enumerations.cs
@@ -43,7 +43,8 @@ public enum ChallengeEventType
     GamespaceOn,
     GamespaceOff,
     Submission,
-    SubmissionRejectedGamespaceExpired
+    SubmissionRejectedGamespaceExpired,
+    SubmissionRejectedGameEnded
 }
 
 public enum ChallengeResult

--- a/src/Gameboard.Api/Data/Migrations/PostgreSQL/GameboardDb/20240125143245_AddIsLateStartAndConvertSessionMinutes.Designer.cs
+++ b/src/Gameboard.Api/Data/Migrations/PostgreSQL/GameboardDb/20240125143245_AddIsLateStartAndConvertSessionMinutes.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Gameboard.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
 {
     [DbContext(typeof(GameboardDbContextPostgreSQL))]
-    partial class GameboardDbContextPostgreSQLModelSnapshot : ModelSnapshot
+    [Migration("20240125143245_AddIsLateStartAndConvertSessionMinutes")]
+    partial class AddIsLateStartAndConvertSessionMinutes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Gameboard.Api/Data/Migrations/PostgreSQL/GameboardDb/20240125143245_AddIsLateStartAndConvertSessionMinutes.cs
+++ b/src/Gameboard.Api/Data/Migrations/PostgreSQL/GameboardDb/20240125143245_AddIsLateStartAndConvertSessionMinutes.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
+{
+    /// <inheritdoc />
+    public partial class AddIsLateStartAndConvertSessionMinutes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<double>(
+                name: "SessionMinutes",
+                table: "Players",
+                type: "double precision",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsLateStart",
+                table: "Players",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsLateStart",
+                table: "Players");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "SessionMinutes",
+                table: "Players",
+                type: "integer",
+                nullable: false,
+                oldClrType: typeof(double),
+                oldType: "double precision");
+        }
+    }
+}

--- a/src/Gameboard.Api/Data/Migrations/SqlServer/GameboardDb/20240125143253_AddIsLateStartAndConvertSessionMinutes.Designer.cs
+++ b/src/Gameboard.Api/Data/Migrations/SqlServer/GameboardDb/20240125143253_AddIsLateStartAndConvertSessionMinutes.Designer.cs
@@ -3,51 +3,55 @@ using System;
 using Gameboard.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
-namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
+namespace Gameboard.Api.Data.Migrations.SqlServer.GameboardDb
 {
-    [DbContext(typeof(GameboardDbContextPostgreSQL))]
-    partial class GameboardDbContextPostgreSQLModelSnapshot : ModelSnapshot
+    [DbContext(typeof(GameboardDbContextSqlServer))]
+    [Migration("20240125143253_AddIsLateStartAndConvertSessionMinutes")]
+    partial class AddIsLateStartAndConvertSessionMinutes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
                 .HasAnnotation("ProductVersion", "7.0.8")
-                .HasAnnotation("Relational:MaxIdentifierLength", 63);
+                .HasAnnotation("Relational:MaxIdentifierLength", 128);
 
-            NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
+            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
 
             modelBuilder.Entity("Gameboard.Api.Data.ApiKey", b =>
                 {
                     b.Property<string>("Id")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<DateTimeOffset?>("ExpiresOn")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("timestamp with time zone")
+                        .HasColumnType("datetimeoffset")
                         .HasDefaultValueSql("NULL");
 
                     b.Property<DateTimeOffset>("GeneratedOn")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("timestamp with time zone")
+                        .HasColumnType("datetimeoffset")
                         .HasDefaultValueSql("NOW()");
 
                     b.Property<string>("Key")
                         .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
+                        .HasColumnType("nvarchar(100)");
 
                     b.Property<string>("Name")
                         .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<string>("OwnerId")
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.HasKey("Id");
 
@@ -60,79 +64,79 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
                 {
                     b.Property<string>("Id")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<long>("Duration")
                         .HasColumnType("bigint");
 
                     b.Property<DateTimeOffset>("EndTime")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetimeoffset");
 
                     b.Property<string>("Events")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("GameId")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<string>("GameName")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<bool>("HasGamespaceDeployed")
-                        .HasColumnType("boolean");
+                        .HasColumnType("bit");
 
                     b.Property<DateTimeOffset>("LastScoreTime")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetimeoffset");
 
                     b.Property<DateTimeOffset>("LastSyncTime")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetimeoffset");
 
                     b.Property<string>("Name")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("PlayerId")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<int>("PlayerMode")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<string>("PlayerName")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<int>("Points")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<int>("Result")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<int>("Score")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<DateTimeOffset>("StartTime")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetimeoffset");
 
                     b.Property<string>("State")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Submissions")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Tag")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("TeamId")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<string>("TeamMembers")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("UserId")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.HasKey("Id");
 
@@ -151,22 +155,22 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
                 {
                     b.Property<string>("Id")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<string>("ChallengeBonusId")
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<string>("ChallengeId")
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<DateTimeOffset>("EnteredOn")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("timestamp with time zone")
+                        .HasColumnType("datetimeoffset")
                         .HasDefaultValueSql("NOW()");
 
                     b.Property<string>("InternalSummary")
                         .HasMaxLength(200)
-                        .HasColumnType("character varying(200)");
+                        .HasColumnType("nvarchar(200)");
 
                     b.HasKey("Id");
 
@@ -181,73 +185,73 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
                 {
                     b.Property<string>("Id")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<DateTimeOffset>("EndTime")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetimeoffset");
 
                     b.Property<string>("ExternalId")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<int>("GameEngineType")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<string>("GameId")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<string>("GraderKey")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<bool>("HasDeployedGamespace")
-                        .HasColumnType("boolean");
+                        .HasColumnType("bit");
 
                     b.Property<DateTimeOffset>("LastScoreTime")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetimeoffset");
 
                     b.Property<DateTimeOffset>("LastSyncTime")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetimeoffset");
 
                     b.Property<string>("Name")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("PendingSubmission")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("PlayerId")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<int>("PlayerMode")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<int>("Points")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<double>("Score")
-                        .HasColumnType("double precision");
+                        .HasColumnType("float");
 
                     b.Property<string>("SpecId")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<DateTimeOffset>("StartTime")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetimeoffset");
 
                     b.Property<string>("State")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Tag")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("TeamId")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<DateTimeOffset>("WhenCreated")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetimeoffset");
 
                     b.HasKey("Id");
 
@@ -264,20 +268,20 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
                 {
                     b.Property<string>("Id")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<int>("ChallengeBonusType")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<string>("ChallengeSpecId")
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<string>("Description")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<double>("PointValue")
-                        .HasColumnType("double precision");
+                        .HasColumnType("float");
 
                     b.HasKey("Id");
 
@@ -294,29 +298,29 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
                 {
                     b.Property<string>("Id")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<string>("ChallengeId")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<string>("TeamId")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<string>("Text")
                         .HasMaxLength(1024)
-                        .HasColumnType("character varying(1024)");
+                        .HasColumnType("nvarchar(1024)");
 
                     b.Property<DateTimeOffset>("Timestamp")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetimeoffset");
 
                     b.Property<int>("Type")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<string>("UserId")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.HasKey("Id");
 
@@ -329,22 +333,22 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
                 {
                     b.Property<string>("Id")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<string>("GameId")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<string>("RequiredId")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<double>("RequiredScore")
-                        .HasColumnType("double precision");
+                        .HasColumnType("float");
 
                     b.Property<string>("TargetId")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.HasKey("Id");
 
@@ -357,52 +361,52 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
                 {
                     b.Property<string>("Id")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<int>("AverageDeploySeconds")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<string>("Description")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<bool>("Disabled")
-                        .HasColumnType("boolean");
+                        .HasColumnType("bit");
 
                     b.Property<string>("ExternalId")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<int>("GameEngineType")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<string>("GameId")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<string>("Name")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int>("Points")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<float>("R")
                         .HasColumnType("real");
 
                     b.Property<bool>("ShowSolutionGuideInCompetitiveMode")
-                        .HasColumnType("boolean");
+                        .HasColumnType("bit");
 
                     b.Property<string>("SolutionGuideUrl")
                         .HasMaxLength(1000)
-                        .HasColumnType("character varying(1000)");
+                        .HasColumnType("nvarchar(1000)");
 
                     b.Property<string>("Tag")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Tags")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Text")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<float>("X")
                         .HasColumnType("real");
@@ -420,23 +424,23 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
             modelBuilder.Entity("Gameboard.Api.Data.ChallengeSubmission", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("Answers")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("ChallengeId")
                         .IsRequired()
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<double>("Score")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("double precision")
+                        .HasColumnType("float")
                         .HasDefaultValue(0.0);
 
                     b.Property<DateTimeOffset>("SubmittedOn")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetimeoffset");
 
                     b.HasKey("Id");
 
@@ -449,22 +453,22 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
                 {
                     b.Property<string>("Id")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<int>("DeployStatus")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<string>("ExternalGameUrl")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("GameId")
                         .IsRequired()
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<string>("TeamId")
                         .IsRequired()
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.HasKey("Id");
 
@@ -479,36 +483,36 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
                 {
                     b.Property<string>("Id")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<string>("Answers")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("ChallengeId")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<string>("ChallengeSpecId")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<string>("GameId")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<string>("PlayerId")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<bool>("Submitted")
-                        .HasColumnType("boolean");
+                        .HasColumnType("bit");
 
                     b.Property<DateTimeOffset>("Timestamp")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetimeoffset");
 
                     b.Property<string>("UserId")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.HasKey("Id");
 
@@ -529,140 +533,140 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
                 {
                     b.Property<string>("Id")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<bool>("AllowPreview")
-                        .HasColumnType("boolean");
+                        .HasColumnType("bit");
 
                     b.Property<bool>("AllowReset")
-                        .HasColumnType("boolean");
+                        .HasColumnType("bit");
 
                     b.Property<string>("Background")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("CardText1")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("CardText2")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("CardText3")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("CertificateTemplate")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Competition")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("Division")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("ExternalGameClientUrl")
                         .HasMaxLength(200)
-                        .HasColumnType("character varying(200)");
+                        .HasColumnType("nvarchar(200)");
 
                     b.Property<string>("ExternalGameStartupUrl")
                         .HasMaxLength(200)
-                        .HasColumnType("character varying(200)");
+                        .HasColumnType("nvarchar(200)");
 
                     b.Property<string>("FeedbackConfig")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<DateTimeOffset>("GameEnd")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetimeoffset");
 
                     b.Property<string>("GameMarkdown")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<DateTimeOffset>("GameStart")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetimeoffset");
 
                     b.Property<int>("GamespaceLimitPerSession")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<bool>("IsPublished")
-                        .HasColumnType("boolean");
+                        .HasColumnType("bit");
 
                     b.Property<string>("Key")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("Logo")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<int>("MaxAttempts")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<int>("MaxTeamSize")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<int>("MinTeamSize")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<string>("Mode")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<string>("Name")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<int>("PlayerMode")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<DateTimeOffset>("RegistrationClose")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetimeoffset");
 
                     b.Property<string>("RegistrationConstraint")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("RegistrationMarkdown")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<DateTimeOffset>("RegistrationOpen")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetimeoffset");
 
                     b.Property<int>("RegistrationType")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<bool>("RequireSponsoredTeam")
-                        .HasColumnType("boolean");
+                        .HasColumnType("bit");
 
                     b.Property<bool>("RequireSynchronizedStart")
-                        .HasColumnType("boolean");
+                        .HasColumnType("bit");
 
                     b.Property<string>("Season")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<int>("SessionLimit")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<int>("SessionMinutes")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<bool>("ShowOnHomePageInPracticeMode")
-                        .HasColumnType("boolean");
+                        .HasColumnType("bit");
 
                     b.Property<string>("Sponsor")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<string>("TestCode")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("Track")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.HasKey("Id");
 
@@ -673,25 +677,25 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
                 {
                     b.Property<string>("Id")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<string>("ChallengeId")
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<string>("Description")
                         .HasMaxLength(200)
-                        .HasColumnType("character varying(200)");
+                        .HasColumnType("nvarchar(200)");
 
                     b.Property<string>("EnteredByUserId")
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<DateTimeOffset>("EnteredOn")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("timestamp with time zone")
+                        .HasColumnType("datetimeoffset")
                         .HasDefaultValueSql("NOW()");
 
                     b.Property<double>("PointValue")
-                        .HasColumnType("double precision");
+                        .HasColumnType("float");
 
                     b.HasKey("Id");
 
@@ -706,81 +710,81 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
                 {
                     b.Property<string>("Id")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<bool>("Advanced")
-                        .HasColumnType("boolean");
+                        .HasColumnType("bit");
 
                     b.Property<string>("ApprovedName")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<int>("CorrectCount")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<string>("GameId")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<string>("InviteCode")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<bool>("IsLateStart")
-                        .HasColumnType("boolean");
+                        .HasColumnType("bit");
 
                     b.Property<bool>("IsReady")
-                        .HasColumnType("boolean");
+                        .HasColumnType("bit");
 
                     b.Property<int>("Mode")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<string>("Name")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("NameStatus")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<int>("PartialCount")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<int>("Rank")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<int>("Role")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<int>("Score")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<DateTimeOffset>("SessionBegin")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetimeoffset");
 
                     b.Property<DateTimeOffset>("SessionEnd")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetimeoffset");
 
                     b.Property<double>("SessionMinutes")
-                        .HasColumnType("double precision");
+                        .HasColumnType("float");
 
                     b.Property<string>("SponsorId")
                         .IsRequired()
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<string>("TeamId")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<long>("Time")
                         .HasColumnType("bigint");
 
                     b.Property<string>("UserId")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<DateTimeOffset>("WhenCreated")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetimeoffset");
 
                     b.HasKey("Id");
 
@@ -799,37 +803,38 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
                 {
                     b.Property<string>("Id")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<string>("CertificateHtmlTemplate")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int>("DefaultPracticeSessionLengthMinutes")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<string>("IntroTextMarkdown")
                         .HasMaxLength(4000)
-                        .HasColumnType("character varying(4000)");
+                        .HasColumnType("nvarchar(4000)");
 
                     b.Property<int?>("MaxConcurrentPracticeSessions")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<int?>("MaxPracticeSessionLengthMinutes")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<string>("SuggestedSearches")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("UpdatedByUserId")
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<DateTimeOffset?>("UpdatedOn")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetimeoffset");
 
                     b.HasKey("Id");
 
                     b.HasIndex("UpdatedByUserId")
-                        .IsUnique();
+                        .IsUnique()
+                        .HasFilter("[UpdatedByUserId] IS NOT NULL");
 
                     b.ToTable("PracticeModeSettings");
                 });
@@ -837,16 +842,16 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
             modelBuilder.Entity("Gameboard.Api.Data.PublishedCertificate", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<int>("Mode")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<string>("OwnerUserId")
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<DateTimeOffset>("PublishedOn")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetimeoffset");
 
                     b.HasKey("Id");
 
@@ -861,20 +866,20 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
                 {
                     b.Property<string>("Id")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<bool>("Approved")
-                        .HasColumnType("boolean");
+                        .HasColumnType("bit");
 
                     b.Property<string>("Logo")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Name")
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("ParentSponsorId")
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.HasKey("Id");
 
@@ -887,32 +892,32 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
                 {
                     b.Property<string>("Id")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<string>("CreatedByUserId")
                         .IsRequired()
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<DateTimeOffset?>("EndsOn")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetimeoffset");
 
                     b.Property<bool>("IsDeleted")
-                        .HasColumnType("boolean");
+                        .HasColumnType("bit");
 
                     b.Property<string>("MarkdownContent")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int>("NotificationType")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<DateTimeOffset?>("StartsOn")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetimeoffset");
 
                     b.Property<string>("Title")
                         .IsRequired()
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.HasKey("Id");
 
@@ -924,24 +929,24 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
             modelBuilder.Entity("Gameboard.Api.Data.SystemNotificationInteraction", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<DateTimeOffset?>("DismissedOn")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetimeoffset");
 
                     b.Property<DateTimeOffset?>("SawCalloutOn")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetimeoffset");
 
                     b.Property<DateTimeOffset?>("SawFullNotificationOn")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetimeoffset");
 
                     b.Property<string>("SystemNotificationId")
                         .IsRequired()
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<string>("UserId")
                         .IsRequired()
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.HasKey("Id");
 
@@ -956,64 +961,62 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
                 {
                     b.Property<string>("Id")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<string>("AssigneeId")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<string>("Attachments")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("ChallengeId")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<DateTimeOffset>("Created")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetimeoffset");
 
                     b.Property<string>("CreatorId")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<string>("Description")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int>("Key")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("integer");
-
-                    NpgsqlPropertyBuilderExtensions.UseSerialColumn(b.Property<int>("Key"));
+                        .HasColumnType("int")
+                        .HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.SerialColumn);
 
                     b.Property<string>("Label")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<DateTimeOffset>("LastUpdated")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetimeoffset");
 
                     b.Property<string>("PlayerId")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<string>("RequesterId")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<bool>("StaffCreated")
-                        .HasColumnType("boolean");
+                        .HasColumnType("bit");
 
                     b.Property<string>("Status")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("Summary")
                         .IsRequired()
                         .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("TeamId")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.HasKey("Id");
 
@@ -1036,35 +1039,35 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
             modelBuilder.Entity("Gameboard.Api.Data.TicketActivity", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("AssigneeId")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<string>("Attachments")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Message")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Status")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("TicketId")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<DateTimeOffset>("Timestamp")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetimeoffset");
 
                     b.Property<int>("Type")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<string>("UserId")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.HasKey("Id");
 
@@ -1081,53 +1084,53 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
                 {
                     b.Property<string>("Id")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<string>("ApprovedName")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<DateTimeOffset>("CreatedOn")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetimeoffset");
 
                     b.Property<string>("Email")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<bool>("HasDefaultSponsor")
-                        .HasColumnType("boolean");
+                        .HasColumnType("bit");
 
                     b.Property<DateTimeOffset?>("LastLoginDate")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetimeoffset");
 
                     b.Property<int>("LoginCount")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("integer")
+                        .HasColumnType("int")
                         .HasDefaultValueSql("0");
 
                     b.Property<string>("Name")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("NameStatus")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<bool>("PlayAudioOnBrowserNotification")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("boolean")
+                        .HasColumnType("bit")
                         .HasDefaultValue(false);
 
                     b.Property<int>("Role")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<string>("SponsorId")
                         .IsRequired()
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.Property<string>("Username")
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.HasKey("Id");
 
@@ -1141,7 +1144,7 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
                     b.HasBaseType("Gameboard.Api.Data.ChallengeBonus");
 
                     b.Property<int>("SolveRank")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.HasDiscriminator().HasValue(0);
                 });
@@ -1152,7 +1155,7 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
 
                     b.Property<string>("GameId")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.HasIndex("GameId");
 
@@ -1167,7 +1170,7 @@ namespace Gameboard.Api.Data.Migrations.PostgreSQL.GameboardDb
 
                     b.Property<string>("ChallengeSpecId")
                         .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
+                        .HasColumnType("nvarchar(40)");
 
                     b.HasIndex("ChallengeSpecId");
 

--- a/src/Gameboard.Api/Data/Migrations/SqlServer/GameboardDb/20240125143253_AddIsLateStartAndConvertSessionMinutes.cs
+++ b/src/Gameboard.Api/Data/Migrations/SqlServer/GameboardDb/20240125143253_AddIsLateStartAndConvertSessionMinutes.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Gameboard.Api.Data.Migrations.SqlServer.GameboardDb
+{
+    /// <inheritdoc />
+    public partial class AddIsLateStartAndConvertSessionMinutes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<double>(
+                name: "SessionMinutes",
+                table: "Players",
+                type: "float",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsLateStart",
+                table: "Players",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsLateStart",
+                table: "Players");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "SessionMinutes",
+                table: "Players",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(double),
+                oldType: "float");
+        }
+    }
+}

--- a/src/Gameboard.Api/Data/Migrations/SqlServer/GameboardDb/GameboardDbContextSqlServerModelSnapshot.cs
+++ b/src/Gameboard.Api/Data/Migrations/SqlServer/GameboardDb/GameboardDbContextSqlServerModelSnapshot.cs
@@ -727,6 +727,9 @@ namespace Gameboard.Api.Data.Migrations.SqlServer.GameboardDb
                         .HasMaxLength(40)
                         .HasColumnType("nvarchar(40)");
 
+                    b.Property<bool>("IsLateStart")
+                        .HasColumnType("bit");
+
                     b.Property<bool>("IsReady")
                         .HasColumnType("bit");
 
@@ -759,8 +762,8 @@ namespace Gameboard.Api.Data.Migrations.SqlServer.GameboardDb
                     b.Property<DateTimeOffset>("SessionEnd")
                         .HasColumnType("datetimeoffset");
 
-                    b.Property<int>("SessionMinutes")
-                        .HasColumnType("int");
+                    b.Property<double>("SessionMinutes")
+                        .HasColumnType("float");
 
                     b.Property<string>("SponsorId")
                         .IsRequired()

--- a/src/Gameboard.Api/Features/Challenge/ChallengeExceptions.cs
+++ b/src/Gameboard.Api/Features/Challenge/ChallengeExceptions.cs
@@ -1,4 +1,19 @@
+using System;
+using Gameboard.Api.Structure;
+
 namespace Gameboard.Api.Features.Challenges;
+
+internal class CantGradeBecauseGameExecutionPeriodIsOver : GameboardValidationException
+{
+    public CantGradeBecauseGameExecutionPeriodIsOver(string challengeId, DateTimeOffset gameEnd, DateTimeOffset now)
+        : base($"Can't grade challenge {challengeId} because its game execution period is over (ended at {gameEnd}, it's currently {now}).") { }
+}
+
+internal class CantStartBecauseGameExecutionPeriodIsOver : GameboardValidationException
+{
+    public CantStartBecauseGameExecutionPeriodIsOver(string challengeSpecId, string playerId, DateTimeOffset gameEnd, DateTimeOffset now)
+        : base($"Can't start challenge spec {challengeSpecId} for player {playerId} because its game execution period is over (ended at {gameEnd}, it's currently {now}).") { }
+}
 
 internal class NoSession : GameboardException
 {

--- a/src/Gameboard.Api/Features/Challenge/Services/ChallengeService.cs
+++ b/src/Gameboard.Api/Features/Challenge/Services/ChallengeService.cs
@@ -355,7 +355,6 @@ public partial class ChallengeService : _Service
             .Include(c => c.Game)
             .SingleAsync(c => c.Id == model.Id);
 
-
         // ensure that the game hasn't ended - if it has, we have to bounce this one
         if (now > challenge.Game.GameEnd)
         {

--- a/src/Gameboard.Api/Features/Challenge/Services/ChallengeService.cs
+++ b/src/Gameboard.Api/Features/Challenge/Services/ChallengeService.cs
@@ -349,8 +349,12 @@ public partial class ChallengeService : _Service
 
     public async Task<Challenge> Grade(GameEngineSectionSubmission model, User actor)
     {
-        var challenge = await _challengeStore.Retrieve(model.Id, q => q.Include(c => c.Game));
         var now = _now.Get();
+        var challenge = await _store
+            .WithNoTracking<Data.Challenge>()
+            .Include(c => c.Game)
+            .SingleAsync(c => c.Id == model.Id);
+
 
         // ensure that the game hasn't ended - if it has, we have to bounce this one
         if (now > challenge.Game.GameEnd)

--- a/src/Gameboard.Api/Features/Challenge/Services/ChallengeService.cs
+++ b/src/Gameboard.Api/Features/Challenge/Services/ChallengeService.cs
@@ -379,10 +379,11 @@ public partial class ChallengeService : _Service
             priorAttemptCount = preGradeState.Challenge.Attempts;
         }
 
-        // log the appropriate event (note that this won't get saved if the call to the game engine's Grade fails)
-        challenge.Events.Add(new ChallengeEvent
+        // log the appropriate event
+        await _store.Create(new ChallengeEvent
         {
             Id = _guids.GetGuid(),
+            ChallengeId = challenge.Id,
             UserId = actor?.Id ?? null,
             TeamId = challenge.TeamId,
             Timestamp = now,

--- a/src/Gameboard.Api/Features/Player/Player.cs
+++ b/src/Gameboard.Api/Features/Player/Player.cs
@@ -25,13 +25,14 @@ public class Player
     public PlayerRole Role { get; set; }
     public DateTimeOffset SessionBegin { get; set; }
     public DateTimeOffset SessionEnd { get; set; }
-    public int SessionMinutes { get; set; }
+    public double SessionMinutes { get; set; }
     public int Rank { get; set; }
     public int Score { get; set; }
     public long Time { get; set; }
     public int CorrectCount { get; set; }
     public int PartialCount { get; set; }
     public bool Advanced { get; set; }
+    public bool IsLateStart { get; set; }
     public bool IsManager { get; set; }
     public bool IsReady { get; set; }
     public PlayerMode Mode { get; set; }
@@ -198,6 +199,14 @@ public class PlayerCertificate
     public Game Game { get; set; }
     public Player Player { get; set; }
     public string Html { get; set; }
+}
+
+public class PlayerCalculatedSessionWindow
+{
+    public required DateTimeOffset Start { get; set; }
+    public required DateTimeOffset End { get; set; }
+    public required double LengthInMinutes { get; set; }
+    public required bool IsLateStart { get; set; }
 }
 
 public class PlayerUpdatedViewModel

--- a/src/Gameboard.Api/Features/Teams/Requests/GetTeamEventHorizon/GetTeamEventHorizon.cs
+++ b/src/Gameboard.Api/Features/Teams/Requests/GetTeamEventHorizon/GetTeamEventHorizon.cs
@@ -83,6 +83,9 @@ internal class GetTeamEventHorizonHandler : IRequestHandler<GetTeamEventHorizonQ
             .Where(c => c.TeamId == request.TeamId)
             .ToArrayAsync(cancellationToken);
 
+        if (challenges.Length == 0)
+            return null;
+
         // make sure we have exactly one game
         var games = challenges.Select(c => c.Game).ToArray();
         if (games.Select(g => g.Id).Distinct().Count() > 1)

--- a/src/Gameboard.Api/Features/Teams/TeamService.cs
+++ b/src/Gameboard.Api/Features/Teams/TeamService.cs
@@ -328,7 +328,7 @@ internal class TeamService : ITeamService
             throw new ArgumentException($"Either {nameof(sessionStart)} or {nameof(sessionEnd)} must be non-null.");
 
         // be sure they have an active session before we go extending things
-        if (sessionEnd is not null)
+        if (sessionStart is null && sessionEnd is not null)
         {
             var playersWithNoSession = await _store
                 .WithNoTracking<Data.Player>()


### PR DESCRIPTION
v3.15.3 of Gameboard brings a few bug fixes and minor updates:

# Enhancements

- A warning banner is now shown when beginning a session would result in a shorter-than-normally-allotted session time due to the execution period ending.
- Players who begin their session after seeing this warning are marked as "late start" players in Admin -> Game -> Players.


# Bug fixes

- Added handling for teams which don't have data for a current challenge spec in the event timeline.
- Fixed an issue that could cause the selected challenge to change when a teammate deploys a challenge. 