### PR TITLE
v3.15.7

### DIFF
--- a/src/Gameboard.Api.Tests.Integration/Fixtures/Exceptions.cs/GameboardIntegrationTestExceptions.cs
+++ b/src/Gameboard.Api.Tests.Integration/Fixtures/Exceptions.cs/GameboardIntegrationTestExceptions.cs
@@ -15,3 +15,9 @@ internal class ResponseContentEmpty : GameboardIntegrationTestException
 {
     public ResponseContentEmpty() : base("Deserialization failed because the body of the response is empty.") { }
 }
+
+internal class WrongExceptionType : GameboardIntegrationTestException
+{
+    public WrongExceptionType(Type expectedType, string responseContent)
+        : base($"The response suggests that the wrong exception was thrown (expected {expectedType}). Message content: {responseContent}") { }
+}

--- a/src/Gameboard.Api.Tests.Integration/Tests/Features/ChallengeBonuses/ChallengeBonusControllerAutoDeleteTests.cs
+++ b/src/Gameboard.Api.Tests.Integration/Tests/Features/ChallengeBonuses/ChallengeBonusControllerAutoDeleteTests.cs
@@ -1,5 +1,7 @@
 using Gameboard.Api.Common;
 using Gameboard.Api.Data;
+using Gameboard.Api.Features.ChallengeBonuses;
+using Gameboard.Api.Structure;
 using Microsoft.EntityFrameworkCore;
 
 namespace Gameboard.Api.Tests.Integration.ChallengeBonuses;
@@ -82,10 +84,8 @@ public class ChallengeBonusControllerAutoDeleteTests : IClassFixture<GameboardTe
         var httpClient = _testContext.CreateHttpClientWithAuthRole(UserRole.Designer);
 
         // when delete is called, then it should fail validation
-        var isValidationException = await httpClient
+        await httpClient
             .DeleteAsync($"api/game/{gameId}/bonus/config")
-            .YieldsGameboardValidationException();
-
-        isValidationException.ShouldBeTrue();
+            .ShouldYieldGameboardValidationException<GameboardAggregatedValidationExceptions>();
     }
 }

--- a/src/Gameboard.Api.Tests.Integration/Tests/Features/Challenges/ChallengeControllerGradeTests.cs
+++ b/src/Gameboard.Api.Tests.Integration/Tests/Features/Challenges/ChallengeControllerGradeTests.cs
@@ -1,5 +1,7 @@
 using Gameboard.Api.Common;
+using Gameboard.Api.Features.Challenges;
 using Gameboard.Api.Features.GameEngine;
+using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.EntityFrameworkCore;
 
 namespace Gameboard.Api.Tests.Integration;
@@ -11,8 +13,6 @@ public class ChallengeControllerGradeTests : IClassFixture<GameboardTestContext>
     public ChallengeControllerGradeTests(GameboardTestContext testContext)
         => _testContext = testContext;
 
