### PR TITLE
v3.19.0

### DIFF
--- a/src/Gameboard.Api/Common/CommonModels.cs
+++ b/src/Gameboard.Api/Common/CommonModels.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq.Expressions;
 
 namespace Gameboard.Api.Common;
 
@@ -52,4 +53,10 @@ public sealed class SimpleEntity
 {
     public string Id { get; set; }
     public string Name { get; set; }
+}
+
+public enum SortDirection
+{
+    Asc,
+    Desc
 }

--- a/src/Gameboard.Api/Features/ChallengeSpec/ChallengeSpecService.cs
+++ b/src/Gameboard.Api/Features/ChallengeSpec/ChallengeSpecService.cs
@@ -76,7 +76,7 @@ public class ChallengeSpecService : _Service
                     specSlug = $"{specSlug}-{nowish.Year}{nowish.Month}{nowish.Day}{nowish.Millisecond}";
 
                     if (!gameTags.Any(s => s == specSlug))
-                        entity.Tag = specSlug
+                        entity.Tag = specSlug;
 
                     // look, you can't win them all.
                 }

--- a/src/Gameboard.Api/Features/Game/External/Services/ExternalGameHostService.cs
+++ b/src/Gameboard.Api/Features/Game/External/Services/ExternalGameHostService.cs
@@ -211,7 +211,7 @@ internal class ExternalGameHostService : IExternalGameHostService
             });
         }
 
-        var gameId = teamData.Values.SelectMany(p => p.Select(thing => thing.GameId)).Single();
+        var gameId = teamData.Values.SelectMany(p => p.Select(thing => thing.GameId)).Distinct().Single();
         var game = await _store
             .WithNoTracking<Data.Game>()
             .Where(g => g.Id == gameId)

--- a/src/Gameboard.Api/Features/Game/External/Services/ExternalGameService.cs
+++ b/src/Gameboard.Api/Features/Game/External/Services/ExternalGameService.cs
@@ -91,6 +91,9 @@ internal class ExternalGameService : IExternalGameService,
         var teamDeployStatuses = externalGameTeamsData
             .ToDictionary(t => t.TeamId, t => t.DeployStatus);
 
+        foreach (var teamId in teamIds.Where(tId => !teamDeployStatuses.ContainsKey(tId)))
+            teamDeployStatuses.Add(teamId, ExternalGameDeployStatus.NotStarted);
+
         // get challenges separately because of SpecId nonsense
         // group by TeamId for quicker lookups
         var teamChallenges = await _store
@@ -283,6 +286,9 @@ internal class ExternalGameService : IExternalGameService,
 
     private ExternalGameDeployStatus ResolveOverallDeployStatus(IEnumerable<ExternalGameDeployStatus> teamStatuses)
     {
+        if (!teamStatuses.Any())
+            return ExternalGameDeployStatus.NotStarted;
+
         if (teamStatuses.All(s => s == ExternalGameDeployStatus.Deployed))
             return ExternalGameDeployStatus.Deployed;
 

--- a/src/Gameboard.Api/Features/Game/ResourceDeployment/GameResourcesDeployService.cs
+++ b/src/Gameboard.Api/Features/Game/ResourceDeployment/GameResourcesDeployService.cs
@@ -85,6 +85,7 @@ internal class GameResourcesDeployService : IGameResourcesDeployService
                 .Include(p => p.Game)
             .Where(p => teamIds.Contains(p.TeamId))
             .Select(p => new SimpleEntity { Id = p.GameId, Name = p.Game.Name })
+            .Distinct()
             .SingleAsync(cancellationToken);
 
         var request = new GameResourcesDeployRequest

--- a/src/Gameboard.Api/Features/Game/ResourceDeployment/GameResourcesDeployService.cs
+++ b/src/Gameboard.Api/Features/Game/ResourceDeployment/GameResourcesDeployService.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using AutoMapper;
+using AutoMapper.Configuration.Annotations;
 using Gameboard.Api.Common.Services;
 using Gameboard.Api.Data;
 using Gameboard.Api.Features.Challenges;

--- a/src/Gameboard.Api/Features/Reports/Extensions/IQueryableExtensions.cs
+++ b/src/Gameboard.Api/Features/Reports/Extensions/IQueryableExtensions.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Gameboard.Api.Features.Reports;
+
+public static class ReportsIQueryableExtensions
+{
+    public static IOrderedEnumerable<TSort> Sort<TSort, TKey>(this IEnumerable<TSort> enumerable, Func<TSort, TKey> orderBy, SortDirection sortDirection = SortDirection.Asc)
+    {
+        if (sortDirection == SortDirection.Asc)
+            return enumerable.OrderBy(orderBy);
+
+        return enumerable.OrderByDescending(orderBy);
+    }
+}

--- a/src/Gameboard.Api/Features/Reports/Extensions/IQueryableExtensions.cs
+++ b/src/Gameboard.Api/Features/Reports/Extensions/IQueryableExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 
 namespace Gameboard.Api.Features.Reports;
 
@@ -12,5 +13,13 @@ public static class ReportsIQueryableExtensions
             return enumerable.OrderBy(orderBy);
 
         return enumerable.OrderByDescending(orderBy);
+    }
+
+    public static IOrderedQueryable<TSort> Sort<TSort, TKey>(this IOrderedQueryable<TSort> query, Expression<Func<TSort, TKey>> orderBy, SortDirection sortDirection = SortDirection.Asc)
+    {
+        if (sortDirection == SortDirection.Asc)
+            return query.OrderBy(orderBy);
+
+        return query.OrderByDescending(orderBy);
     }
 }

