### PR TITLE
v3.16.0

### DIFF
--- a/src/Gameboard.Api.Tests.Integration/Tests/Features/Challenges/ChallengeControllerGradeAutoBonusTests.cs
+++ b/src/Gameboard.Api.Tests.Integration/Tests/Features/Challenges/ChallengeControllerGradeAutoBonusTests.cs
@@ -55,7 +55,11 @@ public class ChallengeControllerGradeAutoBonusTests : IClassFixture<GameboardTes
                     {
                         c.Id = challengeId;
                         c.GraderKey = graderKey.ToSha256();
-                        c.Player = state.Build<Data.Player>(fixture, p => p.TeamId = teamId);
+                        c.Player = state.Build<Data.Player>(fixture, p =>
+                        {
+                            p.GameId = gameId;
+                            p.TeamId = teamId;
+                        });
                         c.SpecId = challengeSpecId;
                         c.TeamId = teamId;
                     }).ToCollection();
@@ -110,6 +114,8 @@ public class ChallengeControllerGradeAutoBonusTests : IClassFixture<GameboardTes
             {
                 state.Add<Data.Game>(fixture, g =>
                 {
+                    g.Id = gameId;
+
                     g.Specs = state.Build<Data.ChallengeSpec>(fixture, spec =>
                     {
                         spec.Id = challengeSpecId;

--- a/src/Gameboard.Api.Tests.Integration/Tests/Features/Challenges/ChallengeControllerGradeTests.cs
+++ b/src/Gameboard.Api.Tests.Integration/Tests/Features/Challenges/ChallengeControllerGradeTests.cs
@@ -1,7 +1,5 @@
 using Gameboard.Api.Common;
-using Gameboard.Api.Features.Challenges;
 using Gameboard.Api.Features.GameEngine;
-using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.EntityFrameworkCore;
 
 namespace Gameboard.Api.Tests.Integration;

--- a/src/Gameboard.Api.Tests.Integration/Tests/Features/Challenges/ChallengeControllerGradeTests.cs
+++ b/src/Gameboard.Api.Tests.Integration/Tests/Features/Challenges/ChallengeControllerGradeTests.cs
@@ -41,7 +41,6 @@ public class ChallengeControllerGradeTests : IClassFixture<GameboardTestContext>
                     g.Challenges = state.Build<Data.Challenge>(fixture, c =>
                     {
                         c.Id = challengeId;
-                        c.GameId = gameId;
                         c.GraderKey = graderKey.ToSha256();
                         c.Points = 0;
                         c.Score = 0;
@@ -49,6 +48,7 @@ public class ChallengeControllerGradeTests : IClassFixture<GameboardTestContext>
                         c.TeamId = teamId;
                         c.Player = state.Build<Data.Player>(fixture, p =>
                         {
+                            p.GameId = gameId;
                             p.Score = 0;
                             p.Rank = 0;
                             p.TeamId = teamId;

--- a/src/Gameboard.Api.Tests.Integration/Tests/Features/Players/PlayerControllerStartTests.cs
+++ b/src/Gameboard.Api.Tests.Integration/Tests/Features/Players/PlayerControllerStartTests.cs
@@ -133,6 +133,7 @@ public class PlayerControllerStartTests : IClassFixture<GameboardTestContext>
             .PutAsync($"/api/player/{playerId}/start", startRequest.ToJsonBody())
             .WithContentDeserializedAs<Player>();
 
+        // the player should have a shortened session window consistent with the remaining execution time
         Math.Round(result.SessionMinutes).ShouldBe(60);
     }
 }

--- a/src/Gameboard.Api.Tests.Integration/Tests/Features/Teams/TeamControllerGetTeamsTests.cs
+++ b/src/Gameboard.Api.Tests.Integration/Tests/Features/Teams/TeamControllerGetTeamsTests.cs
@@ -1,0 +1,108 @@
+using Gameboard.Api.Features.Teams;
+
+namespace Gameboard.Api.Tests.Integration.Teams;
+
+public class TeamControllerGetTeamsTests : IClassFixture<GameboardTestContext>
+{
+    private readonly GameboardTestContext _testContext;
+    public TeamControllerGetTeamsTests(GameboardTestContext testContext) => _testContext = testContext;
+
+    [Theory, GbIntegrationAutoData]
+    public async Task GetTeams_WithSingleTeamOfTwo_ReturnsExpected
+    (
+        string gameId,
+        string teamId,
+        DateTimeOffset sessionEnd,
+        DateTimeOffset wrongSessionEnd,
+        IFixture fixture
+    )
+    {
+        var universalSessionEnd = sessionEnd.ToUniversalTime();
+
+        // given a team with two people
+        await _testContext.WithDataState(state =>
+        {
+            state.Add<Data.Game>(fixture, g =>
+            {
+                g.Id = gameId;
+                g.Players = new List<Data.Player>()
+                {
+                    state.Build<Data.Player>(fixture, p =>
+                    {
+                        p.TeamId = teamId;
+                        p.SessionEnd = wrongSessionEnd.ToUniversalTime();
+                        p.Role = PlayerRole.Member;
+                    }),
+
+                    state.Build<Data.Player>(fixture, p =>
+                    {
+                        p.TeamId = teamId;
+                        p.SessionEnd = universalSessionEnd;
+                        p.Role = PlayerRole.Manager;
+                    })
+                };
+            });
+        });
+
+        // when we ask for the team by Id
+        var result = await _testContext
+            .CreateHttpClientWithAuthRole(UserRole.Observer)
+            .GetAsync($"api/team/{teamId}")
+            .WithContentDeserializedAs<Team>();
+
+        // we should get back one team with two members
+        result.TeamId.ShouldBe(teamId);
+        result.Members.Count().ShouldBe(2);
+        // and we should be respecting the captain's end time
+        result.SessionEnd.ToUniversalTime().ShouldBe(universalSessionEnd, TimeSpan.FromMilliseconds(100));
+    }
+
+    [Theory, GbIntegrationAutoData]
+    public async Task GetTeams_WithMultipleTeamIds_ReturnsExpected
+    (
+        string gameId,
+        string teamId,
+        string otherTeamId,
+        IFixture fixture
+    )
+    {
+        // given a team with two people
+        await _testContext.WithDataState(state =>
+        {
+            state.Add<Data.Game>(fixture, g =>
+            {
+                g.Id = gameId;
+                g.Players = new List<Data.Player>()
+                {
+                    state.Build<Data.Player>(fixture, p =>
+                    {
+                        p.TeamId = teamId;
+                        p.Role = PlayerRole.Member;
+                    }),
+
+                    state.Build<Data.Player>(fixture, p =>
+                    {
+                        p.TeamId = teamId;
+                        p.Role = PlayerRole.Manager;
+                    }),
+
+                    state.Build<Data.Player>(fixture, p =>
+                    {
+                        p.TeamId = otherTeamId;
+                        p.Role = PlayerRole.Manager;
+                    })
+                };
+            });
+        });
+
+        // when we ask for the team by Id
+        var result = await _testContext
+            .CreateHttpClientWithAuthRole(UserRole.Observer)
+            .GetAsync($"api/team/search?teamIds={teamId},{otherTeamId}")
+            .WithContentDeserializedAs<IEnumerable<Team>>();
+
+        // we should get back two tames
+        result.Count().ShouldBe(2);
+        result.Single(t => t.TeamId == teamId).Members.Count().ShouldBe(2);
+    }
+}

--- a/src/Gameboard.Api.Tests.Integration/Tests/Features/Teams/TeamControllerGetTeamsTests.cs
+++ b/src/Gameboard.Api.Tests.Integration/Tests/Features/Teams/TeamControllerGetTeamsTests.cs
@@ -98,7 +98,7 @@ public class TeamControllerGetTeamsTests : IClassFixture<GameboardTestContext>
         // when we ask for the team by Id
         var result = await _testContext
             .CreateHttpClientWithAuthRole(UserRole.Support)
-            .GetAsync($"api/admin/team/search?teamIds={teamId},{otherTeamId}")
+            .GetAsync($"api/admin/team/search?ids={teamId},{otherTeamId}")
             .WithContentDeserializedAs<IEnumerable<Team>>();
 
         // we should get back two tames

--- a/src/Gameboard.Api.Tests.Integration/Tests/Features/Teams/TeamControllerGetTeamsTests.cs
+++ b/src/Gameboard.Api.Tests.Integration/Tests/Features/Teams/TeamControllerGetTeamsTests.cs
@@ -97,8 +97,8 @@ public class TeamControllerGetTeamsTests : IClassFixture<GameboardTestContext>
 
         // when we ask for the team by Id
         var result = await _testContext
-            .CreateHttpClientWithAuthRole(UserRole.Observer)
-            .GetAsync($"api/team/search?teamIds={teamId},{otherTeamId}")
+            .CreateHttpClientWithAuthRole(UserRole.Support)
+            .GetAsync($"api/admin/team/search?teamIds={teamId},{otherTeamId}")
             .WithContentDeserializedAs<IEnumerable<Team>>();
 
         // we should get back two tames

--- a/src/Gameboard.Api.Tests.Shared/Fixtures/GameboardCustomization.cs
+++ b/src/Gameboard.Api.Tests.Shared/Fixtures/GameboardCustomization.cs
@@ -17,15 +17,6 @@ public class GameboardCustomization : ICustomization
     private void RegisterDefaultEntityModels(IFixture fixture)
     {
         fixture.Register(() => fixture);
-
-        // this is necessary for us because we use EF with multiple navigation properties
-        // which ultimately result in circular references. We ignore the behavior in
-        // autofixture because it breaks tests which autofix entities with these references
-        // and we already know about the circular references - they're by design.
-        // fixture.Behaviors.OfType<ThrowingRecursionBehavior>().ToList()
-        //     .ForEach(b => fixture.Behaviors.Remove(b));
-        // fixture.Behaviors.Add(new OmitOnRecursionBehavior());
-
         fixture.Customizations.Add(new IdBuilder());
         var now = DateTimeOffset.UtcNow;
 
@@ -125,7 +116,6 @@ public class GameboardCustomization : ICustomization
         {
             Id = fixture.Create<string>(),
             User = fixture.Create<Data.User>(),
-            Game = fixture.Create<Data.Game>(),
             ApprovedName = "Test Player",
             Sponsor = fixture.Create<Data.Sponsor>(),
             Role = PlayerRole.Manager,

--- a/src/Gameboard.Api.Tests.Unit/Tests/Features/Reports/EnrollmentReportServiceTests.cs
+++ b/src/Gameboard.Api.Tests.Unit/Tests/Features/Reports/EnrollmentReportServiceTests.cs
@@ -26,6 +26,7 @@ public class EnrollmentReportServiceTests
 
         var player = fixture.Create<Data.Player>();
         player.Challenges = new Data.Challenge[] { challenge };
+        player.Game = fixture.Create<Data.Game>();
         player.Game.PlayerMode = PlayerMode.Competition;
         player.Sponsor = sponsors.First();
 
@@ -51,7 +52,7 @@ public class EnrollmentReportServiceTests
     }
 
     [Theory, GameboardAutoData]
-    public async Task GetResults_WithOneTeamRecord_ReportsExpectedValues(IFixture fixture)
+    public async Task GetResults_WithOneTeamRecord_ReportsExpectedValues(string gameId, IFixture fixture)
     {
         // given 
         var sponsors = new List<Data.Sponsor>
@@ -76,10 +77,15 @@ public class EnrollmentReportServiceTests
         challenge.Points = 50;
         challenge.Score = 50;
         challenge.PlayerMode = PlayerMode.Competition;
+        challenge.GameId = gameId;
+
+        var game = fixture.Create<Data.Game>();
+        game.Id = gameId;
+        game.PlayerMode = PlayerMode.Competition;
 
         var player1 = fixture.Create<Data.Player>();
         player1.Challenges = new Data.Challenge[] { challenge };
-        player1.Game.PlayerMode = PlayerMode.Competition;
+        player1.Game = game;
         player1.Sponsor = sponsors.First();
         player1.Role = PlayerRole.Manager;
 
@@ -133,6 +139,7 @@ public class EnrollmentReportServiceTests
 
         var player = fixture.Create<Data.Player>();
         player.Challenges = new Data.Challenge[] { challenge };
+        player.Game = fixture.Create<Data.Game>();
         player.Game.PlayerMode = PlayerMode.Practice;
         player.Sponsor = sponsors.First();
 
@@ -172,6 +179,7 @@ public class EnrollmentReportServiceTests
 
         var player = fixture.Create<Data.Player>();
         player.Challenges = Array.Empty<Data.Challenge>();
+        player.Game = fixture.Create<Data.Game>();
         player.Sponsor = sponsors.First();
         var players = player.ToEnumerable().BuildMock();
 

--- a/src/Gameboard.Api/Common/Extensions/IDictionaryExtensions.cs
+++ b/src/Gameboard.Api/Common/Extensions/IDictionaryExtensions.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+namespace Gameboard.Api.Common;
+
+public static class IDictionaryExtensions
+{
+    public static IDictionary<K, V> EnsureKey<K, V>(this IDictionary<K, V> dictionary, K key, V defaultValue)
+    {
+        if (!dictionary.ContainsKey(key))
+            dictionary.Add(key, defaultValue ?? default);
+
+        return dictionary;
+    }
+}

--- a/src/Gameboard.Api/Features/ChallengeBonuses/ChallengeBonusMaps.cs
+++ b/src/Gameboard.Api/Features/ChallengeBonuses/ChallengeBonusMaps.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using AutoMapper;
 using Gameboard.Api.Data;
 using Gameboard.Api.Features.Scores;
@@ -16,7 +18,6 @@ public class ChallengeBonusMaps : Profile
             }));
 
         CreateMap<Data.AwardedChallengeBonus, GameScoreAutoChallengeBonus>();
-        CreateMap<Data.ChallengeBonus, GameScoringConfigChallengeBonus>();
         CreateMap<Data.ChallengeBonus, GameScoreAutoChallengeBonus>();
         CreateMap<Data.ChallengeBonusCompleteSolveRank, GameScoringConfigChallengeBonus>();
     }

--- a/src/Gameboard.Api/Features/ChallengeBonuses/ListManualBonuses/ListManualBonuses.cs
+++ b/src/Gameboard.Api/Features/ChallengeBonuses/ListManualBonuses/ListManualBonuses.cs
@@ -4,7 +4,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using AutoMapper;
 using Gameboard.Api.Data;
-using Gameboard.Api.Data.Abstractions;
 using Gameboard.Api.Structure.MediatR;
 using Gameboard.Api.Structure.MediatR.Authorizers;
 using Gameboard.Api.Structure.MediatR.Validators;

--- a/src/Gameboard.Api/Features/FeatureStartupExtensions.cs
+++ b/src/Gameboard.Api/Features/FeatureStartupExtensions.cs
@@ -13,6 +13,7 @@ using Gameboard.Api.Features.Games;
 using Gameboard.Api.Features.Games.External;
 using Gameboard.Api.Features.Games.Validators;
 using Gameboard.Api.Features.Reports;
+using Gameboard.Api.Features.Scores;
 using Gameboard.Api.Features.UnityGames;
 using Gameboard.Api.Hubs;
 using Gameboard.Api.Structure;
@@ -48,6 +49,7 @@ public static class ServiceStartupExtensions
             // but allowing multiple-interface classes causes things like IReportQuery implementers to get snagged
             .AddScoped<IExternalSyncGameStartService, ExternalSyncGameStartService>()
             .AddScoped<IGameHubBus, GameHubBus>()
+            .AddScoped<IScoreDenormalizationService, ScoreDenormalizationService>()
             .AddScoped<ISupportHubBus, SupportHubBus>()
             // so close to fixing this, but it's a very special snowflake of a binding
             .AddScoped<IUnityStore, UnityStore>()

--- a/src/Gameboard.Api/Features/Feedback/Feedback.cs
+++ b/src/Gameboard.Api/Features/Feedback/Feedback.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 namespace Gameboard.Api
 {
-     public class FeedbackSubmission
+    public class FeedbackSubmission
     {
         // UserId and PlayerId are set automatically when saved
         public string ChallengeId { get; set; }
@@ -32,7 +32,7 @@ namespace Gameboard.Api
     {
         public string Type { get; set; } = "text"; // if unspecified in config
         public bool Required { get; set; } = false; // if unspecified in config
-        
+
         // For 'likert' type questions only
         public int Min { get; set; } = 1;
         public int Max { get; set; }
@@ -49,22 +49,22 @@ namespace Gameboard.Api
 
     public class GameFeedbackTemplate
     {
-        public QuestionTemplate[] Game { get; set; } = new QuestionTemplate[0];
-        public QuestionTemplate[] Challenge { get; set; } = new QuestionTemplate[0];
+        public QuestionTemplate[] Game { get; set; } = Array.Empty<QuestionTemplate>();
+        public QuestionTemplate[] Challenge { get; set; } = Array.Empty<QuestionTemplate>();
         public string Message { get; set; }
     }
-    
+
 
     public class Feedback
     {
-        public string Id { get; set; } 
-        public string UserId { get; set; } 
-        public string PlayerId { get; set; } 
-        public string ChallengeId { get; set; } 
-        public string ChallengeSpecId { get; set; } 
+        public string Id { get; set; }
+        public string UserId { get; set; }
+        public string PlayerId { get; set; }
+        public string ChallengeId { get; set; }
+        public string ChallengeSpecId { get; set; }
         public string GameId { get; set; }
-        public QuestionSubmission[] Questions { get; set; } 
-        public bool Submitted { get; set; } 
+        public QuestionSubmission[] Questions { get; set; }
+        public bool Submitted { get; set; }
         public DateTimeOffset Timestamp { get; set; }
     }
 
@@ -74,17 +74,17 @@ namespace Gameboard.Api
         public string ChallengeTag { get; set; }
     }
 
-    public class FeedbackSearchParams: SearchFilter
+    public class FeedbackSearchParams : SearchFilter
     {
         public const string GameType = "game";
         public const string ChallengeType = "challenge";
         public const string SortOldest = "oldest";
         public const string SortNewest = "newest";
         public const string Submitted = "submitted";
-        public string GameId { get; set; } 
-        public string ChallengeSpecId { get; set; } 
-        public string ChallengeId { get; set; } 
-        public string Type { get; set; } 
+        public string GameId { get; set; }
+        public string ChallengeSpecId { get; set; }
+        public string ChallengeId { get; set; }
+        public string Type { get; set; }
         public string SubmitStatus { get; set; }
         public bool WantsGame => Type == GameType;
         public bool WantsChallenge => Type == ChallengeType;
@@ -97,12 +97,12 @@ namespace Gameboard.Api
     // Order of properties below determines order of columns in CSV export
     public class FeedbackReportExport
     {
-        public string UserId { get; set; } 
-        public string PlayerId { get; set; } 
+        public string UserId { get; set; }
+        public string PlayerId { get; set; }
         public string ApprovedName { get; set; }
-        public string ChallengeId { get; set; } 
+        public string ChallengeId { get; set; }
         public string ChallengeTag { get; set; }
-        public bool Submitted { get; set; } 
+        public bool Submitted { get; set; }
         public DateTimeOffset Timestamp { get; set; }
     }
 
@@ -114,12 +114,12 @@ namespace Gameboard.Api
     public class FeedbackStats
     {
         public string GameId { get; set; }
-        public string ChallengeSpecId { get; set; } 
+        public string ChallengeSpecId { get; set; }
         public int ConfiguredCount { get; set; }
         public int LikertCount { get; set; }
         public int TextCount { get; set; }
         public int SelectOneCount { get; set; }
-        public int SelectManyCount { get; set;}
+        public int SelectManyCount { get; set; }
         public int RequiredCount { get; set; }
         public int ResponsesCount { get; set; }
         public int MaxResponseCount { get; set; }

--- a/src/Gameboard.Api/Features/Game/GameStart/ExternalSyncGameStartService.cs
+++ b/src/Gameboard.Api/Features/Game/GameStart/ExternalSyncGameStartService.cs
@@ -348,7 +348,7 @@ internal class ExternalSyncGameStartService : IExternalSyncGameStartService
                 }
                 else
                 {
-                    Log($"""Creating challenge for team {team.Team.Id}, spec "{specId}"...""", request.Game.Id);
+                    Log($"Creating challenge for team {team.Team.Id}, spec {specId}...", request.Game.Id);
                     deployedChallenge = await _challengeService.Create
                     (
                         new NewChallenge

--- a/src/Gameboard.Api/Features/Game/GameStart/ExternalSyncGameStartService.cs
+++ b/src/Gameboard.Api/Features/Game/GameStart/ExternalSyncGameStartService.cs
@@ -164,6 +164,9 @@ internal class ExternalSyncGameStartService : IExternalSyncGameStartService
         // update external host and get configuration information for teams
         var externalHostTeamConfigs = await NotifyExternalGameHost(request, syncGameStartState, cancellationToken);
 
+        // log what we got
+        Log($"External host team configurations: {_jsonService.Serialize(externalHostTeamConfigs)}", request.Game.Id);
+
         // then assign a headless server to each team
         foreach (var team in request.Context.Teams)
         {

--- a/src/Gameboard.Api/Features/GameEngine/GameEngineModels.cs
+++ b/src/Gameboard.Api/Features/GameEngine/GameEngineModels.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 
-// These are data-annotated to support automatic JSON schema generation for Gamebrain dev
 namespace Gameboard.Api.Features.GameEngine;
 
 public class GameEngineChallengeRegistration

--- a/src/Gameboard.Api/Features/GameEngine/GameEngineModels.cs
+++ b/src/Gameboard.Api/Features/GameEngine/GameEngineModels.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 
+// These are data-annotated to support automatic JSON schema generation for Gamebrain dev
 namespace Gameboard.Api.Features.GameEngine;
 
 public class GameEngineChallengeRegistration

--- a/src/Gameboard.Api/Features/Reports/Queries/ChallengesReport/GetChallengesReport.cs
+++ b/src/Gameboard.Api/Features/Reports/Queries/ChallengesReport/GetChallengesReport.cs
@@ -38,7 +38,6 @@ internal class GetChallengesReportHandler : IRequestHandler<GetChallengesReportQ
         var statSummary = _challengesReportService.GetStatSummary(rawResults);
         var paged = _pagingService.Page(rawResults, request.PagingArgs);
 
-
         return new ReportResults<ChallengesReportStatSummary, ChallengesReportRecord>
         {
             MetaData = new ReportMetaData

--- a/src/Gameboard.Api/Features/Reports/Queries/PracticeMode/PracticeModeReportModels.cs
+++ b/src/Gameboard.Api/Features/Reports/Queries/PracticeMode/PracticeModeReportModels.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
-using Gameboard.Api.Common;
 
 namespace Gameboard.Api.Features.Reports;
 

--- a/src/Gameboard.Api/Features/Reports/Queries/SupportReport/SupportReportModels.cs
+++ b/src/Gameboard.Api/Features/Reports/Queries/SupportReport/SupportReportModels.cs
@@ -19,6 +19,8 @@ public class SupportReportParameters
     public double? MinutesSinceUpdate { get; set; }
     public DateTimeOffset? OpenedDateStart { get; set; }
     public DateTimeOffset? OpenedDateEnd { get; set; }
+    public DateTimeOffset? UpdatedDateStart { get; set; }
+    public DateTimeOffset? UpdatedDateEnd { get; set; }
     public SupportReportTicketWindow? OpenedWindow { get; set; }
     public string Statuses { get; set; }
 }

--- a/src/Gameboard.Api/Features/Reports/Queries/SupportReport/SupportReportModels.cs
+++ b/src/Gameboard.Api/Features/Reports/Queries/SupportReport/SupportReportModels.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using Gameboard.Api.Common;
 
 namespace Gameboard.Api.Features.Reports;
 
@@ -9,12 +8,6 @@ public enum SupportReportTicketWindow
     BusinessHours,
     EveningHours,
     OffHours
-}
-
-public enum SupportReportLabelsModifier
-{
-    HasAll,
-    HasAny
 }
 
 public class SupportReportParameters
@@ -30,6 +23,28 @@ public class SupportReportParameters
     public string Statuses { get; set; }
 }
 
+public sealed class SupportReportStatSummary
+{
+    public required SupportReportStatSummaryLabel AllTicketsMostPopularLabel { get; set; }
+    public required SupportReportStatSummaryLabel OpenTicketsMostPopularLabel { get; set; }
+    public required int OpenTicketsCount { get; set; }
+    public required int AllTicketsCount { get; set; }
+    public required SupportReportStatSummaryChallengeSpec ChallengeSpecWithMostTickets { get; set; }
+}
+
+public sealed class SupportReportStatSummaryChallengeSpec
+{
+    public required string Id { get; set; }
+    public required string Name { get; set; }
+    public required int TicketCount { get; set; }
+}
+
+public sealed class SupportReportStatSummaryLabel
+{
+    public required string Label { get; set; }
+    public required int TicketCount { get; set; }
+}
+
 public class SupportReportRecord
 {
     public required int Key { get; set; }
@@ -42,6 +57,7 @@ public class SupportReportRecord
     public required SimpleEntity RequestedBy { get; set; }
     public required SimpleEntity Game { get; set; }
     public required SimpleEntity Challenge { get; set; }
+    public required string ChallengeSpecId { get; set; }
     public required IEnumerable<string> AttachmentUris { get; set; }
     public required IEnumerable<string> Labels { get; set; }
     public required string Summary { get; set; }

--- a/src/Gameboard.Api/Features/Reports/Queries/SupportReport/SupportReportService.cs
+++ b/src/Gameboard.Api/Features/Reports/Queries/SupportReport/SupportReportService.cs
@@ -12,6 +12,7 @@ namespace Gameboard.Api.Features.Reports;
 
 public interface ISupportReportService
 {
+    SupportReportStatSummary GetStatSummary(IEnumerable<SupportReportRecord> records);
     SupportReportTicketWindow GetTicketDateSupportWindow(DateTimeOffset ticketDate);
     Task<IEnumerable<SupportReportRecord>> QueryRecords(SupportReportParameters parameters);
 }
@@ -41,6 +42,81 @@ internal class SupportReportService : ISupportReportService
         _reportsService = reportsService;
         _ticketService = ticketService;
         _ticketStore = ticketStore;
+    }
+
+    public SupportReportStatSummary GetStatSummary(IEnumerable<SupportReportRecord> records)
+    {
+        if (records is null || !records.Any())
+        {
+            return new SupportReportStatSummary
+            {
+                AllTicketsCount = 0,
+                AllTicketsMostPopularLabel = null,
+                OpenTicketsCount = 0,
+                OpenTicketsMostPopularLabel = null,
+                ChallengeSpecWithMostTickets = null
+            };
+        }
+
+        var totalLabelCounts = new Dictionary<string, int>();
+        var openLabelCounts = new Dictionary<string, int>();
+        var openTicketCount = 0;
+        var challengeSpecMap = new Dictionary<string, SupportReportStatSummaryChallengeSpec>();
+
+        foreach (var record in records)
+        {
+            foreach (var label in record.Labels)
+            {
+                totalLabelCounts.EnsureKey(label, 0);
+                totalLabelCounts[label] += 1;
+
+                if (record.Status.ToLower() != "closed")
+                {
+                    openLabelCounts.EnsureKey(label, 0);
+                    openLabelCounts[label] += 1;
+                    openTicketCount += 1;
+                }
+            }
+
+            if (record.Challenge is not null && record.ChallengeSpecId.IsNotEmpty())
+            {
+                challengeSpecMap.EnsureKey(record.ChallengeSpecId, new SupportReportStatSummaryChallengeSpec
+                {
+                    Id = record.Challenge.Id,
+                    Name = record.Challenge.Name,
+                    TicketCount = 0
+                });
+
+                challengeSpecMap[record.ChallengeSpecId].TicketCount += 1;
+            }
+        }
+
+        var mostPopularLabel = totalLabelCounts
+            .Select(l => (KeyValuePair<string, int>?)l)
+            .OrderByDescending(k => k.Value.Value)
+            .FirstOrDefault();
+
+        var openMostPopularLabel = openLabelCounts
+            .Select(l => (KeyValuePair<string, int>?)l)
+            .OrderByDescending(k => k.Value.Value)
+            .FirstOrDefault();
+
+        return new SupportReportStatSummary
+        {
+            AllTicketsCount = records.Count(),
+            AllTicketsMostPopularLabel = mostPopularLabel is null ? null : new SupportReportStatSummaryLabel
+            {
+                Label = mostPopularLabel.Value.Key,
+                TicketCount = mostPopularLabel.Value.Value
+            },
+            OpenTicketsCount = openTicketCount,
+            OpenTicketsMostPopularLabel = openMostPopularLabel is null ? null : new SupportReportStatSummaryLabel
+            {
+                Label = openMostPopularLabel.Value.Key,
+                TicketCount = openMostPopularLabel.Value.Value
+            },
+            ChallengeSpecWithMostTickets = !challengeSpecMap.Any() ? null : challengeSpecMap.OrderByDescending(k => k.Value.TicketCount).First().Value
+        };
     }
 
     public async Task<IEnumerable<SupportReportRecord>> QueryRecords(SupportReportParameters parameters)
@@ -113,6 +189,7 @@ internal class SupportReportService : ISupportReportService
             RequestedBy = _mapper.Map<SimpleEntity>(t.Requester),
             Game = t.Player == null ? null : _mapper.Map<SimpleEntity>(t.Player.Game),
             Challenge = _mapper.Map<SimpleEntity>(t.Challenge),
+            ChallengeSpecId = t.Challenge?.SpecId,
             AttachmentUris = _jsonService.Deserialize<List<string>>(t.Attachments),
             Labels = _ticketService.TransformTicketLabels(t.Label),
             ActivityCount = t.Activity.Count()

--- a/src/Gameboard.Api/Features/Reports/Queries/SupportReport/SupportReportService.cs
+++ b/src/Gameboard.Api/Features/Reports/Queries/SupportReport/SupportReportService.cs
@@ -122,8 +122,11 @@ internal class SupportReportService : ISupportReportService
     public async Task<IEnumerable<SupportReportRecord>> QueryRecords(SupportReportParameters parameters)
     {
         // format parameters
-        DateTimeOffset? openedDateStart = parameters.OpenedDateStart.HasValue ? parameters.OpenedDateStart.Value.ToEndDate().ToUniversalTime() : null;
+        DateTimeOffset? openedDateStart = parameters.OpenedDateStart.HasValue ? parameters.OpenedDateStart.Value.ToUniversalTime() : null;
         DateTimeOffset? openedDateEnd = parameters.OpenedDateEnd.HasValue ? parameters.OpenedDateEnd.Value.ToEndDate().ToUniversalTime() : null;
+        DateTimeOffset? updatedDateStart = parameters.UpdatedDateStart.HasValue ? parameters.UpdatedDateStart.Value.ToUniversalTime() : null;
+        DateTimeOffset? updatedDateEnd = parameters.UpdatedDateEnd.HasValue ? parameters.UpdatedDateEnd.Value.ToEndDate().ToUniversalTime() : null;
+
         var labels = _reportsService.ParseMultiSelectCriteria(parameters.Labels);
         var statuses = _reportsService.ParseMultiSelectCriteria(parameters.Statuses);
 
@@ -152,6 +155,12 @@ internal class SupportReportService : ISupportReportService
         if (openedDateEnd != null)
             query = query
                 .Where(t => t.Created <= openedDateEnd);
+
+        if (updatedDateStart is not null)
+            query = query.Where(t => t.LastUpdated >= updatedDateStart);
+
+        if (updatedDateEnd is not null)
+            query = query.Where(t => t.LastUpdated <= updatedDateEnd);
 
         var rightNow = _now.Get();
         if (parameters.MinutesSinceOpen is not null)

--- a/src/Gameboard.Api/Features/Reports/ReportsController.cs
+++ b/src/Gameboard.Api/Features/Reports/ReportsController.cs
@@ -66,12 +66,12 @@ public class ReportsController : ControllerBase
         => await _mediator.Send(new PracticeModeReportPlayerModeSummaryQuery(id, isPractice, _actingUser));
 
     [HttpGet("support")]
-    public async Task<ReportResults<SupportReportRecord>> GetSupportReport([FromQuery] SupportReportParameters reportParams, [FromQuery] PagingArgs pagingArgs)
-        => await _mediator.Send(new SupportReportQuery(reportParams, pagingArgs, _actingUser));
+    public Task<ReportResults<SupportReportStatSummary, SupportReportRecord>> GetSupportReport([FromQuery] SupportReportParameters reportParams, [FromQuery] PagingArgs pagingArgs)
+        => _mediator.Send(new SupportReportQuery(reportParams, pagingArgs, _actingUser));
 
     [HttpGet("metaData")]
-    public async Task<ReportMetaData> GetReportMetaData([FromQuery] string reportKey)
-        => await _mediator.Send(new GetMetaDataQuery(reportKey, _actingUser));
+    public Task<ReportMetaData> GetReportMetaData([FromQuery] string reportKey)
+        => _mediator.Send(new GetMetaDataQuery(reportKey, _actingUser));
 
     [HttpGet("parameter/challenge-specs/{gameId?}")]
     public Task<IEnumerable<SimpleEntity>> GetChallengeSpecs(string gameId = null)

--- a/src/Gameboard.Api/Features/Scores/GameScoreQuery/GameScoreQuery.cs
+++ b/src/Gameboard.Api/Features/Scores/GameScoreQuery/GameScoreQuery.cs
@@ -15,7 +15,6 @@ public record GameScoreQuery(string GameId) : IRequest<GameScore>;
 
 internal sealed class GameScoreQueryHandler : IRequestHandler<GameScoreQuery, GameScore>
 {
-    private readonly IActingUserService _actingUserService;
     private readonly EntityExistsValidator<GameScoreQuery, Data.Game> _gameExists;
     private readonly INowService _nowService;
     private readonly IScoringService _scoringService;
@@ -25,7 +24,6 @@ internal sealed class GameScoreQueryHandler : IRequestHandler<GameScoreQuery, Ga
 
     public GameScoreQueryHandler
     (
-        IActingUserService actingUserService,
         EntityExistsValidator<GameScoreQuery, Data.Game> gameExists,
         INowService nowService,
         IScoringService scoringService,
@@ -34,7 +32,6 @@ internal sealed class GameScoreQueryHandler : IRequestHandler<GameScoreQuery, Ga
         IValidatorService<GameScoreQuery> validator
     )
     {
-        _actingUserService = actingUserService;
         _gameExists = gameExists.UseProperty(q => q.GameId);
         _userRoleAuthorizer = userRoleAuthorizer;
         _nowService = nowService;

--- a/src/Gameboard.Api/Features/Scores/ScoreChangedNotification.cs
+++ b/src/Gameboard.Api/Features/Scores/ScoreChangedNotification.cs
@@ -36,8 +36,8 @@ internal class ScoreChangedNotificationHandler : INotificationHandler<ScoreChang
     public async Task Handle(ScoreChangedNotification notification, CancellationToken cancellationToken)
     {
         // first to the legacy logic (which also includes updating the players table)
-        // we can drop this when we're confident in the new scoreboard and can move that logic
-        // into the new denormalized schema
+        // we can drop this when we're confident in the new scoreboard and reassess how we'll
+        // handle the Score/Rank/Time etc. in the Players table
         await DoLegacyRerank(notification.TeamId, cancellationToken);
         await _scoreDenormalizationService.DenormalizeTeam(notification.TeamId, cancellationToken);
     }
@@ -51,6 +51,7 @@ internal class ScoreChangedNotificationHandler : INotificationHandler<ScoreChang
                     .ThenInclude(b => b.ChallengeBonus)
                 .Include(c => c.AwardedManualBonuses)
             .Where(c => c.TeamId == teamId)
+            .Where(c => c.PlayerMode == PlayerMode.Competition)
             .ToArrayAsync(cancellationToken);
 
         var score = (int)challenges.Sum(c => c.Score);

--- a/src/Gameboard.Api/Features/Scores/ScoreDenormalizationService.cs
+++ b/src/Gameboard.Api/Features/Scores/ScoreDenormalizationService.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Gameboard.Api.Common.Services;
 using Gameboard.Api.Data;
 using Gameboard.Api.Features.Teams;
+using MediatR;
 using Microsoft.EntityFrameworkCore;
 
 namespace Gameboard.Api.Features.Scores;
@@ -15,7 +16,7 @@ public interface IScoreDenormalizationService
     Task DenormalizeTeam(string teamId, CancellationToken cancellationToken);
 }
 
-internal class ScoreDenormalizationService : IScoreDenormalizationService
+internal class ScoreDenormalizationService : IScoreDenormalizationService, INotificationHandler<TeamDeletedNotification>
 {
     private readonly INowService _nowService;
     private readonly IScoringService _scoringService;
@@ -57,6 +58,33 @@ internal class ScoreDenormalizationService : IScoreDenormalizationService
     {
         var teamScore = await _scoringService.GetTeamScore(teamId, cancellationToken);
         await DenormalizeTeam(teamScore, cancellationToken);
+    }
+
+    public async Task Handle(TeamDeletedNotification notification, CancellationToken cancellationToken)
+    {
+        // it's possible that a team being deleted may not appear in the DenormalizedTeamScores
+        // table yet, but if they do, we need to rerank the games they're associated with
+        // (and have to do it a bit weirdly because of schema nonsense)
+        var teamGames = await _store
+            .WithNoTracking<DenormalizedTeamScore>()
+            .Where(s => s.TeamId == notification.TeamId)
+            .Select(s => s.GameId)
+            .Distinct()
+            .ToArrayAsync(cancellationToken);
+
+        if (teamGames.Any())
+        {
+            // delete the dangling records
+            await _store
+                .WithNoTracking<DenormalizedTeamScore>()
+                .Where(s => s.TeamId == notification.TeamId)
+                .ExecuteDeleteAsync(cancellationToken);
+
+            // then rerank relevant games (there should be 1 at most,
+            // but no teams entity means we shouldn't assume)
+            foreach (var gameId in teamGames)
+                await RerankGame(gameId);
+        }
     }
 
     private async Task DenormalizeTeam(TeamScore team, CancellationToken cancellationToken)

--- a/src/Gameboard.Api/Features/Scores/ScoreDenormalizationService.cs
+++ b/src/Gameboard.Api/Features/Scores/ScoreDenormalizationService.cs
@@ -114,9 +114,7 @@ internal class ScoreDenormalizationService : IScoreDenormalizationService
         }));
 
         foreach (var team in teams)
-        {
             team.Rank = rankedTeams.ContainsKey(team.TeamId) ? rankedTeams[team.TeamId] : 0;
-        }
 
         await _store.SaveUpdateRange(teams);
     }

--- a/src/Gameboard.Api/Features/Scores/ScoringModels.cs
+++ b/src/Gameboard.Api/Features/Scores/ScoringModels.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using Gameboard.Api.Data;
 
 namespace Gameboard.Api.Features.Scores;
@@ -26,13 +27,20 @@ public sealed class GameScoringConfigChallengeSpec
     public required double CompletionScore { get; set; }
     public required IEnumerable<GameScoringConfigChallengeBonus> PossibleBonuses { get; set; }
     public required double MaxPossibleScore { get; set; }
+    public required string SupportKey { get; set; }
 }
 
+[JsonDerivedType(typeof(GameScoringChallengeBonusSolveRank), typeDiscriminator: "solveRank")]
 public class GameScoringConfigChallengeBonus
 {
     public required string Id { get; set; }
     public required string Description { get; set; }
     public required double PointValue { get; set; }
+}
+
+public sealed class GameScoringChallengeBonusSolveRank : GameScoringConfigChallengeBonus
+{
+    public required int SolveRank { get; set; }
 }
 
 public class GameScore

--- a/src/Gameboard.Api/Features/Scores/ScoringModels.cs
+++ b/src/Gameboard.Api/Features/Scores/ScoringModels.cs
@@ -55,6 +55,7 @@ public sealed class TeamScore
     public required IEnumerable<PlayerWithSponsor> Players { get; set; }
     public required bool IsAdvancedToNextRound { get; set; }
     public required Score OverallScore { get; set; }
+    public required int Rank { get; set; }
     public required double CumulativeTimeMs { get; set; }
     public required double? RemainingTimeMs { get; set; }
     public required IEnumerable<ManualTeamBonusViewModel> ManualBonuses { get; set; } = Array.Empty<ManualTeamBonusViewModel>();

--- a/src/Gameboard.Api/Features/Scores/ScoringModels.cs
+++ b/src/Gameboard.Api/Features/Scores/ScoringModels.cs
@@ -55,7 +55,6 @@ public sealed class TeamScore
     public required IEnumerable<PlayerWithSponsor> Players { get; set; }
     public required bool IsAdvancedToNextRound { get; set; }
     public required Score OverallScore { get; set; }
-    public required int Rank { get; set; }
     public required double CumulativeTimeMs { get; set; }
     public required double? RemainingTimeMs { get; set; }
     public required IEnumerable<ManualTeamBonusViewModel> ManualBonuses { get; set; } = Array.Empty<ManualTeamBonusViewModel>();

--- a/src/Gameboard.Api/Features/Scores/ScoringService.cs
+++ b/src/Gameboard.Api/Features/Scores/ScoringService.cs
@@ -1,6 +1,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -69,9 +70,7 @@ internal class ScoringService : IScoringService
                 var maxPossibleScore = (double)s.Points;
 
                 if (s.Bonuses.Any(b => b.PointValue > 0))
-                {
                     maxPossibleScore += s.Bonuses.OrderByDescending(b => b.PointValue).First().PointValue;
-                }
 
                 return new GameScoringConfigChallengeSpec
                 {
@@ -80,10 +79,23 @@ internal class ScoringService : IScoringService
                     Description = s.Description,
                     CompletionScore = s.Points,
                     PossibleBonuses = s.Bonuses
-                        .Select(b => _mapper.Map<GameScoringConfigChallengeBonus>(b))
+                        .Select(b =>
+                        {
+                            if (b is not ChallengeBonusCompleteSolveRank)
+                                throw new NotImplementedException("Can't resolve subclasee of ChallengeBonus for game score config.");
+
+                            return new GameScoringChallengeBonusSolveRank
+                            {
+                                Id = b.Id,
+                                Description = b.Description,
+                                PointValue = b.PointValue,
+                                SolveRank = (b as ChallengeBonusCompleteSolveRank).SolveRank
+                            };
+                        })
                         .OrderByDescending(b => b.PointValue)
                             .ThenBy(b => b.Description),
-                    MaxPossibleScore = maxPossibleScore
+                    MaxPossibleScore = maxPossibleScore,
+                    SupportKey = s.Tag
                 };
             }).
             OrderBy(config => config.Name)

--- a/src/Gameboard.Api/Features/Scores/ScoringService.cs
+++ b/src/Gameboard.Api/Features/Scores/ScoringService.cs
@@ -203,13 +203,6 @@ internal class ScoringService : IScoringService
         DateTimeOffset? teamSessionEnd = captain.SessionBegin > now && captain.SessionEnd < now ? captain.SessionEnd : null;
         var overallScore = CalculateScore(pointsFromChallenges, bonusPoints, manualTeamBonusPoints, manualChallengeBonusPoints);
 
-        // for now, try to borrow rank from the denormalized score table (we don't maintain it on any other table since it's
-        // derived information)
-        var denormalizedScore = await _store
-            .WithNoTracking<DenormalizedTeamScore>()
-            .Where(t => t.TeamId == teamId && t.GameId == game.Id)
-            .SingleOrDefaultAsync(cancellationToken);
-
         return new TeamScore
         {
             Team = new SimpleEntity { Id = captain.TeamId, Name = captain.ApprovedName },
@@ -235,7 +228,6 @@ internal class ScoringService : IScoringService
             }),
             IsAdvancedToNextRound = captain.Advanced,
             OverallScore = overallScore,
-            Rank = denormalizedScore is not null ? denormalizedScore.Rank : 0,
             CumulativeTimeMs = cumulativeTimeMs,
             RemainingTimeMs = teamSessionEnd is null || teamSessionEnd < now ? null : (teamSessionEnd.Value - _now.Get()).TotalMilliseconds,
             Challenges = challenges.Select

--- a/src/Gameboard.Api/Features/Scores/ScoringService.cs
+++ b/src/Gameboard.Api/Features/Scores/ScoringService.cs
@@ -203,6 +203,13 @@ internal class ScoringService : IScoringService
         DateTimeOffset? teamSessionEnd = captain.SessionBegin > now && captain.SessionEnd < now ? captain.SessionEnd : null;
         var overallScore = CalculateScore(pointsFromChallenges, bonusPoints, manualTeamBonusPoints, manualChallengeBonusPoints);
 
+        // for now, try to borrow rank from the denormalized score table (we don't maintain it on any other table since it's
+        // derived information)
+        var denormalizedScore = await _store
+            .WithNoTracking<DenormalizedTeamScore>()
+            .Where(t => t.TeamId == teamId && t.GameId == game.Id)
+            .SingleOrDefaultAsync(cancellationToken);
+
         return new TeamScore
         {
             Team = new SimpleEntity { Id = captain.TeamId, Name = captain.ApprovedName },
@@ -228,6 +235,7 @@ internal class ScoringService : IScoringService
             }),
             IsAdvancedToNextRound = captain.Advanced,
             OverallScore = overallScore,
+            Rank = denormalizedScore is not null ? denormalizedScore.Rank : 0,
             CumulativeTimeMs = cumulativeTimeMs,
             RemainingTimeMs = teamSessionEnd is null || teamSessionEnd < now ? null : (teamSessionEnd.Value - _now.Get()).TotalMilliseconds,
             Challenges = challenges.Select

--- a/src/Gameboard.Api/Features/Scores/ScoringService.cs
+++ b/src/Gameboard.Api/Features/Scores/ScoringService.cs
@@ -269,9 +269,7 @@ internal class ScoringService : IScoringService
         foreach (var team in ranked)
         {
             if (lastScore is null || team.OverallScore != lastScore.OverallScore || team.CumulativeTimeMs != lastScore.CumulativeTimeMs)
-            {
                 scoreRank += 1;
-            }
 
             retVal.Add(team.TeamId, scoreRank);
             lastScore = team;

--- a/src/Gameboard.Api/Features/Scores/TeamScoreQuery/TeamScoreQuery.cs
+++ b/src/Gameboard.Api/Features/Scores/TeamScoreQuery/TeamScoreQuery.cs
@@ -4,13 +4,11 @@ using System.Threading.Tasks;
 using Gameboard.Api.Common.Services;
 using Gameboard.Api.Data;
 using Gameboard.Api.Features.Games;
-using Gameboard.Api.Features.Games.Validators;
 using Gameboard.Api.Features.Teams;
 using Gameboard.Api.Structure.MediatR;
 using Gameboard.Api.Structure.MediatR.Authorizers;
 using Gameboard.Api.Structure.MediatR.Validators;
 using MediatR;
-using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
 
 namespace Gameboard.Api.Features.Scores;

--- a/src/Gameboard.Api/Features/Scores/UpdateTeamChallengeScore/UpdateTeamChallengeScore.cs
+++ b/src/Gameboard.Api/Features/Scores/UpdateTeamChallengeScore/UpdateTeamChallengeScore.cs
@@ -86,7 +86,12 @@ internal class UpdateTeamChallengeBaseScoreHandler : IRequestHandler<UpdateTeamC
             // if they have a full solve, compute their ordinal rank by time and award them the appropriate challenge bonus
             var availableBonuses = spec
                     .Bonuses
-                    .Where(bonus => !otherTeamChallenges.SelectMany(c => c.AwardedBonuses).Any(otherTeamBonus => otherTeamBonus.ChallengeBonusId == bonus.Id));
+                    .Where
+                    (
+                        bonus => !otherTeamChallenges
+                            .SelectMany(c => c.AwardedBonuses)
+                            .Any(otherTeamBonus => otherTeamBonus.ChallengeBonusId == bonus.Id)
+                    );
 
             if (availableBonuses.Any() && (availableBonuses.First() as ChallengeBonusCompleteSolveRank).SolveRank == otherTeamChallenges.Length + 1)
                 updateChallenge.AwardedBonuses.Add(new AwardedChallengeBonus

--- a/src/Gameboard.Api/Features/Teams/AdminTeamController.cs
+++ b/src/Gameboard.Api/Features/Teams/AdminTeamController.cs
@@ -1,0 +1,22 @@
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Gameboard.Api.Features.Teams;
+
+[Route("api/admin/team")]
+[Authorize]
+public class AdminTeamsController : ControllerBase
+{
+    private readonly IMediator _mediator;
+
+    public AdminTeamsController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    [HttpPut("session")]
+    public Task<AdminExtendTeamSessionResponse> ExtendTeamSessions([FromBody] AdminExtendTeamSessionRequest request)
+        => _mediator.Send(request);
+}

--- a/src/Gameboard.Api/Features/Teams/AdminTeamController.cs
+++ b/src/Gameboard.Api/Features/Teams/AdminTeamController.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
@@ -15,6 +17,10 @@ public class AdminTeamsController : ControllerBase
     {
         _mediator = mediator;
     }
+
+    [HttpGet("search")]
+    public Task<IEnumerable<Team>> SearchTeams([FromQuery] string ids)
+        => _mediator.Send(new GetTeamsQuery(ids.Split(",", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)));
 
     [HttpPut("session")]
     public Task<AdminExtendTeamSessionResponse> ExtendTeamSessions([FromBody] AdminExtendTeamSessionRequest request)

--- a/src/Gameboard.Api/Features/Teams/Requests/AdminExtendTeamSessions/AdminExtendTeamSession.cs
+++ b/src/Gameboard.Api/Features/Teams/Requests/AdminExtendTeamSessions/AdminExtendTeamSession.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Gameboard.Api.Common.Services;
+using Gameboard.Api.Structure.MediatR.Authorizers;
+using MediatR;
+
+namespace Gameboard.Api.Features.Teams;
+
+public record AdminExtendTeamSessionRequest(IEnumerable<string> TeamIds, double ExtensionDurationInMinutes) : IRequest<AdminExtendTeamSessionResponse>;
+public record AdminExtendTeamSessionResponse(IEnumerable<AdminExtendTeamSessionResponseTeam> Teams);
+public record AdminExtendTeamSessionResponseTeam(string Id, DateTimeOffset SessionEnd);
+
+internal class AdminExtendTeamSessionHandler : IRequestHandler<AdminExtendTeamSessionRequest, AdminExtendTeamSessionResponse>
+{
+    private readonly IActingUserService _actingUserService;
+    private readonly ITeamService _teamService;
+    private readonly UserRoleAuthorizer _userRoleAuthorizer;
+
+    public AdminExtendTeamSessionHandler
+    (
+        IActingUserService actingUserService,
+        ITeamService teamService,
+        UserRoleAuthorizer userRoleAuthorizer
+    )
+    {
+        _actingUserService = actingUserService;
+        _teamService = teamService;
+        _userRoleAuthorizer = userRoleAuthorizer;
+    }
+
+    public async Task<AdminExtendTeamSessionResponse> Handle(AdminExtendTeamSessionRequest request, CancellationToken cancellationToken)
+    {
+        _userRoleAuthorizer
+            .AllowRoles(UserRole.Admin, UserRole.Designer, UserRole.Director, UserRole.Observer, UserRole.Registrar, UserRole.Support)
+            .Authorize();
+
+        var teams = await _teamService.GetTeams(request.TeamIds);
+        var captains = new List<Api.Player>();
+        foreach (var team in teams)
+        {
+            captains.Add(await _teamService.ExtendSession(new ExtendTeamSessionRequest
+            {
+                Actor = _actingUserService.Get(),
+                NewSessionEnd = team.SessionEnd.ToUniversalTime().AddMinutes(request.ExtensionDurationInMinutes),
+                TeamId = team.TeamId
+            }, cancellationToken));
+        };
+
+        return new AdminExtendTeamSessionResponse
+        (
+            captains.Select(p => new AdminExtendTeamSessionResponseTeam(p.TeamId, p.SessionEnd.ToUniversalTime()))
+        );
+    }
+}

--- a/src/Gameboard.Api/Features/Teams/Requests/GetTeamEventHorizon/GetTeamEventHorizon.cs
+++ b/src/Gameboard.Api/Features/Teams/Requests/GetTeamEventHorizon/GetTeamEventHorizon.cs
@@ -190,6 +190,7 @@ internal class GetTeamEventHorizonHandler : IRequestHandler<GetTeamEventHorizonQ
         foreach (var challengeId in events.Keys)
         {
             Data.ChallengeEvent lastOnEvent = null;
+
             foreach (var gamespaceEvent in events[challengeId].OrderBy(e => e.Timestamp))
             {
                 if (gamespaceEvent.Type == ChallengeEventType.GamespaceOn || gamespaceEvent.Type == ChallengeEventType.Started)

--- a/src/Gameboard.Api/Features/Teams/Requests/GetTeamEventHorizon/GetTeamEventHorizon.cs
+++ b/src/Gameboard.Api/Features/Teams/Requests/GetTeamEventHorizon/GetTeamEventHorizon.cs
@@ -196,11 +196,13 @@ internal class GetTeamEventHorizonHandler : IRequestHandler<GetTeamEventHorizonQ
                     lastOnEvent = gamespaceEvent;
                 else if (gamespaceEvent.Type == ChallengeEventType.GamespaceOff)
                 {
+                    // it's technically possible for a challenge to have a gamespace off event but no on event.
+                    // if so, make the start time the challenge's start.
                     var lastOnTimestamp = lastOnEvent?.Timestamp ?? challengeStartEndTimes[challengeId].StartTime;
 
                     retVal.Add(new EventHorizonGamespaceOnOffEvent
                     {
-                        Id = lastOnEvent.Id,
+                        Id = lastOnEvent?.Id ?? gamespaceEvent.Id,
                         ChallengeId = challengeId,
                         Timestamp = lastOnTimestamp,
                         Type = EventHorizonEventType.GamespaceOnOff,

--- a/src/Gameboard.Api/Features/Teams/Requests/GetTeams.cs
+++ b/src/Gameboard.Api/Features/Teams/Requests/GetTeams.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Gameboard.Api.Structure.MediatR.Authorizers;
+using MediatR;
+
+namespace Gameboard.Api.Features.Teams;
+
+public record GetTeamsQuery(IEnumerable<string> TeamIds) : IRequest<IEnumerable<Team>>;
+
+internal class GetTeamsRequest : IRequestHandler<GetTeamsQuery, IEnumerable<Team>>
+{
+    private readonly ITeamService _teamService;
+    private readonly UserRoleAuthorizer _userRoleAuthorizer;
+
+    public GetTeamsRequest
+    (
+        ITeamService teamService,
+        UserRoleAuthorizer userRoleAuthorizer
+    )
+    {
+        _teamService = teamService;
+        _userRoleAuthorizer = userRoleAuthorizer;
+    }
+
+    public async Task<IEnumerable<Team>> Handle(GetTeamsQuery request, CancellationToken cancellationToken)
+    {
+        _userRoleAuthorizer
+            .AllowRoles(UserRole.Admin, UserRole.Director, UserRole.Observer, UserRole.Support, UserRole.Tester)
+            .Authorize();
+
+        return await _teamService.GetTeams(request.TeamIds);
+    }
+}

--- a/src/Gameboard.Api/Features/Teams/Requests/ResetTeamSesssion/ResetTeamSession.cs
+++ b/src/Gameboard.Api/Features/Teams/Requests/ResetTeamSesssion/ResetTeamSession.cs
@@ -77,13 +77,7 @@ internal class ResetTeamSessionHandler : IRequestHandler<ResetTeamSessionCommand
         // delete players from the team iff. requested
         if (request.UnenrollTeam)
         {
-            _logger.LogInformation($"Deleting player records for team {request.TeamId}");
-
-            // for now, we only raise the score changing event if we're keeping the team enrolled
-            // (need to do this in the opposite order if we're resetting)
-            // we need to do this _before_ deleting the team above
-            await _mediator.Publish(new ScoreChangedNotification(request.TeamId), cancellationToken);
-
+            _logger.LogInformation($"Deleting players/challenges/metadata for team {request.TeamId}");
             await _teamService.DeleteTeam(request.TeamId, new SimpleEntity { Id = request.ActingUser.Id, Name = request.ActingUser.ApprovedName }, cancellationToken);
 
             // also get rid of any external game artifacts if they have any

--- a/src/Gameboard.Api/Features/Teams/TeamController.cs
+++ b/src/Gameboard.Api/Features/Teams/TeamController.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Gameboard.Api.Common.Services;
@@ -31,6 +34,11 @@ public class TeamController : ControllerBase
     [HttpGet("{teamId}")]
     public async Task<Team> GetTeam(string teamId)
         => await _mediator.Send(new GetTeamQuery(teamId, _actingUserService.Get()));
+
+    // this is awkward - really, 
+    [HttpGet("search")]
+    public Task<IEnumerable<Team>> GetTeams([FromQuery] string teamIds)
+        => _mediator.Send(new GetTeamsQuery(teamIds.Split(",", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)));
 
     /// <summary>
     /// Extend or end a team's session. If no value is supplied for the SessionEnd property of the

--- a/src/Gameboard.Api/Features/Teams/TeamController.cs
+++ b/src/Gameboard.Api/Features/Teams/TeamController.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Gameboard.Api.Common.Services;

--- a/src/Gameboard.Api/Features/Teams/TeamController.cs
+++ b/src/Gameboard.Api/Features/Teams/TeamController.cs
@@ -34,10 +34,6 @@ public class TeamController : ControllerBase
     public async Task<Team> GetTeam(string teamId)
         => await _mediator.Send(new GetTeamQuery(teamId, _actingUserService.Get()));
 
-    [HttpGet("search")]
-    public Task<IEnumerable<Team>> SearchTeams([FromQuery] string ids)
-        => _mediator.Send(new GetTeamsQuery(ids.Split(",", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)));
-
     /// <summary>
     /// Extend or end a team's session. If no value is supplied for the SessionEnd property of the
     /// body, the session is ended. Otherwise, the session end date/time is updated to the requested 

--- a/src/Gameboard.Api/Features/Teams/TeamController.cs
+++ b/src/Gameboard.Api/Features/Teams/TeamController.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -35,10 +34,9 @@ public class TeamController : ControllerBase
     public async Task<Team> GetTeam(string teamId)
         => await _mediator.Send(new GetTeamQuery(teamId, _actingUserService.Get()));
 
-    // this is awkward - really, 
     [HttpGet("search")]
-    public Task<IEnumerable<Team>> GetTeams([FromQuery] string teamIds)
-        => _mediator.Send(new GetTeamsQuery(teamIds.Split(",", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)));
+    public Task<IEnumerable<Team>> SearchTeams([FromQuery] string ids)
+        => _mediator.Send(new GetTeamsQuery(ids.Split(",", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)));
 
     /// <summary>
     /// Extend or end a team's session. If no value is supplied for the SessionEnd property of the

--- a/src/Gameboard.Api/Features/Teams/TeamService.cs
+++ b/src/Gameboard.Api/Features/Teams/TeamService.cs
@@ -297,13 +297,9 @@ internal class TeamService : ITeamService
         var captains = players.Where(p => p.IsManager);
 
         if (captains.Count() == 1)
-        {
             return captains.First();
-        }
         else if (captains.Count() > 1)
-        {
             return captains.OrderBy(c => c.ApprovedName).First();
-        }
 
         return players.OrderBy(p => p.ApprovedName).First();
     }


### PR DESCRIPTION
Version 3.16.0 of Gameboard brings new features, bug fixes, and infrastructure/stability improvements.

# New features & Enhancements

- **Game/Challenge Feedback Configuration** has received a few usability tweaks. The placeholder for the field now shows a default configuration, allows you to paste it in as a starting point, and provides limited YAML validation for required fields. (#256)
- **Automatic Bonus Configuration** now also supports editing of an existing configuration rather than requiring you to upload a complete configuration in order to make changes. (#313)
- **Admin -> Challenges** now includes challenge submissions in its YAML output. Only challenges completed since the installation of Gameboard v3.14.0 will have this data available. It's still possible to request an audit of submitted answers from the game engine. (#345)
- The **Support Report** has received some minor updates:
  - It now displays a summary card with glanceable data. (#348)
  - It also has new date range filters for both creation and last update. (#315)
  - Its created/updated duration filters have been relabeled to clarify their effects.
- The **Game Editor** now displays a toast notification when challenge specs are synchronized with the game engine.
- **Admin Session Extension** functionality has been improved:
  - In addition to the existing extension functionality (which allows extension through entry of an ISO date), sessions can alternatively be extended via a duration (in minutes).
  - This feature also allows the explicit shortening of sessions via negative duration.
  - The session extension confirmation dialog now displays how a team/player's session will be modified (e.g. extended, shortened, ended) and its new end time (in Gameboard's local time) as a result of a session extension.
  - Multiple players/teams can now be simultaneously extended using the next "Extend" button in Admin -> Game -> Players.
- **"Started" events** on the team timeline are now clickable and cause a modal dialog which shows the team's exact start time.
- **The "Copy Support Code**" link button in the ticket view now displays a tooltip on mouseover which clarifies its function.

# Bug fixes

- Fixed a bug that could cause a 400-level error when a user attempted to reset their session (#195)
- Fixed a bug that could cause the helper text for "Cumulative Time" on the new scoreboard to appear at an incorrect position
- Fixed a bug that could cause the Game -> Deployment view to repeatedly issue requests to the game engine when such a request failed
- Fixed a bug that could cause accidental dismissal of the timeline dialog when opened from Support Tools
- Fixed a bug that could cause the admin-only new scoreboard to fail to load.
- Resolved an issue that could cause the new scoreboard to fail to rerank players after a score change.

# Infrastructure & Stability

- Improved the method by which gamespace on/off events are recorded (for challenge event logs and timeline)
- Improved the clarity of how score changes cause updates to the new scoreboard.
- Gameboard now logs the response from the external game host after its POST to the deployment endpoint.