-    // NOTE: This version is trying to use grader key auth, but our test infrastructure
-    // isn't correctly allowing us to replace services at test time. need to come back to this.
     [Theory, GbIntegrationAutoData]
     public async Task Grade_WithFirstSolve_SetsExpectedRankAndScore
     (
@@ -160,6 +160,85 @@ public class ChallengeControllerGradeTests : IClassFixture<GameboardTestContext>
             .AsNoTracking()
             .Where(ev => ev.ChallengeId == challengeId)
             .Where(ev => ev.Type == ChallengeEventType.SubmissionRejectedGamespaceExpired)
+            .OrderByDescending(ev => ev.Timestamp)
+            .ToArrayAsync();
+
+        challengeEvents.Length.ShouldBe(1);
+    }
+
+    [Theory, GbIntegrationAutoData]
+    public async Task Grade_ExecutionTimeOver_ThrowsAndLogsEvent
+    (
+        string gameId,
+        string graderKey,
+        string challengeId,
+        string challengeSpecId,
+        string sponsorId,
+        string userId,
+        IFixture fixture
+    )
+    {
+        var challengeStartTime = DateTime.UtcNow.AddDays(-1);
+        var challengeEndTime = DateTime.UtcNow.AddDays(1);
+        var gameStartTime = DateTime.UtcNow.AddDays(-1);
+        var gameEndTime = DateTime.UtcNow.AddMinutes(-1);
+
+        // given a challenge and a faked game engine service
+        // which will throw an expired exception on grade
+        await _testContext.WithDataState(state =>
+        {
+            state.Add<Data.Sponsor>(fixture, s => s.Id = sponsorId);
+            state.Add<Data.Game>(fixture, g =>
+            {
+                g.Id = gameId;
+                g.GameStart = gameStartTime;
+                g.GameEnd = gameEndTime;
+                g.PlayerMode = PlayerMode.Competition;
+                g.Players = new List<Data.Player>
+                {
+                    new()
+                    {
+                        Id = fixture.Create<string>(),
+                        Challenges = new List<Data.Challenge>
+                        {
+                            new()
+                            {
+                                Id = challengeId,
+                                EndTime = challengeEndTime,
+                                GraderKey = graderKey.ToSha256(),
+                                StartTime = challengeStartTime,
+                                SpecId = challengeSpecId,
+                                GameId = gameId
+                            }
+                        },
+                        SponsorId = sponsorId,
+                        User = state.Build<Data.User>(fixture, u => u.Id = userId)
+                    }
+                };
+            });
+        });
+
+        var submission = new GameEngineSectionSubmission
+        {
+            Id = challengeId,
+            SectionIndex = 0,
+            Timestamp = DateTimeOffset.UtcNow,
+            Questions = Array.Empty<GameEngineAnswerSubmission>()
+        };
+
+        var http = _testContext
+            .CreateHttpClientWithGraderConfig(100, graderKey);
+
+        // Under the hood, the API does throw a specialized exception for this, but we only get 400s for now.
+        // await Should.ThrowAsync<CantGradeBecauseGameExecutionPeriodIsOver>(() => http.PutAsync("/api/challenge/grade", submission.ToJsonBody()));
+        var result = await http.PutAsync("/api/challenge/grade", submission.ToJsonBody());
+        result.IsSuccessStatusCode.ShouldBeFalse();
+
+        var challengeEvents = await _testContext.GetDbContext()
+            .ChallengeEvents
+            .AsNoTracking()
+            .Where(ev => ev.ChallengeId == challengeId)
+            .Where(ev => ev.Type == ChallengeEventType.SubmissionRejectedGameEnded)
             .OrderByDescending(ev => ev.Timestamp)
             .ToArrayAsync();
 

--- a/src/Gameboard.Api.Tests.Integration/Tests/Features/Games/GameControllerGetSyncStartStateTests.cs
+++ b/src/Gameboard.Api.Tests.Integration/Tests/Features/Games/GameControllerGetSyncStartStateTests.cs
@@ -1,5 +1,6 @@
 using Gameboard.Api.Common;
 using Gameboard.Api.Features.Games;
+using Gameboard.Api.Structure;
 
 namespace Gameboard.Api.Tests.Integration;
 
@@ -105,12 +106,11 @@ public class GameControllerGetSyncStartStateTests : IClassFixture<GameboardTestC
             });
         });
 
-        var yieldsValidationFailure = await _testContext
+        // when
+        await _testContext
             .CreateDefaultClient()
             .GetAsync($"/api/game/{gameId}/ready")
-            .YieldsGameboardValidationException();
-
-        // when / then
-        yieldsValidationFailure.ShouldBeTrue();
+            // then
+            .ShouldYieldGameboardValidationException<GameboardAggregatedValidationExceptions>();
     }
 }

