### PR TITLE
v3.19.1

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,0 @@
-{
-    "recommendations": [
-        "ms-azuretools.vscode-docker",
-        "ms-dotnettools.csharp",
-        "ms-dotnettools.csdevkit"
-    ]
-}

--- a/.vscode/gameboard.code-snippets
+++ b/.vscode/gameboard.code-snippets
@@ -1,0 +1,50 @@
+{
+	// see https://code.visualstudio.com/docs/editor/userdefinedsnippets
+	"Create Gameboard Unit Test Suite": {
+		"scope": "csharp",
+		"description": "Create a Gameboard unit test suite",
+		"prefix": "test-suite-unit",
+		"body": [
+			"namespace Gameboard.Api.Tests.Unit;",
+			"",
+			"public class ${TM_FILENAME/\\.cs//g}",
+			"{",
+			"\t$0",
+			"}"
+		]
+	},
+	"Create Gameboard Unit Test": {
+		"scope": "csharp",
+		"description": "Start a new Gameboard unit test",
+		"prefix": "test-unit",
+		"isFileTemplate": true,
+		"body": [
+			"[${0:Theory}, ${1:GameboardAutoData}]",
+			"public async Task ${TM_FILENAME/Tests\\.cs//g}_$2_$3(IFixture fixture)",
+			"{",
+			"\t\/\/ given",
+			"\t$4",
+			"\t\/\/ when",
+			"\t\/\/ var sut = new ${TM_FILENAME/Tests\\.cs//g}(...)",
+			"",
+			"\t\/\/ then",
+			"}"
+		]
+	// },
+	"Create Gameboard Integration Test Suite": {
+		"scope": "csharp",
+		"description": "Create a Gameboard integration test suite",
+		"prefix": "test-suite-int",
+		"body": [
+			"namespace Gameboard.Api.Tests.Integration;",
+			"",
+			"public class ${0:Some}ControllerTests : IClassFixture<GameboardTestContext>",
+			"{",
+			"\tprivate readonly GameboardTestContext _testContext;",
+			"",
+			"\tpublic ${0:Some}ControllerTests(GameboardTestContext testContext",
+			"\t\t=> _testContext = testContext;",
+			"}"
+		]
+	}
+}

--- a/src/Gameboard.Api.Tests.Integration/Tests/Features/Games/GameControllerTests.cs
+++ b/src/Gameboard.Api.Tests.Integration/Tests/Features/Games/GameControllerTests.cs
@@ -13,6 +13,7 @@ public class GameControllerTests : IClassFixture<GameboardTestContext>
     public async Task GameController_Create_ReturnsGame()
     {
         // arrange
+
         var game = new NewGame()
         {
             Name = "Test game",
@@ -31,7 +32,7 @@ public class GameControllerTests : IClassFixture<GameboardTestContext>
         var responseGame = await _testContext
             .CreateHttpClientWithAuthRole(UserRole.Designer)
             .PostAsync("/api/game", game.ToJsonBody())
-            .WithContentDeserializedAs<Api.Data.Game>();
+            .WithContentDeserializedAs<Data.Game>();
 
         // assert
         responseGame?.Name.ShouldBe(game.Name);

--- a/src/Gameboard.Api/Data/GameboardDbContext.cs
+++ b/src/Gameboard.Api/Data/GameboardDbContext.cs
@@ -271,6 +271,9 @@ public class GameboardDbContext : DbContext
             b.Property(p => p.InviteCode).HasMaxLength(40);
             b.Property(p => p.AdvancedFromTeamId).HasStandardGuidLength();
 
+            // performance-oriented indices
+            b.HasIndex(p => new { p.UserId, p.TeamId });
+
             // nav properties
             b.HasOne(p => p.User).WithMany(u => u.Enrollments).OnDelete(DeleteBehavior.Cascade);
             b

--- a/src/Gameboard.Api/Features/Challenge/Services/ChallengeService.cs
+++ b/src/Gameboard.Api/Features/Challenge/Services/ChallengeService.cs
@@ -657,11 +657,10 @@ public partial class ChallengeService : _Service
         var teamIds = teamChallengeIds.Keys;
 
         var userTeamIds = await _store
-            .WithNoTracking<Data.Challenge>()
-            .Include(c => c.Player)
-            .Where(c => c.Player.UserId != null && c.Player.UserId != string.Empty)
-            .Where(c => teamIds.Contains(c.TeamId))
-            .Select(c => new { c.Player.UserId, c.TeamId })
+            .WithNoTracking<Data.Player>()
+            .Where(p => p.UserId != null && p.UserId != string.Empty)
+            .Where(p => teamIds.Contains(p.TeamId))
+            .Select(p => new { p.UserId, p.TeamId })
             .GroupBy(p => p.UserId)
             .ToDictionaryAsync(gr => gr.Key, gr => gr.Select(thing => thing.TeamId).Distinct(), cancellationToken);
 

--- a/src/Gameboard.Api/Features/Challenge/Services/ChallengeService.cs
+++ b/src/Gameboard.Api/Features/Challenge/Services/ChallengeService.cs
@@ -650,11 +650,7 @@ public partial class ChallengeService : _Service
     public async Task<ChallengeIdUserIdMap> GetChallengeUserMaps(IQueryable<Data.Challenge> query, CancellationToken cancellationToken)
     {
         var teamChallengeIds = await query
-            .Select(c => new
-            {
-                c.Id,
-                c.TeamId
-            })
+            .Select(c => new { c.Id, c.TeamId })
             .GroupBy(c => c.TeamId)
             .ToDictionaryAsync(gr => gr.Key, gr => gr.Select(c => c.Id).ToArray(), cancellationToken);
 
@@ -670,7 +666,8 @@ public partial class ChallengeService : _Service
             .ToDictionaryAsync(gr => gr.Key, gr => gr.Select(thing => thing.TeamId).Distinct(), cancellationToken);
 
         var userIdChallengeIds = userTeamIds
-            .ToDictionary(gr => gr.Key, gr => gr.Value.SelectMany(tId => teamChallengeIds[tId]));
+            .ToDictionary(gr => gr.Key, gr => gr.Value
+            .SelectMany(tId => teamChallengeIds[tId]));
 
         var challengeIdUserIds = new Dictionary<string, IEnumerable<string>>();
         foreach (var kv in userIdChallengeIds)

--- a/src/Gameboard.Api/Features/Game/External/ExternalGamesModels.cs
+++ b/src/Gameboard.Api/Features/Game/External/ExternalGamesModels.cs
@@ -17,7 +17,7 @@ public sealed class GetExternalGameHostsResponseHost
     public required string ClientUrl { get; set; }
     public required bool DestroyResourcesOnDeployFailure { get; set; }
     public required int? GamespaceDeployBatchSize { get; set; }
-    public required string HostApiKey { get; set; }
+    public required bool HasApiKey { get; set; }
     public required string HostUrl { get; set; }
     public required string PingEndpoint { get; set; }
     public required string StartupEndpoint { get; set; }

--- a/src/Gameboard.Api/Features/Game/External/Services/ExternalGameHostService.cs
+++ b/src/Gameboard.Api/Features/Game/External/Services/ExternalGameHostService.cs
@@ -11,7 +11,6 @@ using Gameboard.Api.Features.GameEngine;
 using Gameboard.Api.Features.Teams;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
-using ServiceStack;
 
 namespace Gameboard.Api.Features.Games.External;
 
@@ -95,7 +94,7 @@ internal class ExternalGameHostService : IExternalGameHostService
                 ClientUrl = h.ClientUrl,
                 DestroyResourcesOnDeployFailure = h.DestroyResourcesOnDeployFailure,
                 GamespaceDeployBatchSize = h.GamespaceDeployBatchSize,
-                HostApiKey = h.HostApiKey,
+                HasApiKey = h.HostApiKey != null && h.HostApiKey != string.Empty,
                 HostUrl = h.HostUrl,
                 PingEndpoint = h.PingEndpoint,
                 StartupEndpoint = h.StartupEndpoint,

--- a/src/Gameboard.Api/Features/Game/External/Services/ExternalGameService.cs
+++ b/src/Gameboard.Api/Features/Game/External/Services/ExternalGameService.cs
@@ -33,7 +33,6 @@ internal class ExternalGameService : IExternalGameService,
     INotificationHandler<GameResourcesDeployStartNotification>,
     INotificationHandler<GameResourcesDeployEndNotification>
 {
-    private readonly IGameModeServiceFactory _gameModeServiceFactory;
     private readonly IGuidService _guids;
     private readonly ILogger<ExternalGameService> _logger;
     private readonly INowService _now;
@@ -43,7 +42,6 @@ internal class ExternalGameService : IExternalGameService,
 
     public ExternalGameService
     (
-        IGameModeServiceFactory gameModeServiceFactory,
         IGuidService guids,
         ILogger<ExternalGameService> logger,
         INowService now,
@@ -52,7 +50,6 @@ internal class ExternalGameService : IExternalGameService,
         ITeamService teamService
     )
     {
-        _gameModeServiceFactory = gameModeServiceFactory;
         _guids = guids;
         _logger = logger;
         _now = now;

--- a/src/Gameboard.Api/Features/Game/GameController.cs
+++ b/src/Gameboard.Api/Features/Game/GameController.cs
@@ -103,7 +103,7 @@ namespace Gameboard.Api.Controllers
         [Authorize(AppConstants.DesignerPolicy)]
         public async Task Update([FromBody] ChangedGame model)
         {
-            await Validate(new Entity { Id = model.Id });
+            await Validate(model);
             await GameService.Update(model);
         }
 

--- a/src/Gameboard.Api/Features/Game/GameExceptions.cs
+++ b/src/Gameboard.Api/Features/Game/GameExceptions.cs
@@ -67,6 +67,12 @@ public class GameDoesntAllowReset : GameboardValidationException
     public GameDoesntAllowReset(string gameId) : base($"""Game {gameId} has "Allow Reset" set to disabled.""") { }
 }
 
+public class InvalidTeamSize : GameboardValidationException
+{
+    public InvalidTeamSize(string id, string name, int min, int max)
+        : base($"Couldn't set team size {min}-{max} for game {name}. The minimum team size must be less than the max.") { }
+}
+
 internal class UserIsntPlayingGame : GameboardValidationException
 {
     public UserIsntPlayingGame(string userId, string gameId, string whyItMatters = null) : base($"""User {userId} isn't playing game {gameId}.{(string.IsNullOrWhiteSpace(whyItMatters) ? string.Empty : ". " + whyItMatters)} """) { }

--- a/src/Gameboard.Api/Features/Game/GameModes/ExternalGameModeService.cs
+++ b/src/Gameboard.Api/Features/Game/GameModes/ExternalGameModeService.cs
@@ -34,7 +34,7 @@ internal class ExternalGameModeService : IExternalGameModeService
     public Task<GamePlayState> GetGamePlayStateForTeam(string teamId, CancellationToken cancellationToken)
         => GetGamePlayStateForGameAndTeam(null, teamId, cancellationToken);
 
-    private async Task<GamePlayState> GetGamePlayStateForGameAndTeam(string gameId, string teamId, CancellationToken cancellationToken)
+    internal async Task<GamePlayState> GetGamePlayStateForGameAndTeam(string gameId, string teamId, CancellationToken cancellationToken)
     {
         if (teamId.IsNotEmpty())
             gameId = await _teamService.GetGameId(teamId, cancellationToken);

--- a/src/Gameboard.Api/Features/Game/GameService.cs
+++ b/src/Gameboard.Api/Features/Game/GameService.cs
@@ -78,17 +78,24 @@ public class GameService : _Service, IGameService
                 model.CertificateTemplate = _defaults.CertificateTemplate;
         }
 
-        // default to standard-mode challenges
+        // defaults: standard, 60 minutes, scoreboard access, etc.
         if (model.Mode.IsEmpty())
             model.Mode = GameEngineMode.Standard;
 
-        // by default, enable public scoreboard access (after the game has ended)
+        // default to a session length of 60 minutes
+        if (model.SessionMinutes == 0)
+            model.SessionMinutes = 60;
+
+        if (model.MinTeamSize == 0)
+            model.MinTeamSize = 1;
+
+        if (model.MaxTeamSize == 0)
+            model.MaxTeamSize = 1;
+
         model.AllowPublicScoreboardAccess = true;
 
         var entity = Mapper.Map<Data.Game>(model);
-
         await _gameStore.Create(entity);
-
         return Mapper.Map<Game>(entity);
     }
 
@@ -111,10 +118,9 @@ public class GameService : _Service, IGameService
         await _gameStore.Update(entity);
     }
 
-    public async Task Delete(string id)
-    {
-        await _gameStore.Delete(id);
-    }
+    public Task Delete(string id)
+        => _gameStore.Delete(id);
+
 
     public IQueryable<Data.Game> BuildQuery(GameSearchFilter model = null, bool sudo = false)
     {

--- a/src/Gameboard.Api/Features/Game/GameValidator.cs
+++ b/src/Gameboard.Api/Features/Game/GameValidator.cs
@@ -1,45 +1,61 @@
 // Copyright 2021 Carnegie Mellon University. All Rights Reserved.
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
+using System;
 using System.Threading.Tasks;
-using Gameboard.Api.Data.Abstractions;
+using Gameboard.Api.Data;
+using Gameboard.Api.Features.Games;
+using Microsoft.EntityFrameworkCore;
 
-namespace Gameboard.Api.Validators
+namespace Gameboard.Api.Validators;
+
+public class GameValidator : IModelValidator
 {
-    public class GameValidator : IModelValidator
+    private readonly IStore _store;
+
+    public GameValidator(IStore store)
     {
-        private readonly IGameStore _store;
-
-        public GameValidator(
-            IGameStore store
-        )
-        {
-            _store = store;
-        }
-
-        public Task Validate(object model)
-        {
-            if (model is Entity)
-                return _validate(model as Entity);
-
-            throw new ValidationTypeFailure<GameValidator>(model.GetType());
-        }
-
-        private async Task _validate(Entity model)
-        {
-            if ((await Exists(model.Id)).Equals(false))
-                throw new ResourceNotFound<Data.Game>(model.Id);
-
-            await Task.CompletedTask;
-        }
-
-        private async Task<bool> Exists(string id)
-        {
-            return
-                id.NotEmpty() &&
-                (await _store.Retrieve(id)) is not null
-            ;
-        }
-
+        _store = store;
     }
+
+    public Task Validate(object model)
+    {
+        if (model is Entity)
+            return _validate(model as Entity);
+
+        if (model is ChangedGame)
+            return _validate(model as ChangedGame);
+
+        throw new ValidationTypeFailure<GameValidator>(model.GetType());
+    }
+
+    private Task _validate(ChangedGame game)
+    {
+        if (game.MinTeamSize > game.MaxTeamSize)
+            throw new InvalidTeamSize(game.Id, game.Name, game.MinTeamSize, game.MaxTeamSize);
+
+        if (game.GameStart.IsNotEmpty() && game.GameEnd.IsNotEmpty() && game.GameStart > game.GameEnd)
+            throw new InvalidDateRange(new DateRange(game.GameStart, game.GameEnd));
+
+        if (game.RegistrationType == GameRegistrationType.Open && game.RegistrationOpen > game.RegistrationClose)
+            throw new InvalidDateRange(new DateRange(game.RegistrationOpen, game.RegistrationClose));
+
+        return Task.CompletedTask;
+    }
+
+    private async Task _validate(Entity model)
+    {
+        if ((await Exists(model.Id)).Equals(false))
+            throw new ResourceNotFound<Data.Game>(model.Id);
+
+        await Task.CompletedTask;
+    }
+
+    private async Task<bool> Exists(string id)
+    {
+        return id.IsNotEmpty() && await _store
+            .WithNoTracking<Data.Game>()
+            .AnyAsync(g => g.Id == id);
+    }
+
 }

--- a/src/Gameboard.Api/Features/Reports/Queries/SiteUsageReport/GetSiteUsageReportPlayers.cs
+++ b/src/Gameboard.Api/Features/Reports/Queries/SiteUsageReport/GetSiteUsageReportPlayers.cs
@@ -45,7 +45,6 @@ internal sealed class GetSiteUsageReportPlayersHandler : IRequestHandler<GetSite
         paging.PageNumber ??= 0;
         paging.PageSize ??= 20;
 
-
         var challengeIdUserIdMaps = await _challengeService.GetChallengeUserMaps(_reportService.GetBaseQuery(request.ReportParameters), cancellationToken);
         var challengeData = await _store
             .WithNoTracking<Data.Challenge>()

--- a/src/Gameboard.Api/Features/Reports/Queries/SiteUsageReport/GetSiteUsageReportSponsors.cs
+++ b/src/Gameboard.Api/Features/Reports/Queries/SiteUsageReport/GetSiteUsageReportSponsors.cs
@@ -59,6 +59,7 @@ internal class GetSiteUsageReportSponsorsHandler : IRequestHandler<GetSiteUsageR
                 ParentName = gr.Key.ParentName,
                 PlayerCount = gr.Select(p => p.UserId).Distinct().Count()
             })
+            .OrderByDescending(s => s.PlayerCount)
             .ToArrayAsync(cancellationToken);
     }
 }


### PR DESCRIPTION
Version 3.19.1 of Gameboard contains minor bug fixes and performance optimizations.

# Enhancements

- The "Sponsors" modal of the new Site Usage Report now sorts its results by player count (descending).
- Games are now initially created with a default session time (60 minutes) and team min/max (1, i.e. an individual game)

# Bug fixes

- Added performance optimizations to the query which retrieves the "Playesrs" modal of the Site Usage Report.
- Gameboard no longer permits registration start/end dates, execution start/end dates, and team size settings which conflict with each other (resolves #250).
- The external game host endpoints have been resurfaced.