### PR TITLE
v3.13.3

### DIFF
--- a/src/Gameboard.Api/Features/Challenge/Services/ChallengeSyncService.cs
+++ b/src/Gameboard.Api/Features/Challenge/Services/ChallengeSyncService.cs
@@ -83,7 +83,7 @@ internal class ChallengeSyncService : IChallengeSyncService
         // Just load them all, then sync one by one.
         var challenges = await _store
             .WithNoTracking<Data.Challenge>()
-            .Where(c => c.Player.SessionEnd < now && (c.LastSyncTime < c.Player.SessionEnd || c.EndTime == DateTimeOffset.MinValue))
+            .Where(c => c.Player.SessionEnd != DateTimeOffset.MinValue && c.Player.SessionEnd < now && (c.LastSyncTime < c.Player.SessionEnd || c.EndTime == DateTimeOffset.MinValue))
             .ToArrayAsync(cancellationToken);
 
         var playerIds = challenges.Select(c => c.PlayerId).Distinct().ToArray();

--- a/src/Gameboard.Api/Features/Game/External/Requests/GetExternalTeamData.cs
+++ b/src/Gameboard.Api/Features/Game/External/Requests/GetExternalTeamData.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Gameboard.Api/Features/Game/External/Requests/PreDeployGameResources.cs
+++ b/src/Gameboard.Api/Features/Game/External/Requests/PreDeployGameResources.cs
@@ -3,7 +3,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Gameboard.Api.Common.Services;
 using Gameboard.Api.Features.Games.Start;
-using Gameboard.Api.Structure;
 using Gameboard.Api.Structure.MediatR;
 using Gameboard.Api.Structure.MediatR.Authorizers;
 using Gameboard.Api.Structure.MediatR.Validators;

--- a/src/Gameboard.Api/Features/Game/GameService.cs
+++ b/src/Gameboard.Api/Features/Game/GameService.cs
@@ -115,7 +115,7 @@ public class GameService : _Service, IGameService
             return q;
 
         if (model.WantsCompetitive)
-            q = q.Where(g => g.PlayerMode == PlayerMode.Competition);
+            q = q.Where(g => g.PlayerMode == PlayerMode.Competition || g.ShowOnHomePageInPracticeMode);
 
         if (model.WantsPractice)
             q = q.Where(g => g.PlayerMode == PlayerMode.Practice);

--- a/src/Gameboard.Api/Features/Game/GameStart/GameStartService.cs
+++ b/src/Gameboard.Api/Features/Game/GameStart/GameStartService.cs
@@ -23,7 +23,6 @@ public interface IGameStartService
 internal class GameStartService : IGameStartService
 {
     private readonly IActingUserService _actingUserService;
-    // private readonly IExternalSyncGameStartService _externalSyncGameStartService;
     private readonly IGameModeServiceFactory _gameModeServiceFactory;
     private readonly ILockService _lockService;
     private readonly ILogger<GameStartService> _logger;
@@ -35,7 +34,6 @@ internal class GameStartService : IGameStartService
     public GameStartService
     (
         IActingUserService actingUserService,
-        // IExternalSyncGameStartService externalSyncGameStartService,
         IGameModeServiceFactory gameModeServiceFactory,
         ILockService lockService,
         ILogger<GameStartService> logger,
@@ -46,7 +44,6 @@ internal class GameStartService : IGameStartService
     )
     {
         _actingUserService = actingUserService;
-        // _externalSyncGameStartService = externalSyncGameStartService;
         _gameModeServiceFactory = gameModeServiceFactory;
         _lockService = lockService;
         _logger = logger;


### PR DESCRIPTION
v3.15.3 of Gameboard contains enhanced features, stability improvements, and bug fixes.

# New features

- **Player Timeline (beta):** The Admin -> Game -> Players screen now includes a prototype of this new feature. It shows important events which have occurred during the player's session, including challenge launches, submissions, solves, and gamespace activations. We'll continue to refine this feature over the coming releases.
- **Admin Overview** - A new submenu called "Overview" has been added to the Admin area. It shows simple summary information about current activity on Gameboard. We've also moved the global **Announcements** tool from the Games submenu to this new Overview submenu to improve its visibility.

# Enhancements

- Generating an invite code in team creation now automatically copies the code to the clipboard. A notification is shown when this happens.
- The "Copy to Markdown" feature for Support tickets now includes the challenge support code and a link to the Admin -> Challenges view scoped to the challenge (#338).
- Support tickets created from challenges in the Practice Area are now automatically tagged with "practice-challenge".
- The Practice Area can now be completely deactivated in the web client by setting its "Maximum Concurrent Users" setting in Admin -> Practice Area to zero.
- The Admin -> Game -> Players screen no longer automatically refreshes while a player panel has been expanded. When this happens, the autorefresh button will indicate that it is paused.
- The Game edit screen has a new "Show On Homepage When In Practice Mode" that allows admins to optionally display practice games on Gameboard's home screen.
- The suggested searches shown in the Practice Area now correctly match the corresponding labels on practice challenges.
- Admins can now force practice games to show on the homepage (to allow access to scoreboards accumulated while the game was in competitive mode)
- Improvements for players/teams who begin a session near the end of a game's execution period:
  - These players will see a warning on the homepage of the game before they start their session
  - These players will be displayed with an indicator that they had a shortened session in Admin -> Game -> Players

# Bug fixes

- Fixed an issue that could cause the team name listed in Admin -> Challenges -> Observe Challenges to be incorrect (#334)
- Fixed an issue that caused the Admin -> Observe screens to fail to correctly show console user pills (#335)
- Fixed an issue that caused the Gameboard page to automatically navigate to a challenge upon deploy (#339)
- Fixed an issue that caused the number of total and complete solves to be reversed on the Challenges Report
- Fixed an issue that could cause the Game hub to fail to connect for external/sync games.
- The per-team deploy button in Admin -> Game -> Deployment now correctly disables itself while deploys are executing.
- The error message shown when the global practice session limit has been exceeded has been clarified (#343).
- Fixed an issue that caused use of the "Games" filter on the Players Report to exclude all records (#346).
- Attempt to extend a player or team's session when it hasn't started will now correctly throw a visible error.
- Extending a session or using the Announcements feature will now show a toast notification to indicate success.
- Fixed an issue that caused the Practice Area report to exclude some records when the Start Date filter was used.
- Fixed an issue that caused the selected challenge on a board to change when a teammate deploys a new one
- Fixed an issue that caused the challenge countdown clock to display an incorrect value for players who began their session near the end of the game's execution time
- The New Ticket page now disables its submit button during a submission to reduce the likelihood of accidental duplicate submissions (#319).
- The service that synchronizes expired challenges:
  - Attempts to sync challenges with no recorded end time
  - Will not attempt to sync challenges with no player session end time
  - Now automatically fills the end time with the end of the player session if the game engine doesn't provide one.

# Stability

- Updated some package dependencies