--- a/src/Gameboard.Api.Tests.Integration/Tests/Features/Players/PlayerControllerStartTests.cs
+++ b/src/Gameboard.Api.Tests.Integration/Tests/Features/Players/PlayerControllerStartTests.cs
@@ -1,0 +1,138 @@
+using System.Net;
+using Gameboard.Api.Features.Games;
+using Gameboard.Api.Features.Player;
+
+namespace Gameboard.Api.Tests.Integration;
+
+public class PlayerControllerStartTests : IClassFixture<GameboardTestContext>
+{
+    private readonly GameboardTestContext _testContext;
+
+    public PlayerControllerStartTests(GameboardTestContext testContext)
+    {
+        _testContext = testContext;
+    }
+
+    [Theory, GbIntegrationAutoData]
+    public async Task Start_WithClosedExecutionWindow_Throws
+    (
+        IFixture fixture,
+        string playerId,
+        string sponsorId,
+        string userId
+    )
+    {
+        // given a game with a closed execution window and a registered player
+        await _testContext.WithDataState(state =>
+        {
+            state.Add<Data.Sponsor>(fixture, s => s.Id = sponsorId);
+            state.Add<Data.Game>(fixture, g =>
+            {
+                g.GameStart = DateTime.UtcNow.AddDays(-2);
+                g.GameEnd = DateTime.UtcNow.AddDays(-1);
+
+                g.Players = new Data.Player[]
+                {
+                    new()
+                    {
+                        Id = playerId,
+                        SponsorId = sponsorId,
+                        User = new Data.User { Id = userId, SponsorId = sponsorId }
+                    }
+                };
+            });
+        });
+
+        // when the player tries to start their session
+        var startRequest = new SessionStartRequest { PlayerId = playerId };
+        await _testContext
+            .CreateHttpClientWithActingUser(u => u.Id = userId)
+            .PutAsync($"/api/player/{playerId}/start", startRequest.ToJsonBody())
+            // we expect a validation exception
+            .ShouldYieldGameboardValidationException<GameNotActive>();
+    }
+
+    [Theory, GbIntegrationAutoData]
+    public async Task Start_WithAlmostClosedExecutionWindowAndLateStartDisabled_Throws
+    (
+        IFixture fixture,
+        string playerId,
+        string sponsorId,
+        string userId
+    )
+    {
+        // given a game with a closed execution window and a registered player
+        await _testContext.WithDataState(state =>
+        {
+            state.Add<Data.Sponsor>(fixture, s => s.Id = sponsorId);
+            state.Add<Data.Game>(fixture, g =>
+            {
+                g.GameStart = DateTime.UtcNow.AddDays(-2);
+                g.GameEnd = DateTime.UtcNow.AddHours(1);
+                g.SessionMinutes = 120;
+                g.AllowLateStart = false;
+
+                g.Players = new Data.Player[]
+                {
+                    new()
+                    {
+                        Id = playerId,
+                        SponsorId = sponsorId,
+                        TeamId = fixture.Create<string>(),
+                        User = new Data.User { Id = userId, SponsorId = sponsorId }
+                    }
+                };
+            });
+        });
+
+        // when the player tries to start their session
+        var startRequest = new SessionStartRequest { PlayerId = playerId };
+        await _testContext
+            .CreateHttpClientWithActingUser(u => u.Id = userId)
+            .PutAsync($"/api/player/{playerId}/start", startRequest.ToJsonBody())
+            .ShouldYieldGameboardValidationException<CantLateStart>();
+    }
+
+    [Theory, GbIntegrationAutoData]
+    public async Task Start_WithAlmostClosedExecutionWindowAndLateStartEnabled_AllowsShortSession
+    (
+        IFixture fixture,
+        string playerId,
+        string sponsorId,
+        string userId
+    )
+    {
+        // given a game with a closed execution window and a registered player
+        await _testContext.WithDataState(state =>
+        {
+            state.Add<Data.Sponsor>(fixture, s => s.Id = sponsorId);
+            state.Add<Data.Game>(fixture, g =>
+            {
+                g.GameStart = DateTime.UtcNow.AddDays(-2);
+                g.GameEnd = DateTime.UtcNow.AddHours(1);
+                g.SessionMinutes = 120;
+                g.AllowLateStart = true;
+
+                g.Players = new Data.Player[]
+                {
+                    new()
+                    {
+                        Id = playerId,
+                        SponsorId = sponsorId,
+                        TeamId = fixture.Create<string>(),
+                        User = new Data.User { Id = userId, SponsorId = sponsorId }
+                    }
+                };
+            });
+        });
+
+        // when the player tries to start their session
+        var startRequest = new SessionStartRequest { PlayerId = playerId };
+        var result = await _testContext
+            .CreateHttpClientWithActingUser(u => u.Id = userId)
+            .PutAsync($"/api/player/{playerId}/start", startRequest.ToJsonBody())
+            .WithContentDeserializedAs<Player>();
+
+        Math.Round(result.SessionMinutes).ShouldBe(60);
+    }
+}

