### PR TITLE
v3.17.1

### DIFF
--- a/src/Gameboard.Api.Tests.Integration/Tests/Features/Teams/TeamControllerResetTests.cs
+++ b/src/Gameboard.Api.Tests.Integration/Tests/Features/Teams/TeamControllerResetTests.cs
@@ -1,0 +1,123 @@
+using System.Net;
+using Gameboard.Api.Features.Teams;
+using Microsoft.EntityFrameworkCore;
+
+namespace Gameboard.Api.Tests.Integration;
+
+public class TeamsControllerResetTests : IClassFixture<GameboardTestContext>
+{
+    private readonly GameboardTestContext _testContext;
+
+    public TeamsControllerResetTests(GameboardTestContext testContext)
+        => _testContext = testContext;
+
+    // these two tests should really be one with inline data, but then you have to specify all the args
+    // and that feels weird and i don't like it
+    [Theory, GbIntegrationAutoData]
+    public async Task Reset_WithNoUnenroll_ArchivesChallenges
+    (
+        string challengeSpecId,
+        string gameId,
+        string teamId,
+        IFixture fixture
+    )
+    {
+        // given a team with a challenge and a started session
+        await _testContext.WithDataState(state =>
+        {
+            state.Add<Data.ChallengeSpec>(fixture, spec => spec.Id = challengeSpecId);
+
+            state.Add<Data.Game>(fixture, g =>
+            {
+                g.Id = gameId;
+                g.Players = new List<Data.Player>
+                {
+                    state.Build<Data.Player>(fixture, p =>
+                    {
+                        p.SessionBegin = DateTimeOffset.UtcNow.AddHours(-1);
+                        p.SessionEnd = DateTimeOffset.UtcNow.AddHours(1);
+                        p.TeamId = teamId;
+                        p.Challenges = new List<Data.Challenge>
+                        {
+                            state.Build<Data.Challenge>(fixture, c =>
+                            {
+                                c.GameId = gameId;
+                                c.TeamId = teamId;
+                            })
+                        };
+                    })
+                };
+            });
+        });
+
+        // when the team's session is reset
+        var response = await _testContext
+            .CreateHttpClientWithAuthRole(UserRole.Registrar)
+            .PostAsync($"api/team/{teamId}/session", new ResetTeamSessionCommand(teamId, false, null).ToJsonBody());
+
+        // we expect a successful request and no challenges in the DB
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var teamChallengeCount = await _testContext
+            .GetDbContext()
+            .Challenges
+            .AsNoTracking()
+            .Where(c => c.TeamId == teamId)
+            .CountAsync();
+        teamChallengeCount.ShouldBe(0);
+    }
+
+    [Theory, GbIntegrationAutoData]
+    public async Task Reset_WithUnenroll_ArchivesChallenges
+    (
+        string challengeSpecId,
+        string gameId,
+        string teamId,
+        IFixture fixture
+    )
+    {
+        // given a team with a challenge and a started session
+        await _testContext.WithDataState(state =>
+        {
+            state.Add<Data.ChallengeSpec>(fixture, spec => spec.Id = challengeSpecId);
+
+            state.Add<Data.Game>(fixture, g =>
+            {
+                g.Id = gameId;
+                g.Players = new List<Data.Player>
+                {
+                    state.Build<Data.Player>(fixture, p =>
+                    {
+                        p.SessionBegin = DateTimeOffset.UtcNow.AddHours(-1);
+                        p.SessionEnd = DateTimeOffset.UtcNow.AddHours(1);
+                        p.TeamId = teamId;
+                        p.Challenges = new List<Data.Challenge>
+                        {
+                            state.Build<Data.Challenge>(fixture, c =>
+                            {
+                                c.GameId = gameId;
+                                c.TeamId = teamId;
+                            })
+                        };
+                    })
+                };
+            });
+        });
+
+        // when the team's session is reset
+        var response = await _testContext
+            .CreateHttpClientWithAuthRole(UserRole.Registrar)
+            .PostAsync($"api/team/{teamId}/session", new ResetTeamSessionCommand(teamId, true, null).ToJsonBody());
+
+        // we expect a successful request and no challenges in the DB
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var teamChallengeCount = await _testContext
+            .GetDbContext()
+            .Challenges
+            .AsNoTracking()
+            .Where(c => c.TeamId == teamId)
+            .CountAsync();
+        teamChallengeCount.ShouldBe(0);
+    }
+}

--- a/src/Gameboard.Api/Features/Player/Player.cs
+++ b/src/Gameboard.Api/Features/Player/Player.cs
@@ -37,7 +37,7 @@ public class Player
     public PlayerMode Mode { get; set; }
 
     public bool Advanced { get; set; }
-    public string AdvancedFromGameId { get; set; }
+    public SimpleEntity AdvancedFromGame { get; set; }
     public string AdvancedFromPlayerId { get; set; }
     public string AdvancedFromTeamId { get; set; }
     public double? AdvancedWithScore { get; set; }

--- a/src/Gameboard.Api/Features/Player/PlayerService.cs
+++ b/src/Gameboard.Api/Features/Player/PlayerService.cs
@@ -361,6 +361,7 @@ public class PlayerService
         var q = PlayerStore.List()
             .Include(p => p.User)
             .Include(p => p.Sponsor)
