### PR TITLE
v3.18.1

### DIFF
--- a/src/Gameboard.Api.Tests.Unit/Tests/Features/Player/PlayerServiceTestHelpers.cs
+++ b/src/Gameboard.Api.Tests.Unit/Tests/Features/Player/PlayerServiceTestHelpers.cs
@@ -4,6 +4,7 @@ using Gameboard.Api.Data;
 using Gameboard.Api.Data.Abstractions;
 using Gameboard.Api.Features.Games;
 using Gameboard.Api.Features.Practice;
+using Gameboard.Api.Features.Scores;
 using Gameboard.Api.Features.Teams;
 using Gameboard.Api.Services;
 using MediatR;
@@ -29,6 +30,7 @@ internal static class PlayerServiceTestHelpers
         INowService? now = null,
         IPlayerStore? playerStore = null,
         IPracticeService? practiceService = null,
+        IScoringService? scoringService = null,
         IStore? store = null,
         ISyncStartGameService? syncStartGameService = null,
         ITeamService? teamService = null
@@ -48,6 +50,7 @@ internal static class PlayerServiceTestHelpers
             now ?? A.Fake<INowService>(),
             playerStore ?? A.Fake<IPlayerStore>(),
             practiceService ?? A.Fake<IPracticeService>(),
+            scoringService ?? A.Fake<IScoringService>(),
             store ?? A.Fake<IStore>(),
             syncStartGameService ?? A.Fake<ISyncStartGameService>(),
             teamService ?? A.Fake<ITeamService>()

--- a/src/Gameboard.Api/Features/Player/PlayerService.cs
+++ b/src/Gameboard.Api/Features/Player/PlayerService.cs
@@ -698,7 +698,7 @@ public class PlayerService
                     AdvancedFromGameId = player.GameId,
                     AdvancedFromPlayerId = player.Id,
                     AdvancedFromTeamId = player.TeamId,
-                    AdvancedWithScore = model.WithScores ? player.Score : null,
+                    AdvancedWithScore = model.WithScores ? teamScore.OverallScore.TotalScore : null,
                     ApprovedName = player.ApprovedName,
                     Name = player.Name,
                     SponsorId = player.SponsorId,

--- a/src/Gameboard.Api/Features/Player/PlayerService.cs
+++ b/src/Gameboard.Api/Features/Player/PlayerService.cs
@@ -13,6 +13,7 @@ using Gameboard.Api.Data.Abstractions;
 using Gameboard.Api.Features.Games;
 using Gameboard.Api.Features.Player;
 using Gameboard.Api.Features.Practice;
+using Gameboard.Api.Features.Scores;
 using Gameboard.Api.Features.Sponsors;
 using Gameboard.Api.Features.Teams;
 using MediatR;
@@ -32,6 +33,7 @@ public class PlayerService
     private readonly IMediator _mediator;
     private readonly INowService _now;
     private readonly IPracticeService _practiceService;
+    private readonly IScoringService _scores;
     private readonly IStore _store;
     private readonly ISyncStartGameService _syncStartGameService;
     private readonly ITeamService _teamService;
@@ -56,6 +58,7 @@ public class PlayerService
         INowService now,
         IPlayerStore playerStore,
         IPracticeService practiceService,
+        IScoringService scores,
         IStore store,
         ISyncStartGameService syncStartGameService,
         ITeamService teamService
@@ -75,6 +78,7 @@ public class PlayerService
         LocalCache = memCache;
         _mapper = mapper;
         PlayerStore = playerStore;
+        _scores = scores;
         _store = store;
         _syncStartGameService = syncStartGameService;
         _teamService = teamService;
@@ -679,10 +683,13 @@ public class PlayerService
         foreach (var team in teams)
         {
             string newId = _guids.GetGuid();
+            // compute complete score, including bonuses
+            var teamScore = await _scores.GetTeamScore(team.Key, CancellationToken.None);
 
             foreach (var player in team)
             {
                 player.Advanced = true;
+
                 var newPlayer = new Data.Player
                 {
                     TeamId = newId,
@@ -696,7 +703,7 @@ public class PlayerService
                     Name = player.Name,
                     SponsorId = player.SponsorId,
                     Role = player.Role,
-                    Score = model.WithScores ? player.Score : 0
+                    Score = model.WithScores ? (int)Math.Floor(teamScore.OverallScore.TotalScore) : 0
                 };
 
                 enrollments.Add(newPlayer);


### PR DESCRIPTION
Gameboard version 3.18.1 includes two minor bug fixes.

- Fixed an issue that caused a team's "Advanced" score not to include team-level manual bonuses.
- Fixed an issue that made it impossible to add team-level manual bonuses to a team until they'd started a challenge.