--- a/src/Gameboard.Api.Tests.Unit/Tests/Features/Challenges/ChallengeSyncServiceTests.cs
+++ b/src/Gameboard.Api.Tests.Unit/Tests/Features/Challenges/ChallengeSyncServiceTests.cs
@@ -1,0 +1,182 @@
+using AutoMapper;
+using Gameboard.Api.Common.Services;
+using Gameboard.Api.Data;
+using Gameboard.Api.Features.Challenges;
+using Gameboard.Api.Features.GameEngine;
+using Gameboard.Api.Services;
+using Microsoft.Extensions.Logging;
+
+namespace Gameboard.Api.Tests.Unit;
+
+public class ChallengeSyncServiceTests
+{
+    [Fact]
+    public async Task GetExpiredChallengesForSync_WithPlayerWithNullishEndDate_DoesNotSync()
+    {
+        // given a player with a nullish end date
+        var now = DateTimeOffset.UtcNow;
+        var challenge = new Data.Challenge
+        {
+            EndTime = DateTimeOffset.MinValue,
+            LastSyncTime = DateTimeOffset.MinValue,
+            Player = new()
+            {
+                SessionEnd = DateTimeOffset.MinValue
+            }
+        };
+        var store = BuildTestableStore(challenge);
+        var sut = new ChallengeSyncService
+        (
+            A.Fake<ConsoleActorMap>(),
+            A.Fake<IGameEngineService>(),
+            A.Fake<ILogger<IChallengeSyncService>>(),
+            A.Fake<IMapper>(),
+            A.Fake<INowService>(),
+            store
+        );
+
+        // when we query challenges to expire
+        var challengesToExpire = await sut.GetExpiredChallengesForSync(now, CancellationToken.None);
+
+        // we should get zero
+        challengesToExpire.Count().ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task GetExpiredChallengesForSync_WithPlayerSessionEndInFuture_DoesNotSync()
+    {
+        // given a player with a nullish end date
+        var now = DateTimeOffset.UtcNow;
+        var challenge = new Data.Challenge
+        {
+            EndTime = DateTimeOffset.MinValue,
+            LastSyncTime = DateTimeOffset.MinValue,
+            Player = new()
+            {
+                SessionEnd = now.AddHours(1)
+            }
+        };
+        var store = BuildTestableStore(challenge);
+        var sut = new ChallengeSyncService
+        (
+            A.Fake<ConsoleActorMap>(),
+            A.Fake<IGameEngineService>(),
+            A.Fake<ILogger<IChallengeSyncService>>(),
+            A.Fake<IMapper>(),
+            A.Fake<INowService>(),
+            store
+        );
+
+        // when we query challenges to expire
+        var challengesToExpire = await sut.GetExpiredChallengesForSync(now, CancellationToken.None);
+
+        // we should get zero
+        challengesToExpire.Count().ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task GetExpiredChallengesForSync_WithChallengeAlreadySynced_DoesNotSync()
+    {
+        // given a player with a nullish end date
+        var now = DateTimeOffset.UtcNow;
+        var challenge = new Data.Challenge
+        {
+            EndTime = now.AddMinutes(-5),
+            LastSyncTime = now.AddMinutes(-4),
+            Player = new()
+            {
+                SessionEnd = now.AddHours(-1)
+            }
+        };
+        var store = BuildTestableStore(challenge);
+        var sut = new ChallengeSyncService
+        (
+            A.Fake<ConsoleActorMap>(),
+            A.Fake<IGameEngineService>(),
+            A.Fake<ILogger<IChallengeSyncService>>(),
+            A.Fake<IMapper>(),
+            A.Fake<INowService>(),
+            store
+        );
+
+        // when we query challenges to expire
+        var challengesToExpire = await sut.GetExpiredChallengesForSync(now, CancellationToken.None);
+
+        // we should get zero
+        challengesToExpire.Count().ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task GetExpiredChallengesForSync_WithNonNullishEndDate_DoesNotSync()
+    {
+        // given a player with a nullish end date
+        var now = DateTimeOffset.UtcNow;
+        var challenge = new Data.Challenge
+        {
+            EndTime = now.AddMinutes(-2),
+            LastSyncTime = now.AddMinutes(-1),
+            Player = new()
+            {
+                SessionEnd = now.AddMinutes(-2)
+            }
+        };
+        var store = BuildTestableStore(challenge);
+        var sut = new ChallengeSyncService
+        (
+            A.Fake<ConsoleActorMap>(),
+            A.Fake<IGameEngineService>(),
+            A.Fake<ILogger<IChallengeSyncService>>(),
+            A.Fake<IMapper>(),
+            A.Fake<INowService>(),
+            store
+        );
+
+        // when we query challenges to expire
+        var challengesToExpire = await sut.GetExpiredChallengesForSync(now, CancellationToken.None);
+
+        // we should get zero
+        challengesToExpire.Count().ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task GetExpiredChallengesForSync_WithAllRequiredCriteriaAndNullishEndDate_Syncs()
+    {
+        // given a player with a nullish end date
+        var now = DateTimeOffset.UtcNow;
+        var challenge = new Data.Challenge
+        {
+            EndTime = DateTimeOffset.MinValue,
+            LastSyncTime = now.AddMinutes(-3),
+            Player = new()
+            {
+                SessionEnd = now.AddMinutes(-2)
+            }
+        };
+        var store = BuildTestableStore(challenge);
+        var sut = new ChallengeSyncService
+        (
+            A.Fake<ConsoleActorMap>(),
+            A.Fake<IGameEngineService>(),
+            A.Fake<ILogger<IChallengeSyncService>>(),
+            A.Fake<IMapper>(),
+            A.Fake<INowService>(),
+            store
+        );
+
+        // when we query challenges to expire
+        var challengesToExpire = await sut.GetExpiredChallengesForSync(now, CancellationToken.None);
+
+        // we should get zero
+        challengesToExpire.Count().ShouldBe(1);
+    }
+
+    private IStore BuildTestableStore(params Data.Challenge[] challenges)
+    {
+        var store = A.Fake<IStore>();
+        A
+            .CallTo(() => store.WithNoTracking<Data.Challenge>())
+            .Returns(challenges.BuildMock());
+
+        return store;
+    }
+}

--- a/src/Gameboard.Api/Extensions/ExceptionExtensions.cs
+++ b/src/Gameboard.Api/Extensions/ExceptionExtensions.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Text;
+using Gameboard.Api.Structure;
+
+namespace Gameboard.Api;
+
+public static class ExceptionExtensions
+{
+    public static string ToExceptionCode<T>(this T exception) where T : GameboardValidationException
+        => ToExceptionCode(typeof(T));
+
+    public static string ToExceptionCode(this Type t)
+        => ToExceptionCode(t.Name);
+
+    private static string ToExceptionCode(string typeName)
+        => Convert.ToBase64String(Encoding.UTF8.GetBytes(typeName));
+}

--- a/src/Gameboard.Api/Extensions/HttpContentExtensions.cs
+++ b/src/Gameboard.Api/Extensions/HttpContentExtensions.cs
@@ -24,9 +24,7 @@ public static class HttpExtensions
             var deserialized = JsonSerializer.Deserialize<T>(rawResponse, serializerOptions);
 
             if (deserialized != null)
-            {
                 return deserialized;
-            }
         }
         catch (Exception ex)
         {

--- a/src/Gameboard.Api/Extensions/JsonExceptionMiddleware.cs
+++ b/src/Gameboard.Api/Extensions/JsonExceptionMiddleware.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Gameboard.Api;
-using Gameboard.Api.Common;
 using Gameboard.Api.Structure;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
@@ -40,7 +39,8 @@ namespace Gameboard.Api
                 if (!context.Response.HasStarted)
                 {
                     context.Response.StatusCode = 500;
-                    string message = "Error";
+                    var message = "Error";
+                    var code = string.Empty;
                     Type type = ex.GetType();
 
                     if (typeof(GameboardException).IsAssignableFrom(type))
@@ -52,6 +52,7 @@ namespace Gameboard.Api
                     {
                         context.Response.StatusCode = 400;
                         message = ex.Message;
+                        code = ex.GetType().ToExceptionCode();
                     }
                     else if (ex is InvalidOperationException || type.Namespace.StartsWith("Gameboard"))
                     {
@@ -62,7 +63,7 @@ namespace Gameboard.Api
                             .Replace("Exception", "");
                     }
 
-                    await context.Response.WriteAsync(JsonSerializer.Serialize(new { message = message }));
+                    await context.Response.WriteAsync(JsonSerializer.Serialize(new { message, code }));
                 }
             }
 

--- a/src/Gameboard.Api/Features/Challenge/Services/ChallengeService.cs
+++ b/src/Gameboard.Api/Features/Challenge/Services/ChallengeService.cs
@@ -370,6 +370,7 @@ public partial class ChallengeService : _Service
             await _store.Create(new ChallengeEvent
             {
                 Id = _guids.GetGuid(),
+                ChallengeId = challenge.Id,
                 UserId = actor?.Id ?? null,
                 TeamId = challenge.TeamId,
                 Timestamp = now,

--- a/src/Gameboard.Api/Features/Game/GameExceptions.cs
+++ b/src/Gameboard.Api/Features/Game/GameExceptions.cs
@@ -11,6 +11,12 @@ internal class CantDeleteGameWithPlayers : GameboardValidationException
         : base($"Game {gameId} can't be deleted because it has {playerCount} players.") { }
 }
 
+internal class GameNotActive : GameboardValidationException
+{
+    public GameNotActive(string gameId, DateTimeOffset startTime, DateTimeOffset endTime)
+        : base($"Game {gameId} execution period is inactive (ran from {startTime}-{endTime} )") { }
+}
+
 internal class CantStartGameWithNoPlayers : GameboardException
 {
     public CantStartGameWithNoPlayers(string gameId) : base($"Can't start game {gameId} - no players are registered.") { }

--- a/src/Gameboard.Api/Features/Player/PlayerService.cs
+++ b/src/Gameboard.Api/Features/Player/PlayerService.cs
@@ -208,7 +208,7 @@ public class PlayerService
 
         // rule: game's execution period has to be open
         if (!sudo && game.IsLive.Equals(false))
-            throw new GameNotActive();
+            throw new GameNotActive(game.Id, game.GameStart, game.GameEnd);
 
         // rule: players per team has to be within the game's constraint
         if (
@@ -242,7 +242,6 @@ public class PlayerService
         }
 
         var sessionWindow = CalculateSessionWindow(game, _now.Get());
-
 
         // rule: if the player/team is starting late, this must be allowed on the game level
         if (sessionWindow.IsLateStart && !game.AllowLateStart)

--- a/src/Gameboard.Api/Features/Reports/Queries/ChallengesReport/ChallengesReportModels.cs
+++ b/src/Gameboard.Api/Features/Reports/Queries/ChallengesReport/ChallengesReportModels.cs
@@ -20,6 +20,7 @@ public sealed class ChallengesReportRecord
     public required IEnumerable<string> Tags { get; set; }
 
     // aggregations
+    public required int AttemptCount { get; set; }
     public required double? AvgScore { get; set; }
     public required double? AvgCompleteSolveTimeMs { get; set; }
     public required int DeployCompetitiveCount { get; set; }
@@ -58,7 +59,9 @@ public sealed class ChallengesReportExportRecord
     public required PlayerMode CurrentPlayerMode { get; set; }
     public required int Points { get; set; }
     public required string GameEngineTags { get; set; }
+    public required int AttemptCount { get; set; }
     public required double? AvgCompleteSolveTimeMs { get; set; }
+    public required string AvgCompleteSolveTime { get; set; }
     public required double? AvgScore { get; set; }
     public required int DeployCompetitiveCount { get; set; }
     public required int DeployPracticeCount { get; set; }
@@ -66,4 +69,7 @@ public sealed class ChallengesReportExportRecord
     public required int SolveZeroCount { get; set; }
     public required int SolvePartialCount { get; set; }
     public required int SolveCompleteCount { get; set; }
+    public required double? SolveZeroPct { get; set; }
+    public required double? SolvePartialPct { get; set; }
+    public required double? SolveCompletePct { get; set; }
 }

--- a/src/Gameboard.Api/Features/Reports/Queries/ChallengesReport/ChallengesReportModels.cs
+++ b/src/Gameboard.Api/Features/Reports/Queries/ChallengesReport/ChallengesReportModels.cs
@@ -20,7 +20,6 @@ public sealed class ChallengesReportRecord
     public required IEnumerable<string> Tags { get; set; }
 
     // aggregations
-    public required int AttemptCount { get; set; }
     public required double? AvgScore { get; set; }
     public required double? AvgCompleteSolveTimeMs { get; set; }
     public required int DeployCompetitiveCount { get; set; }
@@ -59,7 +58,6 @@ public sealed class ChallengesReportExportRecord
     public required PlayerMode CurrentPlayerMode { get; set; }
     public required int Points { get; set; }
     public required string GameEngineTags { get; set; }
-    public required int AttemptCount { get; set; }
     public required double? AvgCompleteSolveTimeMs { get; set; }
     public required string AvgCompleteSolveTime { get; set; }
     public required double? AvgScore { get; set; }

--- a/src/Gameboard.Api/Features/Reports/Queries/ChallengesReport/ChallengesReportService.cs
+++ b/src/Gameboard.Api/Features/Reports/Queries/ChallengesReport/ChallengesReportService.cs
@@ -106,12 +106,15 @@ internal class ChallengesReportService : IChallengesReportService
                     .Count(),
                 SolveZeroCount = group
                     .Where(c => c.Score == 0)
+                    .Where(c => c.PlayerMode == PlayerMode.Competition)
                     .Count(),
                 SolvePartialCount = group
                     .Where(c => c.Score > 0 && c.Score < c.Points)
+                    .Where(c => c.PlayerMode == PlayerMode.Competition)
                     .Count(),
                 SolveCompleteCount = group
                     .Where(c => c.Score >= c.Points)
+                    .Where(c => c.PlayerMode == PlayerMode.Competition)
                     .Count()
             });
 

--- a/src/Gameboard.Api/Features/Reports/Queries/ChallengesReport/ChallengesReportService.cs
+++ b/src/Gameboard.Api/Features/Reports/Queries/ChallengesReport/ChallengesReportService.cs
@@ -88,7 +88,6 @@ internal class ChallengesReportService : IChallengesReportService
             .GroupBy(c => c.SpecId)
             .ToDictionaryAsync(group => group.Key, group => new
             {
-                AttemptCount = group.Count(),
                 AvgScore = group.Any() ? group.Average(c => c.Score) as double? : null,
                 AvgCompleteSolveTimeMs = group.Where(c => c.Score >= c.Points).Any() ? group
                     .Where(c => c.Score >= c.Points)
@@ -135,7 +134,6 @@ internal class ChallengesReportService : IChallengesReportService
                 PlayerModeCurrent = cs.PlayerModeCurrent,
                 Points = cs.Points,
                 Tags = cs.Tags.IsNotEmpty() ? cs.Tags.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries) : Array.Empty<string>(),
-                AttemptCount = aggregations is not null ? aggregations.AttemptCount : 0,
                 AvgCompleteSolveTimeMs = aggregations?.AvgCompleteSolveTimeMs,
                 AvgScore = aggregations?.AvgScore,
                 DeployCompetitiveCount = aggregations is not null ? aggregations.DeployCompetitiveCount : 0,

--- a/src/Gameboard.Api/Features/Reports/Queries/ChallengesReport/ChallengesReportService.cs
+++ b/src/Gameboard.Api/Features/Reports/Queries/ChallengesReport/ChallengesReportService.cs
@@ -88,6 +88,7 @@ internal class ChallengesReportService : IChallengesReportService
             .GroupBy(c => c.SpecId)
             .ToDictionaryAsync(group => group.Key, group => new
             {
+                AttemptCount = group.Count(),
                 AvgScore = group.Any() ? group.Average(c => c.Score) as double? : null,
                 AvgCompleteSolveTimeMs = group.Where(c => c.Score >= c.Points).Any() ? group
                     .Where(c => c.Score >= c.Points)
@@ -134,6 +135,7 @@ internal class ChallengesReportService : IChallengesReportService
                 PlayerModeCurrent = cs.PlayerModeCurrent,
                 Points = cs.Points,
                 Tags = cs.Tags.IsNotEmpty() ? cs.Tags.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries) : Array.Empty<string>(),
+                AttemptCount = aggregations is not null ? aggregations.AttemptCount : 0,
                 AvgCompleteSolveTimeMs = aggregations?.AvgCompleteSolveTimeMs,
                 AvgScore = aggregations?.AvgScore,
                 DeployCompetitiveCount = aggregations is not null ? aggregations.DeployCompetitiveCount : 0,

--- a/src/Gameboard.Api/Features/Reports/Queries/ChallengesReport/GetChallengesReportExport.cs
+++ b/src/Gameboard.Api/Features/Reports/Queries/ChallengesReport/GetChallengesReportExport.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -41,15 +42,19 @@ internal class GetChallengesReportExportHandler : IRequestHandler<GetChallengesR
             CurrentPlayerMode = r.PlayerModeCurrent,
             Points = r.Points,
             GameEngineTags = string.Join(",", r.Tags),
+            AttemptCount = r.AttemptCount,
             AvgCompleteSolveTimeMs = r.AvgCompleteSolveTimeMs,
+            AvgCompleteSolveTime = r.AvgCompleteSolveTimeMs is not null ? TimeSpan.FromMilliseconds(r.AvgCompleteSolveTimeMs.Value).ToString("g") : null,
             AvgScore = r.AvgScore,
             DeployCompetitiveCount = r.DeployCompetitiveCount,
             DeployPracticeCount = r.DeployPracticeCount,
             DistinctPlayerCount = r.DistinctPlayerCount,
             SolveZeroCount = r.SolveZeroCount,
             SolvePartialCount = r.SolvePartialCount,
-            SolveCompleteCount = r.SolveCompleteCount
-        })
-        .ToArray();
+            SolveCompleteCount = r.SolveCompleteCount,
+            SolveZeroPct = r.AttemptCount > 0 ? (r.SolveZeroCount / r.AttemptCount) : null,
+            SolvePartialPct = r.AttemptCount > 0 ? (r.SolvePartialCount / r.AttemptCount) : null,
+            SolveCompletePct = r.AttemptCount > 0 ? (r.SolveCompleteCount / r.AttemptCount) : null
+        });
     }
 }