--- a/src/Gameboard.Api/Features/Reports/Queries/ChallengesReport/ChallengesReportModels.cs
+++ b/src/Gameboard.Api/Features/Reports/Queries/ChallengesReport/ChallengesReportModels.cs
@@ -11,6 +11,8 @@ public sealed class ChallengesReportParameters
     public required string Games { get; set; }
     public required string Seasons { get; set; }
     public required string Series { get; set; }
+    public string Sort { get; set; }
+    public SortDirection SortDirection { get; set; }
     public required string Tracks { get; set; }
 }
 

--- a/src/Gameboard.Api/Features/Reports/Queries/EnrollmentReport/EnrollmentReportModels.cs
+++ b/src/Gameboard.Api/Features/Reports/Queries/EnrollmentReport/EnrollmentReportModels.cs
@@ -12,6 +12,8 @@ public class EnrollmentReportParameters
     public string Series { get; set; }
     public string Sponsors { get; set; }
     public string Tracks { get; set; }
+    public string Sort { get; set; }
+    public SortDirection SortDirection { get; set; }
 }
 
 public class EnrollmentReportRecord
@@ -24,6 +26,7 @@ public class EnrollmentReportRecord
 
     // performance data
     public required IEnumerable<EnrollmentReportChallengeViewModel> Challenges { get; set; }
+    public required int ChallengeCount { get; set; }
     public required int ChallengesPartiallySolvedCount { get; set; }
     public required int ChallengesCompletelySolvedCount { get; set; }
     public required double Score { get; set; }
@@ -33,6 +36,7 @@ public class EnrollmentReportByGameRecord
 {
     public required EnrollmentReportByGameGame Game { get; set; }
     public required int PlayerCount { get; set; }
+    public required int SponsorCount { get; set; }
     public required IEnumerable<EnrollmentReportByGameSponsor> Sponsors { get; set; }
     public required EnrollmentReportByGameSponsor TopSponsor { get; set; }
 }

--- a/src/Gameboard.Api/Features/Reports/Queries/PlayersReport/PlayersReportModels.cs
+++ b/src/Gameboard.Api/Features/Reports/Queries/PlayersReport/PlayersReportModels.cs
@@ -14,6 +14,8 @@ public sealed class PlayersReportParameters
     public string Series { get; set; }
     public string Sponsors { get; set; }
     public string Tracks { get; set; }
+    public string Sort { get; set; }
+    public SortDirection SortDirection { get; set; }
 }
 
 public sealed class PlayersReportRecord

--- a/src/Gameboard.Api/Features/Reports/Queries/PracticeMode/PracticeModeReportModels.cs
+++ b/src/Gameboard.Api/Features/Reports/Queries/PracticeMode/PracticeModeReportModels.cs
@@ -41,6 +41,9 @@ public sealed class PracticeModeReportParameters
     public string Tracks { get; set; }
     public string Sponsors { get; set; }
     public string Grouping { get; set; }
+
+    public string Sort { get; set; }
+    public SortDirection SortDirection { get; set; }
 }
 
 public sealed class PracticeModeByUserReportRecord : IPracticeModeReportRecord

--- a/src/Gameboard.Api/Features/Reports/Queries/SupportReport/SupportReportModels.cs
+++ b/src/Gameboard.Api/Features/Reports/Queries/SupportReport/SupportReportModels.cs
@@ -22,6 +22,8 @@ public class SupportReportParameters
     public DateTimeOffset? UpdatedDateStart { get; set; }
     public DateTimeOffset? UpdatedDateEnd { get; set; }
     public SupportReportTicketWindow? OpenedWindow { get; set; }
+    public string Sort { get; set; }
+    public SortDirection SortDirection { get; set; }
     public string Statuses { get; set; }
 }
 

