### PR TITLE
v3.15.9

### DIFF
--- a/src/Gameboard.Api.Tests.Integration/Tests/Features/Scores/ScoringControllerTeamGameSummaryTests.cs
+++ b/src/Gameboard.Api.Tests.Integration/Tests/Features/Scores/ScoringControllerTeamGameSummaryTests.cs
@@ -44,8 +44,7 @@ public class ScoringControllerTeamGameSummaryTests : IClassFixture<GameboardTest
                 {
                     p.Id = playerId;
                     // need to rethink default entities
-                    p.User = null;
-                    p.UserId = playerUserId;
+                    p.User = state.Build<Data.User>(fixture, u => u.Id = playerUserId);
                     p.TeamId = teamId;
                     p.Challenges = new List<Data.Challenge>
                     {

--- a/src/Gameboard.Api.Tests.Integration/Tests/Features/Scores/ScoringControllerTeamGameSummaryTests.cs
+++ b/src/Gameboard.Api.Tests.Integration/Tests/Features/Scores/ScoringControllerTeamGameSummaryTests.cs
@@ -18,6 +18,8 @@ public class ScoringControllerTeamGameSummaryTests : IClassFixture<GameboardTest
     (
         IFixture fixture,
         string gameId,
+        string playerId,
+        string playerUserId,
         string teamId,
         string challenge1Id,
         string challenge2Id,
@@ -40,6 +42,10 @@ public class ScoringControllerTeamGameSummaryTests : IClassFixture<GameboardTest
                 g.Id = gameId;
                 g.Players = state.Build<Data.Player>(fixture, p =>
                 {
+                    p.Id = playerId;
+                    // need to rethink default entities
+                    p.User = null;
+                    p.UserId = playerUserId;
                     p.TeamId = teamId;
                     p.Challenges = new List<Data.Challenge>
                     {
@@ -48,6 +54,7 @@ public class ScoringControllerTeamGameSummaryTests : IClassFixture<GameboardTest
                             c.Id = challenge1Id;
                             c.Points = baseScore1;
                             c.Score = baseScore1;
+                            c.PlayerId = playerId;
                             c.GameId = gameId;
                             c.TeamId = teamId;
                             c.AwardedManualBonuses = new List<ManualChallengeBonus>()
@@ -73,6 +80,7 @@ public class ScoringControllerTeamGameSummaryTests : IClassFixture<GameboardTest
                             c.Id = challenge2Id;
                             c.Points = baseScore2;
                             c.Score = baseScore2;
+                            c.PlayerId = playerId;
                             c.GameId = gameId;
                             c.TeamId = teamId;
                             c.AwardedManualBonuses = new ManualChallengeBonus
@@ -88,8 +96,8 @@ public class ScoringControllerTeamGameSummaryTests : IClassFixture<GameboardTest
             });
         });
 
-        // anon access is ok 👍
-        var httpClient = _testContext.CreateClient();
+        // only accessible by elevated roles or players on the team 👍
+        var httpClient = _testContext.CreateHttpClientWithActingUser(u => u.Id = playerUserId);
 
         // when
         var result = await httpClient

--- a/src/Gameboard.Api/Features/Game/External/Services/ExternalGameService.cs
+++ b/src/Gameboard.Api/Features/Game/External/Services/ExternalGameService.cs
@@ -54,6 +54,11 @@ internal class ExternalGameService : IExternalGameService
     public async Task CreateTeams(string gameId, IEnumerable<string> teamIds, CancellationToken cancellationToken)
     {
         // first, delete any metadata associated with a previous attempt
+        await _store
+            .WithNoTracking<ExternalGameTeam>()
+            .Where(t => t.GameId == gameId)
+            .ExecuteDeleteAsync(cancellationToken);
+
         await DeleteTeamExternalData(cancellationToken, teamIds.ToArray());
 
         // then create an entry for each team in this game

--- a/src/Gameboard.Api/Features/Game/Validators/UserIsPlayingGameValidator.cs
+++ b/src/Gameboard.Api/Features/Game/Validators/UserIsPlayingGameValidator.cs
@@ -14,7 +14,10 @@ public class UserIsPlayingGameValidator : IGameboardValidator
     private string _userId;
     private readonly IStore _store;
 
-    public UserIsPlayingGameValidator(IStore store) => _store = store;
+    public UserIsPlayingGameValidator(IStore store)
+    {
+        _store = store;
+    }
 
     public UserIsPlayingGameValidator UseGameId(string gameId)
     {

--- a/src/Gameboard.Api/Features/Scores/GameScoreQuery/GameScoreQuery.cs
+++ b/src/Gameboard.Api/Features/Scores/GameScoreQuery/GameScoreQuery.cs
@@ -1,6 +1,9 @@
 using System.Threading;
 using System.Threading.Tasks;
+using Gameboard.Api.Common.Services;
+using Gameboard.Api.Features.Games.Validators;
 using Gameboard.Api.Structure.MediatR;
+using Gameboard.Api.Structure.MediatR.Authorizers;
 using Gameboard.Api.Structure.MediatR.Validators;
 using MediatR;
 
@@ -10,21 +13,29 @@ public record GameScoreQuery(string GameId) : IRequest<GameScore>;
 
 internal sealed class GameScoreQueryHandler : IRequestHandler<GameScoreQuery, GameScore>
 {
-    private readonly IScoringService _scoringService;
-
+    private readonly IActingUserService _actingUserService;
     private readonly EntityExistsValidator<GameScoreQuery, Data.Game> _gameExists;
+    private readonly IScoringService _scoringService;
+    private readonly UserIsPlayingGameValidator _userIsPlaying;
+    private readonly UserRoleAuthorizer _userRoleAuthorizer;
     private readonly IValidatorService<GameScoreQuery> _validator;
 
     public GameScoreQueryHandler
     (
+        IActingUserService actingUserService,
         EntityExistsValidator<GameScoreQuery, Data.Game> gameExists,
         IScoringService scoringService,
+        UserIsPlayingGameValidator userIsPlaying,
+        UserRoleAuthorizer userRoleAuthorizer,
         IValidatorService<GameScoreQuery> validator
     )
     {
-        _scoringService = scoringService;
-
+        _actingUserService = actingUserService;
         _gameExists = gameExists.UseProperty(q => q.GameId);
+        _userRoleAuthorizer = userRoleAuthorizer;
+        _scoringService = scoringService;
+        _userIsPlaying = userIsPlaying;
+        _userRoleAuthorizer = userRoleAuthorizer;
         _validator = validator;
     }
 
@@ -32,6 +43,17 @@ internal sealed class GameScoreQueryHandler : IRequestHandler<GameScoreQuery, Ga
     {
         // validate
         _validator.AddValidator(_gameExists);
+
+        if (!_userRoleAuthorizer.AllowRoles(UserRole.Admin, UserRole.Support, UserRole.Tester, UserRole.Designer).WouldAuthorize())
+        {
+            _validator.AddValidator
+            (
+                _userIsPlaying
+                    .UseGameId(request.GameId)
+                    .UseUserId(_actingUserService.Get().Id)
+            );
+        }
+
         await _validator.Validate(request, cancellationToken);
 
         // and go

--- a/src/Gameboard.Api/Features/Scores/GetScoreboardQuery/GetScoreboard.cs
+++ b/src/Gameboard.Api/Features/Scores/GetScoreboardQuery/GetScoreboard.cs
@@ -10,7 +10,6 @@ using Gameboard.Api.Structure.MediatR;
 using Gameboard.Api.Structure.MediatR.Validators;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
-using TopoMojo.Api.Client;
 
 namespace Gameboard.Api.Features.Scores;
 

--- a/src/Gameboard.Api/Features/Scores/ScoreDenormalizationService.cs
+++ b/src/Gameboard.Api/Features/Scores/ScoreDenormalizationService.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -107,7 +106,7 @@ internal class ScoreDenormalizationService : IScoreDenormalizationService
             .WithTracking<DenormalizedTeamScore>()
             .Where(t => t.GameId == gameId)
             .ToArrayAsync();
-        var rankedTeams = _scoringService.GetTeamkRanks(teams.Select(t => new TeamForRanking
+        var rankedTeams = _scoringService.GetTeamRanks(teams.Select(t => new TeamForRanking
         {
             CumulativeTimeMs = t.CumulativeTimeMs,
             OverallScore = t.ScoreOverall,

--- a/src/Gameboard.Api/Features/Scores/ScoringController.cs
+++ b/src/Gameboard.Api/Features/Scores/ScoringController.cs
@@ -31,10 +31,10 @@ public class ScoringController : ControllerBase
         => _mediator.Send(new GetScoreboardQuery(gameId));
 
     [HttpGet("challenge/{challengeId}/score")]
-    public async Task<TeamChallengeScore> GetTeamChallengeScoreSummary([FromRoute] string challengeId)
+    public async Task<TeamChallengeScore> GetChallengeScore([FromRoute] string challengeId)
         => await _mediator.Send(new TeamChallengeScoreQuery(challengeId));
 
     [HttpGet("team/{teamId}/score")]
-    public async Task<TeamScoreQueryResponse> GetTeamGameScoreSummary([FromRoute] string teamId)
+    public async Task<TeamScoreQueryResponse> GetTeamScore([FromRoute] string teamId)
         => await _mediator.Send(new GetTeamScoreQuery(teamId));
 }

--- a/src/Gameboard.Api/Features/Scores/ScoringExceptions.cs
+++ b/src/Gameboard.Api/Features/Scores/ScoringExceptions.cs
@@ -5,7 +5,7 @@ namespace Gameboard.Api.Features.Scores;
 public sealed class CantAccessThisScore : GameboardValidationException
 {
     public CantAccessThisScore(string message)
-        : base($"You don't have access to this score. This is usually because you're either not on an eligible team. ({message})") { }
+        : base($"You don't have access to this score. This is usually because the game hasn't ended yet and you're not on an eligible team. ({message})") { }
 }
 
 public sealed class CantAwardNegativePointValue : GameboardValidationException

--- a/src/Gameboard.Api/Features/Scores/ScoringExceptions.cs
+++ b/src/Gameboard.Api/Features/Scores/ScoringExceptions.cs
@@ -2,13 +2,19 @@ using Gameboard.Api.Structure;
 
 namespace Gameboard.Api.Features.Scores;
 
-public sealed class CantRescoreChallengeWithANonZeroBonus : GameboardValidationException
+public sealed class CantAccessThisScore : GameboardValidationException
 {
-    public CantRescoreChallengeWithANonZeroBonus(string challengeId, string teamId, string bonusId, double pointValue)
-        : base($"""Challenge "{challengeId}" (for team "{teamId}") can't be re-scored, because the team has already received bonus "{bonusId}" for {pointValue} points.""") { }
+    public CantAccessThisScore(string message)
+        : base($"You don't have access to this score. This is usually because you're either not on an eligible team. ({message})") { }
 }
 
 public sealed class CantAwardNegativePointValue : GameboardValidationException
 {
     public CantAwardNegativePointValue(string challengeId, string teamId, double pointValue) : base($"""Can't award a non-positive point value ({pointValue}) to team "{teamId}" for challenge "{challengeId}".""") { }
+}
+
+public sealed class CantRescoreChallengeWithANonZeroBonus : GameboardValidationException
+{
+    public CantRescoreChallengeWithANonZeroBonus(string challengeId, string teamId, string bonusId, double pointValue)
+        : base($"""Challenge "{challengeId}" (for team "{teamId}") can't be re-scored, because the team has already received bonus "{bonusId}" for {pointValue} points.""") { }
 }

--- a/src/Gameboard.Api/Features/Scores/ScoringService.cs
+++ b/src/Gameboard.Api/Features/Scores/ScoringService.cs
@@ -20,7 +20,7 @@ public interface IScoringService
     Task<GameScore> GetGameScore(string gameId, CancellationToken cancellationToken);
     Task<TeamScore> GetTeamScore(string teamId, CancellationToken cancellationToken);
     Task<TeamChallengeScore> GetTeamChallengeScore(string challengeId);
-    IDictionary<string, int> GetTeamkRanks(IEnumerable<TeamForRanking> teams);
+    IDictionary<string, int> GetTeamRanks(IEnumerable<TeamForRanking> teams);
 }
 
 internal class ScoringService : IScoringService
@@ -247,7 +247,7 @@ internal class ScoringService : IScoringService
         };
     }
 
-    public IDictionary<string, int> GetTeamkRanks(IEnumerable<TeamForRanking> teams)
+    public IDictionary<string, int> GetTeamRanks(IEnumerable<TeamForRanking> teams)
     {
         var scoreRank = 0;
         TeamForRanking lastScore = null;

--- a/src/Gameboard.Api/Features/Scores/TeamScoreQuery/TeamScoreQuery.cs
+++ b/src/Gameboard.Api/Features/Scores/TeamScoreQuery/TeamScoreQuery.cs
@@ -26,6 +26,7 @@ public record GetTeamScoreQuery(string TeamId) : IRequest<TeamScoreQueryResponse
 internal class GetTeamScoreHandler : IRequestHandler<GetTeamScoreQuery, TeamScoreQueryResponse>
 {
     private readonly IActingUserService _actingUserService;
+    private readonly INowService _nowService;
     private readonly IScoringService _scoreService;
     private readonly IStore _store;
     private readonly TeamExistsValidator<GetTeamScoreQuery> _teamExists;
@@ -35,6 +36,7 @@ internal class GetTeamScoreHandler : IRequestHandler<GetTeamScoreQuery, TeamScor
 
     public GetTeamScoreHandler(
         IActingUserService actingUserService,
+        INowService nowService,
         IScoringService scoreService,
         IStore store,
         TeamExistsValidator<GetTeamScoreQuery> teamExists,
@@ -43,6 +45,7 @@ internal class GetTeamScoreHandler : IRequestHandler<GetTeamScoreQuery, TeamScor
         IValidatorService<GetTeamScoreQuery> validatorService)
     {
         _actingUserService = actingUserService;
+        _nowService = nowService;
         _scoreService = scoreService;
         _store = store;
         _teamExists = teamExists;
@@ -55,16 +58,33 @@ internal class GetTeamScoreHandler : IRequestHandler<GetTeamScoreQuery, TeamScor
     {
         _validatorService.AddValidator(_teamExists.UseProperty(r => r.TeamId));
 
-        var userId = _actingUserService.Get().Id;
-
         if (!_userRoleAuthorizer.AllowRoles(UserRole.Admin, UserRole.Designer, UserRole.Support, UserRole.Tester).WouldAuthorize())
         {
             _validatorService.AddValidator(async (req, ctx) =>
             {
+                var gameInfo = await _store
+                    .WithNoTracking<Data.Game>()
+                    .Where(g => g.Players.Any(p => p.TeamId == req.TeamId))
+                    .Select(g => new
+                    {
+                        g.Id,
+                        g.GameEnd
+                    })
+                    .SingleAsync(cancellationToken);
+
+                var now = _nowService.Get();
+
+                // if the game is over, this data is generally available
+                if (gameInfo.GameEnd <= now)
+                    return;
+
+                // otherwise, you need to be on the team you're looking at
+                var userId = _actingUserService.Get().Id;
                 var isOnTeam = await _store
                     .WithNoTracking<Data.Player>()
                     .Where(p => p.TeamId == request.TeamId)
                     .Where(p => p.UserId == userId)
+                    .Where(p => p.GameId == gameInfo.Id)
                     .AnyAsync(cancellationToken);
 
                 if (!isOnTeam)

--- a/src/Gameboard.Api/Features/Scores/TeamScoreQuery/TeamScoreQuery.cs
+++ b/src/Gameboard.Api/Features/Scores/TeamScoreQuery/TeamScoreQuery.cs
@@ -1,11 +1,16 @@
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Gameboard.Api.Common.Services;
 using Gameboard.Api.Data;
 using Gameboard.Api.Features.Games;
+using Gameboard.Api.Features.Games.Validators;
 using Gameboard.Api.Features.Teams;
 using Gameboard.Api.Structure.MediatR;
+using Gameboard.Api.Structure.MediatR.Authorizers;
 using Gameboard.Api.Structure.MediatR.Validators;
 using MediatR;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
 
 namespace Gameboard.Api.Features.Scores;
@@ -20,29 +25,53 @@ public record GetTeamScoreQuery(string TeamId) : IRequest<TeamScoreQueryResponse
 
 internal class GetTeamScoreHandler : IRequestHandler<GetTeamScoreQuery, TeamScoreQueryResponse>
 {
+    private readonly IActingUserService _actingUserService;
     private readonly IScoringService _scoreService;
     private readonly IStore _store;
     private readonly TeamExistsValidator<GetTeamScoreQuery> _teamExists;
     private readonly ITeamService _teamService;
+    private readonly UserRoleAuthorizer _userRoleAuthorizer;
     private readonly IValidatorService<GetTeamScoreQuery> _validatorService;
 
     public GetTeamScoreHandler(
+        IActingUserService actingUserService,
         IScoringService scoreService,
         IStore store,
         TeamExistsValidator<GetTeamScoreQuery> teamExists,
         ITeamService teamService,
+        UserRoleAuthorizer userRoleAuthorizer,
         IValidatorService<GetTeamScoreQuery> validatorService)
     {
+        _actingUserService = actingUserService;
         _scoreService = scoreService;
         _store = store;
         _teamExists = teamExists;
         _teamService = teamService;
+        _userRoleAuthorizer = userRoleAuthorizer;
         _validatorService = validatorService;
     }
 
     public async Task<TeamScoreQueryResponse> Handle(GetTeamScoreQuery request, CancellationToken cancellationToken)
     {
         _validatorService.AddValidator(_teamExists.UseProperty(r => r.TeamId));
+
+        var userId = _actingUserService.Get().Id;
+
+        if (!_userRoleAuthorizer.AllowRoles(UserRole.Admin, UserRole.Designer, UserRole.Support, UserRole.Tester).WouldAuthorize())
+        {
+            _validatorService.AddValidator(async (req, ctx) =>
+            {
+                var isOnTeam = await _store
+                    .WithNoTracking<Data.Player>()
+                    .Where(p => p.TeamId == request.TeamId)
+                    .Where(p => p.UserId == userId)
+                    .AnyAsync(cancellationToken);
+
+                if (!isOnTeam)
+                    ctx.AddValidationException(new CantAccessThisScore("not on requested team"));
+            });
+        }
+
         await _validatorService.Validate(request, cancellationToken);
 
         // there are definitely extra reads in here but i just can't

--- a/src/Gameboard.Api/Structure/MediatR/Validators/ValidatorService.cs
+++ b/src/Gameboard.Api/Structure/MediatR/Validators/ValidatorService.cs
@@ -98,6 +98,9 @@ internal class ValidatorService<TModel> : IValidatorService<TModel>
         foreach (var task in _validationTasks)
             await task(model, context);
 
+        foreach (var task in _nonModelValidationTasks)
+            await task(context);
+
         if (context.ValidationExceptions.Any())
         {
             throw GameboardAggregatedValidationExceptions.FromValidationExceptions(context.ValidationExceptions);


### PR DESCRIPTION
Version 3.15.9 of Gameboard includes minor bug fixes and stability improvements.

# Bug fixes

- Resolved an issue that caused the new Support Tools links to 404 in some environments.
- The Players view for game admin now expands the card of the relevant player if included in the querystring.
- Resolved an issue that caused external games to fail to launch if not predeployed.
- Resolved an issue that caused the support code to fail to copy correctly for untagged challenges

# Structure & Stability

- Improved/centralized validation around access to detailed scoring endpoints