--- a/src/Gameboard.Api/Features/Reports/Queries/ChallengesReport/GetChallengesReportExport.cs
+++ b/src/Gameboard.Api/Features/Reports/Queries/ChallengesReport/GetChallengesReportExport.cs
@@ -42,7 +42,6 @@ internal class GetChallengesReportExportHandler : IRequestHandler<GetChallengesR
             CurrentPlayerMode = r.PlayerModeCurrent,
             Points = r.Points,
             GameEngineTags = string.Join(",", r.Tags),
-            AttemptCount = r.AttemptCount,
             AvgCompleteSolveTimeMs = r.AvgCompleteSolveTimeMs,
             AvgCompleteSolveTime = r.AvgCompleteSolveTimeMs is not null ? TimeSpan.FromMilliseconds(r.AvgCompleteSolveTimeMs.Value).ToString("g") : null,
             AvgScore = r.AvgScore,
@@ -52,9 +51,9 @@ internal class GetChallengesReportExportHandler : IRequestHandler<GetChallengesR
             SolveZeroCount = r.SolveZeroCount,
             SolvePartialCount = r.SolvePartialCount,
             SolveCompleteCount = r.SolveCompleteCount,
-            SolveZeroPct = r.AttemptCount > 0 ? (r.SolveZeroCount / r.AttemptCount) : null,
-            SolvePartialPct = r.AttemptCount > 0 ? (r.SolvePartialCount / r.AttemptCount) : null,
-            SolveCompletePct = r.AttemptCount > 0 ? (r.SolveCompleteCount / r.AttemptCount) : null
+            SolveZeroPct = r.DeployCompetitiveCount > 0 ? (r.SolveZeroCount / r.DeployCompetitiveCount) : null,
+            SolvePartialPct = r.DeployCompetitiveCount > 0 ? (r.SolvePartialCount / r.DeployCompetitiveCount) : null,
+            SolveCompletePct = r.DeployCompetitiveCount > 0 ? (r.SolveCompleteCount / r.DeployCompetitiveCount) : null
         });
     }
 }