--- a/src/Gameboard.Api/Features/Reports/ReportsService.cs
+++ b/src/Gameboard.Api/Features/Reports/ReportsService.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
-using AutoMapper;
 using Gameboard.Api.Common.Services;
 using Gameboard.Api.Data;
 using Gameboard.Api.Features.Teams;
@@ -34,7 +33,6 @@ public class ReportsService : IReportsService
 {
     private static readonly string MULTI_SELECT_DELIMITER = ",";
 
-    private readonly IMapper _mapper;
     private readonly INowService _now;
     private readonly IPagingService _paging;
     private readonly IStore _store;
@@ -42,14 +40,12 @@ public class ReportsService : IReportsService
 
     public ReportsService
     (
-        IMapper mapper,
         INowService now,
         IPagingService paging,
         IStore store,
         ITeamService teamService
     )
     {
-        _mapper = mapper;
         _now = now;
         _paging = paging;
         _store = store;

--- a/src/Gameboard.Api/Features/Teams/Notifications/TeamSessionStartedNotification.cs
+++ b/src/Gameboard.Api/Features/Teams/Notifications/TeamSessionStartedNotification.cs
@@ -1,0 +1,5 @@
+using MediatR;
+
+namespace Gameboard.Api.Features.Teams;
+
+public sealed record TeamSessionStartedNotification(string TeamId, CalculatedSessionWindow Session) : INotification;


### PR DESCRIPTION
Version 3.19.0 of Gameboard contains new features, enhancements, architectural optimizations, and bug fixes.

# New features

- Gameboard now supports configuration of multiple hosts for external games (resolves #410).
   - Hosts can be added, edited, or deleted from the Game Editor screen
   - Hosts can be reused across games 
   - External hosts currently only support `x-api-key` header authentication
 - New report: Site Usage (resolves #311)
   - Gives a high-level overview of user activity in the app, optionally constrained by sponsor and date range
   - This report is not exportable, as it's really a more general and digestible view of data contained in the Challenges report.
   - Where applicable, each statistic also has a modal view which gives greater detail about the data represented (e.g. active players, challenges attempted, etc.)
- A button has been added to each ticket activity entry which allows one-click copying of the text (resolves #433)
- Alpha-level support has been added for admin-level manual deployment of game resources
  - Admins can predeploy all challenges for any enrolled player with a default expiration time determined by the game engine.  Gamespace expiration times are adjusted to the desired session length when the player's session begins.
  - Gameboard's **Admin** -> **Challenges** tab will correctly represent these challenges as predeployed, but it does not currently display this information elsewhere. Usability refinements will be added in a future release.
- Alpha support has been added for simple integration between Gameboard and Mattermost's "bot" API. Related UI changes, expanded configuration, and more flexibility will come to this feature over time.
 
# Enhancements

- Updates to Reports
  - The new Reporting area has been promoted from beta :tada:
  - All reports developed for this area are now sortable. To sort a report, click any of its blue headers. Click again to sort by the same field descending (rather than ascending), and click a third time to remove the sort.
  - Note that sorting applies only to the report view displayed in Gameboard. To sort a CSV export, we recommend the use of a compatible CSV editor (e.g. Excel, Numbers, Google Sheets, etc.)
  - Reports formerly available in Admin are now available in the new Reports area under the "Legacy" label. These reports have been marked as deprecated and are no longer actively in development. As we develop new reports, we will remove corresponding legacy ones. 
- The "unattempted [challenges]" label in the new scoreboard has been changed to read "remaining" for clarity.
- A team manager is now called "Captain" in Gameboard.
- The user experience of team invite generation has been improved slightly.
- Many "loading" animations in Gameboard now have descriptive text about the loading process (e.g. "Loading the game...")
- Additional loading animations have been added for certain longer-running actions (e.g. player enrollment)
- The Deployment view for external games now shows each team's assigned remote host if it has one.
- Challenge consoles now receive a default name if one isn't specified by the developer.
- Challenges added to a game using the game editor will now receive a default support code.

# Architecture & Stability

- Gameboard's game launch and resource deployment pipeline has been revamped to improve its stability, performance, and maintainability.  
- The reporting module's SCSS has been refactored for maintainability.

# Bug fixes

- Options in the "Games" filter in the Reports module now sort alphabetically.
- Resolved an issue that caused Practice Area certificates to fail to render in some cases.
- Resolved an issue that caused the nav bar to fail to properly "sticky" to the top of the window
- Resolved an issue that caused subscriptions to the scoreboard's feed to fail to dispose when navigating away from it.
- Resolved an issue that prevented admins from adding team-level manual bonuses for teams who had not started a session
- Resolved an issue that could cause practice challenges to fail to launch if in a game configured with no attempt maximum.