+            .Include(p => p.AdvancedFromGame)
             .AsNoTracking();
 
         if (model.WantsMode)

--- a/src/Gameboard.Api/Features/Scores/ScoringService.cs
+++ b/src/Gameboard.Api/Features/Scores/ScoringService.cs
@@ -255,6 +255,7 @@ internal class ScoringService : IScoringService
                     return BuildTeamScoreChallenge(c, spec, unawardedBonuses);
                 }
             )
+            .Where(c => c is not null)
         };
     }
 

--- a/src/Gameboard.Api/Features/Teams/Notifications/TeamDeletedNotification.cs
+++ b/src/Gameboard.Api/Features/Teams/Notifications/TeamDeletedNotification.cs
@@ -29,6 +29,9 @@ internal sealed class TeamDeletedHandler : INotificationHandler<TeamDeletedNotif
 
     public async Task Handle(TeamDeletedNotification notification, CancellationToken cancellationToken)
     {
+        // under current behavior, a team being deleted should never have challenges because their session
+        // must first be reset. but just in case, archive any remaining challenges (which sends the
+        // "completed" notification to game engines).
         await _challengeService.ArchiveTeamChallenges(notification.TeamId);
         await _externalGameService.DeleteTeamExternalData(cancellationToken, notification.TeamId);
         await _scoreDenormalizer.DenormalizeGame(notification.GameId, cancellationToken);

--- a/src/Gameboard.Api/Features/Teams/Notifications/TeamSessionResetNotification.cs
+++ b/src/Gameboard.Api/Features/Teams/Notifications/TeamSessionResetNotification.cs
@@ -11,17 +11,20 @@ public record TeamSessionResetNotification(string GameId, string TeamId) : INoti
 
 internal class TeamSessionResetHandler : INotificationHandler<TeamSessionResetNotification>
 {
+    private readonly ChallengeService _challengeService;
     private readonly IExternalGameService _externalGameService;
     private readonly GameService _gameService;
     private readonly IScoreDenormalizationService _scoreDenormalizationService;
 
     public TeamSessionResetHandler
     (
+        ChallengeService challengeService,
         IExternalGameService externalGameService,
         GameService gameService,
         IScoreDenormalizationService scoreDenormalizationService
     )
     {
+        _challengeService = challengeService;
         _externalGameService = externalGameService;
         _gameService = gameService;
         _scoreDenormalizationService = scoreDenormalizationService;
@@ -29,6 +32,9 @@ internal class TeamSessionResetHandler : INotificationHandler<TeamSessionResetNo
 
     public async Task Handle(TeamSessionResetNotification notification, CancellationToken cancellationToken)
     {
+        // archive challenges
+        await _challengeService.ArchiveTeamChallenges(notification.TeamId);
+
         // delete data for any external games
         await _externalGameService.DeleteTeamExternalData(cancellationToken, notification.TeamId);
 

--- a/src/Gameboard.Api/Features/Teams/Requests/ResetTeamSesssion/ResetTeamSessionCommandValidator.cs
+++ b/src/Gameboard.Api/Features/Teams/Requests/ResetTeamSesssion/ResetTeamSessionCommandValidator.cs
@@ -8,7 +8,6 @@ using Gameboard.Api.Features.Teams;
 using Gameboard.Api.Structure.MediatR;
 using Gameboard.Api.Structure.MediatR.Authorizers;
 using Gameboard.Api.Structure.MediatR.Validators;
-using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 
 namespace Gameboard.Api.Features.Player;
@@ -51,7 +50,15 @@ internal class ResetSessionCommandValidator : IGameboardRequestValidator<ResetTe
         // users with a correct role can do this, but those without can only do it if they're on the
         // team being reset AND if the game allows reset AND if no players on the team have
         // started a session
-        _userRoleAuthorizer.AllowRoles(UserRole.Admin, UserRole.Designer, UserRole.Tester, UserRole.Support);
+        _userRoleAuthorizer.AllowRoles
+        (
+            UserRole.Admin,
+            UserRole.Designer,
+            UserRole.Registrar,
+            UserRole.Support,
+            UserRole.Tester
+        );
+
         if (!_userRoleAuthorizer.WouldAuthorize())
         {
             if (!players.Any(p => p.UserId == request.ActingUser.Id))


### PR DESCRIPTION
Version 3.17.1 of Gameboard includes enhancements, bug fixes, and improvements to stability.

# Enhancements

- In addition to adding new games by uploading a file containing a YAML array of games, you can now create a single new game by pasting its YAML into a dialog available in the Games tab of Admin. Text describing the dropzone's functionality has been clarified (addresses #160).
- It is now possible to remove a player from the team to be enrolled in the admin "Add Team" dialog.
- Players who were advanced from a previous game now show a label in Game -> Players -> Admin's "collapsed" player card with the name of the game from which they advanced.

# Bug fixes

- Resolved an issue that prevented correct cleanup of gamespaces upon team unenroll.
- Resolved an issue that caused some links from Admin -> Overview's new modals to render incorrectly.
- Resolved an issue that caused avatars to fail to render in some contexts.

# Stability

- Integration test coverage has been enhanced for team session reset.