--- a/src/Gameboard.Api/Features/Ticket/TicketStore.cs
+++ b/src/Gameboard.Api/Features/Ticket/TicketStore.cs
@@ -73,7 +73,10 @@ public class TicketStore : Store<Ticket>, ITicketStore
                 t.Requester.ApprovedName.ToLower().Contains(term) ||
                 t.Assignee.ApprovedName.ToLower().Contains(term) ||
                 t.Challenge.Name.ToLower().Contains(term) ||
-                t.Challenge.Tag.ToLower().Contains(term)
+                t.Challenge.Tag.ToLower().Contains(term) ||
+                t.TeamId.ToLower().Contains(term) ||
+                t.PlayerId.ToLower().Contains(term) ||
+                t.RequesterId.ToLower().Contains(term)
             );
         }
 

--- a/src/Gameboard.Api/Structure/Exceptions.cs
+++ b/src/Gameboard.Api/Structure/Exceptions.cs
@@ -94,7 +94,6 @@ namespace Gameboard.Api
 
     public class ActionForbidden : Exception { }
     public class EntityNotFound : Exception { }
-    public class GameNotActive : Exception { }
     public class SessionNotAdjustable : Exception { }
     public class InvalidTeamSize : Exception { }
     public class InvalidConsoleAction : Exception { }


### PR DESCRIPTION
- Corrected a bug that prevented report filters from affecting CSV export
- Added new fields to Support search
  - UserId (requester)
  - PlayerId
  - TeamId
- Added new fields to export generated by the Challenges report
  - Percentage of zero/partial/complete solves across all competitive attempts
  - A formatted AvgSolveTime in addition to the existing AvgSolve
- The challenges report now only includes competitive solves in its solve counts (column header updated to reflect this)
- Minor visual tweaks to the timeline