### PR TITLE
v3.13.3-beta1

### DIFF
--- a/src/Gameboard.Api.Tests.Integration/Tests/Features/Challenges/ChallengeControllerGradeAutoBonusTests.cs
+++ b/src/Gameboard.Api.Tests.Integration/Tests/Features/Challenges/ChallengeControllerGradeAutoBonusTests.cs
@@ -78,12 +78,14 @@ public class ChallengeControllerGradeAutoBonusTests : IClassFixture<GameboardTes
             .GetDbContext()
             .AwardedChallengeBonuses
             .Include(b => b.ChallengeBonus)
+            .Include(b => b.Challenge)
             .AsNoTracking()
             .FirstOrDefaultAsync(b => b.ChallengeId == challengeId);
 
         // then
         awardedBonus.ShouldNotBeNull();
         awardedBonus.ChallengeBonus.PointValue.ShouldBe(bonusPoints);
+        awardedBonus.Challenge.Score.ShouldBe(baseScore);
     }
 
     [Theory, GbIntegrationAutoData]

--- a/src/Gameboard.Api/Features/Challenge/Services/ChallengeService.cs
+++ b/src/Gameboard.Api/Features/Challenge/Services/ChallengeService.cs
@@ -423,8 +423,9 @@ public partial class ChallengeService : _Service
         // update the team score and award automatic bonuses
         var updatedScore = await _mediator.Send(new UpdateTeamChallengeBaseScoreCommand(challenge.Id, challenge.Score));
 
-        // update the challenge object with the store
-        challenge.Score = updatedScore.Score.TotalScore;
+        // update the challenge object with the score (note that we omit bonuses here because we want the 
+        // score in the players table only to count base completion score for now
+        challenge.Score = updatedScore.Score.CompletionScore;
 
         // The game engine (Topo, in most cases) may optionally not count this as an attempt if the answers are identical 
         // to a previous attempt, which means we need to be sure this consumed an attempt

--- a/src/Gameboard.Api/Features/Player/PlayersTableDenormalizationService.cs
+++ b/src/Gameboard.Api/Features/Player/PlayersTableDenormalizationService.cs
@@ -44,13 +44,7 @@ internal class PlayersTableDenormalizationService : IPlayersTableDenormalization
             .Where(c => c.TeamId == teamId)
             .ToArrayAsync(cancellationToken);
 
-        var score = (int)challenges.Sum
-        (
-            c =>
-                c.Score +
-                c.AwardedBonuses.Sum(b => b.ChallengeBonus.PointValue) +
-                c.AwardedManualBonuses.Sum(m => m.PointValue)
-        );
+        var score = (int)challenges.Sum(c => c.Score);
         var time = challenges.Sum(c => c.Duration);
         var complete = challenges.Count(c => c.Result == ChallengeResult.Success);
         var partial = challenges.Count(c => c.Result == ChallengeResult.Partial);


### PR DESCRIPTION
- Simplified new validation for extend session 
- Fixed a scoring bug that caused bonuses to be recorded incorrectly
- Hide the session alignment warning for external games until deploy is done
- Fixed an issue in the challenge sync service that prevented syncing in some cases