### PR TITLE
v3.19.2

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,0 @@
-{
-    "recommendations": [
-        "ms-azuretools.vscode-docker",
-        "ms-dotnettools.csharp",
-        "ms-dotnettools.csdevkit"
-    ]
-}

--- a/.vscode/gameboard.code-snippets
+++ b/.vscode/gameboard.code-snippets
@@ -1,0 +1,50 @@
+{
+	// see https://code.visualstudio.com/docs/editor/userdefinedsnippets
+	"Create Gameboard Unit Test Suite": {
+		"scope": "csharp",
+		"description": "Create a Gameboard unit test suite",
+		"prefix": "test-suite-unit",
+		"body": [
+			"namespace Gameboard.Api.Tests.Unit;",
+			"",
+			"public class ${TM_FILENAME/\\.cs//g}",
+			"{",
+			"\t$0",
+			"}"
+		]
+	},
+	"Create Gameboard Unit Test": {
+		"scope": "csharp",
+		"description": "Start a new Gameboard unit test",
+		"prefix": "test-unit",
+		"isFileTemplate": true,
+		"body": [
+			"[${0:Theory}, ${1:GameboardAutoData}]",
+			"public async Task ${TM_FILENAME/Tests\\.cs//g}_$2_$3(IFixture fixture)",
+			"{",
+			"\t\/\/ given",
+			"\t$4",
+			"\t\/\/ when",
+			"\t\/\/ var sut = new ${TM_FILENAME/Tests\\.cs//g}(...)",
+			"",
+			"\t\/\/ then",
+			"}"
+		]
+	// },
+	"Create Gameboard Integration Test Suite": {
+		"scope": "csharp",
+		"description": "Create a Gameboard integration test suite",
+		"prefix": "test-suite-int",
+		"body": [
+			"namespace Gameboard.Api.Tests.Integration;",
+			"",
+			"public class ${0:Some}ControllerTests : IClassFixture<GameboardTestContext>",
+			"{",
+			"\tprivate readonly GameboardTestContext _testContext;",
+			"",
+			"\tpublic ${0:Some}ControllerTests(GameboardTestContext testContext",
+			"\t\t=> _testContext = testContext;",
+			"}"
+		]
+	}
+}

--- a/src/Gameboard.Api.Tests.Integration/Tests/Features/Games/GameControllerTests.cs
+++ b/src/Gameboard.Api.Tests.Integration/Tests/Features/Games/GameControllerTests.cs
@@ -13,6 +13,7 @@ public class GameControllerTests : IClassFixture<GameboardTestContext>
     public async Task GameController_Create_ReturnsGame()
     {
         // arrange
+
         var game = new NewGame()
         {
             Name = "Test game",
@@ -31,7 +32,7 @@ public class GameControllerTests : IClassFixture<GameboardTestContext>
         var responseGame = await _testContext
             .CreateHttpClientWithAuthRole(UserRole.Designer)
             .PostAsync("/api/game", game.ToJsonBody())
-            .WithContentDeserializedAs<Api.Data.Game>();
+            .WithContentDeserializedAs<Data.Game>();
 
         // assert
         responseGame?.Name.ShouldBe(game.Name);

--- a/src/Gameboard.Api.Tests.Integration/Tests/Features/Players/PlayerControllerEnrollTests.cs
+++ b/src/Gameboard.Api.Tests.Integration/Tests/Features/Players/PlayerControllerEnrollTests.cs
@@ -40,8 +40,7 @@ public class PlayerControllerEnrollTests : IClassFixture<GameboardTestContext>
         var enrollRequest = new NewPlayer()
         {
             UserId = userId,
-            GameId = gameId,
-            Name = fixture.Create<string>()
+            GameId = gameId
         };
 
         var httpClient = _testContext.CreateHttpClientWithActingUser(u => u.Id = userId); ;

--- a/src/Gameboard.Api/Data/GameboardDbContext.cs
+++ b/src/Gameboard.Api/Data/GameboardDbContext.cs
@@ -271,6 +271,9 @@ public class GameboardDbContext : DbContext
             b.Property(p => p.InviteCode).HasMaxLength(40);
             b.Property(p => p.AdvancedFromTeamId).HasStandardGuidLength();
 
+            // performance-oriented indices
+            b.HasIndex(p => new { p.UserId, p.TeamId });
+
             // nav properties
             b.HasOne(p => p.User).WithMany(u => u.Enrollments).OnDelete(DeleteBehavior.Cascade);
             b

--- a/src/Gameboard.Api/Features/Admin/AdminExternalGamesController.cs
+++ b/src/Gameboard.Api/Features/Admin/AdminExternalGamesController.cs
@@ -23,6 +23,6 @@ public class AdminExternalGamesController : ControllerBase
         => _mediator.Send(new GetExternalGameAdminContextRequest(gameId));
 
     [HttpPost("{gameId}/pre-deploy")]
-    public Task PreDeployGame([FromRoute] string gameId, [FromBody] ExternalGameDeployTeamResourcesRequest request)
-        => _mediator.Send(new DeployGameResourcesCommand(gameId, request.TeamIds));
+    public Task PreDeployGame([FromRoute] string gameId, [FromBody] DeployGameResourcesBody body)
+        => _mediator.Send(new DeployGameResourcesCommand(gameId, body?.TeamIds));
 }

--- a/src/Gameboard.Api/Features/Challenge/Services/ChallengeService.cs
+++ b/src/Gameboard.Api/Features/Challenge/Services/ChallengeService.cs
@@ -657,11 +657,10 @@ public partial class ChallengeService : _Service
         var teamIds = teamChallengeIds.Keys;
 
         var userTeamIds = await _store
-            .WithNoTracking<Data.Challenge>()
-            .Include(c => c.Player)
-            .Where(c => c.Player.UserId != null && c.Player.UserId != string.Empty)
-            .Where(c => teamIds.Contains(c.TeamId))
-            .Select(c => new { c.Player.UserId, c.TeamId })
+            .WithNoTracking<Data.Player>()
+            .Where(p => p.UserId != null && p.UserId != string.Empty)
+            .Where(p => teamIds.Contains(p.TeamId))
+            .Select(p => new { p.UserId, p.TeamId })
             .GroupBy(p => p.UserId)
             .ToDictionaryAsync(gr => gr.Key, gr => gr.Select(thing => thing.TeamId).Distinct(), cancellationToken);
 

--- a/src/Gameboard.Api/Features/Challenge/Services/ChallengeService.cs
+++ b/src/Gameboard.Api/Features/Challenge/Services/ChallengeService.cs
@@ -650,11 +650,7 @@ public partial class ChallengeService : _Service
     public async Task<ChallengeIdUserIdMap> GetChallengeUserMaps(IQueryable<Data.Challenge> query, CancellationToken cancellationToken)
     {
         var teamChallengeIds = await query
-            .Select(c => new
-            {
-                c.Id,
-                c.TeamId
-            })
+            .Select(c => new { c.Id, c.TeamId })
             .GroupBy(c => c.TeamId)
             .ToDictionaryAsync(gr => gr.Key, gr => gr.Select(c => c.Id).ToArray(), cancellationToken);
 
@@ -670,7 +666,8 @@ public partial class ChallengeService : _Service
             .ToDictionaryAsync(gr => gr.Key, gr => gr.Select(thing => thing.TeamId).Distinct(), cancellationToken);
 
         var userIdChallengeIds = userTeamIds
-            .ToDictionary(gr => gr.Key, gr => gr.Value.SelectMany(tId => teamChallengeIds[tId]));
+            .ToDictionary(gr => gr.Key, gr => gr.Value
+            .SelectMany(tId => teamChallengeIds[tId]));
 
         var challengeIdUserIds = new Dictionary<string, IEnumerable<string>>();
         foreach (var kv in userIdChallengeIds)

--- a/src/Gameboard.Api/Features/Game/External/ExternalGamesModels.cs
+++ b/src/Gameboard.Api/Features/Game/External/ExternalGamesModels.cs
@@ -17,7 +17,7 @@ public sealed class GetExternalGameHostsResponseHost
     public required string ClientUrl { get; set; }
     public required bool DestroyResourcesOnDeployFailure { get; set; }
     public required int? GamespaceDeployBatchSize { get; set; }
-    public required string HostApiKey { get; set; }
+    public required bool HasApiKey { get; set; }
     public required string HostUrl { get; set; }
     public required string PingEndpoint { get; set; }
     public required string StartupEndpoint { get; set; }

--- a/src/Gameboard.Api/Features/Game/External/Services/ExternalGameHostService.cs
+++ b/src/Gameboard.Api/Features/Game/External/Services/ExternalGameHostService.cs
@@ -11,7 +11,6 @@ using Gameboard.Api.Features.GameEngine;
 using Gameboard.Api.Features.Teams;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
-using ServiceStack;
 
 namespace Gameboard.Api.Features.Games.External;
 
@@ -95,7 +94,7 @@ internal class ExternalGameHostService : IExternalGameHostService
                 ClientUrl = h.ClientUrl,
                 DestroyResourcesOnDeployFailure = h.DestroyResourcesOnDeployFailure,
                 GamespaceDeployBatchSize = h.GamespaceDeployBatchSize,
-                HostApiKey = h.HostApiKey,
+                HasApiKey = h.HostApiKey != null && h.HostApiKey != string.Empty,
                 HostUrl = h.HostUrl,
                 PingEndpoint = h.PingEndpoint,
                 StartupEndpoint = h.StartupEndpoint,

--- a/src/Gameboard.Api/Features/Game/External/Services/ExternalGameService.cs
+++ b/src/Gameboard.Api/Features/Game/External/Services/ExternalGameService.cs
@@ -257,7 +257,7 @@ internal class ExternalGameService : IExternalGameService,
             .WithNoTracking<Data.Player>()
             .Where(p => teamIds.Contains(p.TeamId))
             .GroupBy(p => p.TeamId)
-            .ToDictionaryAsync(kv => kv.Key, kv => kv.Select(p => p.GameId), cancellationToken);
+            .ToDictionaryAsync(kv => kv.Key, kv => kv.Select(p => p.GameId).Distinct(), cancellationToken);
 
         if (teamGameIds.Values.Any(gIds => gIds.Count() > 1))
             throw new InvalidOperationException("One of the teams to be created is tied to more than one game.");

--- a/src/Gameboard.Api/Features/Game/External/Services/ExternalGameService.cs
+++ b/src/Gameboard.Api/Features/Game/External/Services/ExternalGameService.cs
@@ -33,7 +33,6 @@ internal class ExternalGameService : IExternalGameService,
     INotificationHandler<GameResourcesDeployStartNotification>,
     INotificationHandler<GameResourcesDeployEndNotification>
 {
-    private readonly IGameModeServiceFactory _gameModeServiceFactory;
     private readonly IGuidService _guids;
     private readonly ILogger<ExternalGameService> _logger;
     private readonly INowService _now;
@@ -43,7 +42,6 @@ internal class ExternalGameService : IExternalGameService,
 
     public ExternalGameService
     (
-        IGameModeServiceFactory gameModeServiceFactory,
         IGuidService guids,
         ILogger<ExternalGameService> logger,
         INowService now,
@@ -52,7 +50,6 @@ internal class ExternalGameService : IExternalGameService,
         ITeamService teamService
     )
     {
-        _gameModeServiceFactory = gameModeServiceFactory;
         _guids = guids;
         _logger = logger;
         _now = now;

--- a/src/Gameboard.Api/Features/Game/Game.cs
+++ b/src/Gameboard.Api/Features/Game/Game.cs
@@ -139,3 +139,5 @@ public class GameGroup
     public int Month { get; set; }
     public Game[] Games { get; set; }
 }
+
+public sealed record DeployGameResourcesBody(IEnumerable<string> TeamIds);

--- a/src/Gameboard.Api/Features/Game/GameController.cs
+++ b/src/Gameboard.Api/Features/Game/GameController.cs
@@ -91,8 +91,8 @@ namespace Gameboard.Api.Controllers
 
         [HttpPost("api/game/{gameId}/resources")]
         [Authorize]
-        public Task DeployResources([FromRoute] string gameId, [FromBody] IEnumerable<string> teamIds)
-            => _mediator.Send(new DeployGameResourcesCommand(gameId, teamIds));
+        public Task DeployResources([FromRoute] string gameId, [FromBody] DeployGameResourcesBody body)
+            => _mediator.Send(new DeployGameResourcesCommand(gameId, body?.TeamIds));
 
         /// <summary>
         /// Change game

--- a/src/Gameboard.Api/Features/Game/GameController.cs
+++ b/src/Gameboard.Api/Features/Game/GameController.cs
@@ -103,7 +103,7 @@ namespace Gameboard.Api.Controllers
         [Authorize(AppConstants.DesignerPolicy)]
         public async Task Update([FromBody] ChangedGame model)
         {
-            await Validate(new Entity { Id = model.Id });
+            await Validate(model);
             await GameService.Update(model);
         }
 

--- a/src/Gameboard.Api/Features/Game/GameExceptions.cs
+++ b/src/Gameboard.Api/Features/Game/GameExceptions.cs
@@ -67,6 +67,12 @@ public class GameDoesntAllowReset : GameboardValidationException
     public GameDoesntAllowReset(string gameId) : base($"""Game {gameId} has "Allow Reset" set to disabled.""") { }
 }
 
+public class InvalidTeamSize : GameboardValidationException
+{
+    public InvalidTeamSize(string id, string name, int min, int max)
+        : base($"Couldn't set team size {min}-{max} for game {name}. The minimum team size must be less than the max.") { }
+}
+
 internal class UserIsntPlayingGame : GameboardValidationException
 {
     public UserIsntPlayingGame(string userId, string gameId, string whyItMatters = null) : base($"""User {userId} isn't playing game {gameId}.{(string.IsNullOrWhiteSpace(whyItMatters) ? string.Empty : ". " + whyItMatters)} """) { }

--- a/src/Gameboard.Api/Features/Game/GameModes/ExternalGameModeService.cs
+++ b/src/Gameboard.Api/Features/Game/GameModes/ExternalGameModeService.cs
@@ -34,7 +34,7 @@ internal class ExternalGameModeService : IExternalGameModeService
     public Task<GamePlayState> GetGamePlayStateForTeam(string teamId, CancellationToken cancellationToken)
         => GetGamePlayStateForGameAndTeam(null, teamId, cancellationToken);
 
-    private async Task<GamePlayState> GetGamePlayStateForGameAndTeam(string gameId, string teamId, CancellationToken cancellationToken)
+    internal async Task<GamePlayState> GetGamePlayStateForGameAndTeam(string gameId, string teamId, CancellationToken cancellationToken)
     {
         if (teamId.IsNotEmpty())
             gameId = await _teamService.GetGameId(teamId, cancellationToken);

--- a/src/Gameboard.Api/Features/Game/GameService.cs
+++ b/src/Gameboard.Api/Features/Game/GameService.cs
@@ -78,17 +78,24 @@ public class GameService : _Service, IGameService
                 model.CertificateTemplate = _defaults.CertificateTemplate;
         }
 
-        // default to standard-mode challenges
+        // defaults: standard, 60 minutes, scoreboard access, etc.
         if (model.Mode.IsEmpty())
             model.Mode = GameEngineMode.Standard;
 
-        // by default, enable public scoreboard access (after the game has ended)
+        // default to a session length of 60 minutes
+        if (model.SessionMinutes == 0)
+            model.SessionMinutes = 60;
+
+        if (model.MinTeamSize == 0)
+            model.MinTeamSize = 1;
+
+        if (model.MaxTeamSize == 0)
+            model.MaxTeamSize = 1;
+
         model.AllowPublicScoreboardAccess = true;
 
         var entity = Mapper.Map<Data.Game>(model);
-
         await _gameStore.Create(entity);
-
         return Mapper.Map<Game>(entity);
     }
 
@@ -111,10 +118,9 @@ public class GameService : _Service, IGameService
         await _gameStore.Update(entity);
     }
 
-    public async Task Delete(string id)
-    {
-        await _gameStore.Delete(id);
-    }
+    public Task Delete(string id)
+        => _gameStore.Delete(id);
+
 
     public IQueryable<Data.Game> BuildQuery(GameSearchFilter model = null, bool sudo = false)
     {

--- a/src/Gameboard.Api/Features/Game/GameValidator.cs
+++ b/src/Gameboard.Api/Features/Game/GameValidator.cs
@@ -1,45 +1,61 @@
 // Copyright 2021 Carnegie Mellon University. All Rights Reserved.
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
+using System;
 using System.Threading.Tasks;
-using Gameboard.Api.Data.Abstractions;
+using Gameboard.Api.Data;
+using Gameboard.Api.Features.Games;
+using Microsoft.EntityFrameworkCore;
 
-namespace Gameboard.Api.Validators
+namespace Gameboard.Api.Validators;
+
+public class GameValidator : IModelValidator
 {
-    public class GameValidator : IModelValidator
+    private readonly IStore _store;
+
+    public GameValidator(IStore store)
     {
-        private readonly IGameStore _store;
-
-        public GameValidator(
-            IGameStore store
-        )
-        {
-            _store = store;
-        }
-
-        public Task Validate(object model)
-        {
-            if (model is Entity)
-                return _validate(model as Entity);
-
-            throw new ValidationTypeFailure<GameValidator>(model.GetType());
-        }
-
-        private async Task _validate(Entity model)
-        {
-            if ((await Exists(model.Id)).Equals(false))
-                throw new ResourceNotFound<Data.Game>(model.Id);
-
-            await Task.CompletedTask;
-        }
-
-        private async Task<bool> Exists(string id)
-        {
-            return
-                id.NotEmpty() &&
-                (await _store.Retrieve(id)) is not null
-            ;
-        }
-
+        _store = store;
     }
+
+    public Task Validate(object model)
+    {
+        if (model is Entity)
+            return _validate(model as Entity);
+
+        if (model is ChangedGame)
+            return _validate(model as ChangedGame);
+
+        throw new ValidationTypeFailure<GameValidator>(model.GetType());
+    }
+
+    private Task _validate(ChangedGame game)
+    {
+        if (game.MinTeamSize > game.MaxTeamSize)
+            throw new InvalidTeamSize(game.Id, game.Name, game.MinTeamSize, game.MaxTeamSize);
+
+        if (game.GameStart.IsNotEmpty() && game.GameEnd.IsNotEmpty() && game.GameStart > game.GameEnd)
+            throw new InvalidDateRange(new DateRange(game.GameStart, game.GameEnd));
+
+        if (game.RegistrationType == GameRegistrationType.Open && game.RegistrationOpen > game.RegistrationClose)
+            throw new InvalidDateRange(new DateRange(game.RegistrationOpen, game.RegistrationClose));
+
+        return Task.CompletedTask;
+    }
+
+    private async Task _validate(Entity model)
+    {
+        if ((await Exists(model.Id)).Equals(false))
+            throw new ResourceNotFound<Data.Game>(model.Id);
+
+        await Task.CompletedTask;
+    }
+
+    private async Task<bool> Exists(string id)
+    {
+        return id.IsNotEmpty() && await _store
+            .WithNoTracking<Data.Game>()
+            .AnyAsync(g => g.Id == id);
+    }
+
 }

--- a/src/Gameboard.Api/Features/GameEngine/GameEngineExceptions.cs
+++ b/src/Gameboard.Api/Features/GameEngine/GameEngineExceptions.cs
@@ -5,7 +5,7 @@ namespace Gameboard.Api.Features.GameEngine;
 
 internal class GradingFailed : GameboardException
 {
-    public GradingFailed(string challengeId, Exception innerException) : base($"Grading failed for challenge {challengeId}.", innerException) { }
+    public GradingFailed(string challengeId, Exception innerException) : base($"Grading failed for challenge {challengeId}: {innerException?.Message}", innerException) { }
 }
 
 internal class GamespaceStartFailure : GameboardException

--- a/src/Gameboard.Api/Features/Player/Player.cs
+++ b/src/Gameboard.Api/Features/Player/Player.cs
@@ -47,8 +47,6 @@ public class NewPlayer
 {
     public string UserId { get; set; }
     public string GameId { get; set; }
-    // Looks unused
-    public string Name { get; set; }
 }
 
 public class ChangedPlayer

--- a/src/Gameboard.Api/Features/Reports/Queries/SiteUsageReport/GetSiteUsageReportPlayers.cs
+++ b/src/Gameboard.Api/Features/Reports/Queries/SiteUsageReport/GetSiteUsageReportPlayers.cs
@@ -45,7 +45,6 @@ internal sealed class GetSiteUsageReportPlayersHandler : IRequestHandler<GetSite
         paging.PageNumber ??= 0;
         paging.PageSize ??= 20;
 
-
         var challengeIdUserIdMaps = await _challengeService.GetChallengeUserMaps(_reportService.GetBaseQuery(request.ReportParameters), cancellationToken);
         var challengeData = await _store
             .WithNoTracking<Data.Challenge>()

--- a/src/Gameboard.Api/Features/Reports/Queries/SiteUsageReport/GetSiteUsageReportSponsors.cs
+++ b/src/Gameboard.Api/Features/Reports/Queries/SiteUsageReport/GetSiteUsageReportSponsors.cs
@@ -59,6 +59,7 @@ internal class GetSiteUsageReportSponsorsHandler : IRequestHandler<GetSiteUsageR
                 ParentName = gr.Key.ParentName,
                 PlayerCount = gr.Select(p => p.UserId).Distinct().Count()
             })
+            .OrderByDescending(s => s.PlayerCount)
             .ToArrayAsync(cancellationToken);
     }
 }

--- a/src/Gameboard.Api/Features/Teams/AdminTeamController.cs
+++ b/src/Gameboard.Api/Features/Teams/AdminTeamController.cs
@@ -14,9 +14,7 @@ public class AdminTeamsController : ControllerBase
     private readonly IMediator _mediator;
 
     public AdminTeamsController(IMediator mediator)
-    {
-        _mediator = mediator;
-    }
+        => _mediator = mediator;
 
     [HttpPost]
     public Task<AdminEnrollTeamResponse> Create([FromBody] AdminEnrollTeamRequest request)

--- a/src/Gameboard.Api/Features/Teams/TeamController.cs
+++ b/src/Gameboard.Api/Features/Teams/TeamController.cs
@@ -63,6 +63,11 @@ public class TeamController : ControllerBase
     public Task<GamePlayState> GetTeamGamePlayState([FromRoute] string teamId)
         => _mediator.Send(new GetGamePlayStateQuery(teamId, _actingUserService.Get()?.Id));
 
+    [HttpPut("{teamId}/ready")]
+    [Authorize]
+    public Task UpdateTeamReadyState([FromRoute] string teamId, [FromBody] UpdateIsReadyRequest isReadyCommand)
+        => _mediator.Send(new UpdateTeamReadyStateCommand(teamId, isReadyCommand.IsReady));
+
     [HttpPut("{teamId}/session")]
     public Task ResetSession([FromRoute] string teamId, [FromBody] ResetTeamSessionCommand request, CancellationToken cancellationToken)
         => _mediator.Send(new ResetTeamSessionCommand(teamId, request.ResetType, _actingUserService.Get()), cancellationToken);
@@ -74,9 +79,4 @@ public class TeamController : ControllerBase
     // [HttpPost("{teamId}/session")]
     // public Task StartSessions([FromBody] StartTeamSessionsCommand request, CancellationToken cancellationToken)
     //     => _mediator.Send(request, cancellationToken);
-
-    [HttpPut("{teamId}/ready")]
-    [Authorize]
-    public Task UpdateTeamReadyState([FromRoute] string teamId, [FromBody] UpdateIsReadyRequest isReadyCommand)
-        => _mediator.Send(new UpdateTeamReadyStateCommand(teamId, isReadyCommand.IsReady));
 }

--- a/src/Gameboard.Api/Features/User/Requests/TryCreateUsers.cs
+++ b/src/Gameboard.Api/Features/User/Requests/TryCreateUsers.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Gameboard.Api.Common.Services;
+using Gameboard.Api.Data;
+using Gameboard.Api.Services;
+using Gameboard.Api.Structure.MediatR;
+using Gameboard.Api.Structure.MediatR.Authorizers;
+using Gameboard.Api.Structure.MediatR.Validators;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Gameboard.Api.Features.Users;
+
+public sealed record TryCreateUsersCommand(TryCreateUsersRequest Request) : IRequest<TryCreateUsersResponse>;
+
+internal sealed class TryCreateUsersHandler : IRequestHandler<TryCreateUsersCommand, TryCreateUsersResponse>
+{
+    private readonly IActingUserService _actingUserService;
+    private readonly EntityExistsValidator<TryCreateUsersCommand, Data.Game> _gameExists;
+    private readonly PlayerService _playerService;
+    private readonly EntityExistsValidator<TryCreateUsersCommand, Data.Sponsor> _sponsorExists;
+    private readonly IStore _store;
+    private readonly UserRoleAuthorizer _userRole;
+    private readonly UserService _userService;
+    private readonly IValidatorService<TryCreateUsersCommand> _validator;
+
+    public TryCreateUsersHandler
+    (
+        IActingUserService actingUserService,
+        EntityExistsValidator<TryCreateUsersCommand, Data.Game> gameExists,
+        PlayerService playerService,
+        EntityExistsValidator<TryCreateUsersCommand, Data.Sponsor> sponsorExists,
+        IStore store,
+        UserRoleAuthorizer userRole,
+        UserService userService,
+        IValidatorService<TryCreateUsersCommand> validator
+    )
+    {
+        _actingUserService = actingUserService;
+        _gameExists = gameExists;
+        _playerService = playerService;
+        _sponsorExists = sponsorExists;
+        _store = store;
+        _userRole = userRole;
+        _userService = userService;
+        _validator = validator;
+    }
+
+    public async Task<TryCreateUsersResponse> Handle(TryCreateUsersCommand request, CancellationToken cancellationToken)
+    {
+        // validate/authorize
+        _userRole.AllowRoles(UserRole.Admin).Authorize();
+
+        // optionally throw if the caller doesn't want to ignore the fact that some users exist already
+        if (!request.Request.AllowSubsetCreation)
+        {
+            _validator.AddValidator(async (req, ctx) =>
+        {
+            var userIds = req.Request.UserIds.ToArray();
+            var existingUserIds = await _store
+                .WithNoTracking<Data.User>()
+                .Where(u => userIds.Contains(u.Id))
+                .Select(u => u.Id)
+                .ToArrayAsync(cancellationToken);
+
+            if (existingUserIds.Any())
+                ctx.AddValidationException(new CantCreateExistingUsers(existingUserIds));
+        });
+        }
+
+        if (request.Request.EnrollInGameId.IsNotEmpty())
+            _validator.AddValidator(_gameExists.UseProperty(r => r.Request.EnrollInGameId));
+
+        if (request.Request.SponsorId.IsNotEmpty())
+            _validator.AddValidator(_sponsorExists.UseProperty(r => r.Request.SponsorId));
+
+        await _validator.Validate(request, cancellationToken);
+
+        // do the business
+        var createdUsers = new List<TryCreateUserResult>();
+        foreach (var id in request.Request.UserIds.ToArray())
+        {
+            createdUsers.Add(await _userService.TryCreate(new NewUser
+            {
+                Id = id,
+                SponsorId = request.Request.SponsorId,
+                UnsetDefaultSponsorFlag = request.Request.UnsetDefaultSponsorFlag
+            }));
+        }
+
+        // if requested, enroll them in the game
+        if (request.Request.EnrollInGameId.IsNotEmpty())
+        {
+            var actingUser = _actingUserService.Get();
+
+            // - query to determine if anyone is already enrolled
+            var createdUserIds = createdUsers.Select(u => u.User.Id).ToArray();
+            var enrolledUserIds = await _store
+                .WithNoTracking<Data.Player>()
+                .Where(p => createdUserIds.Contains(p.UserId))
+                .Where(p => p.Mode == p.Game.PlayerMode)
+                .WhereDateIsNotEmpty(p => p.SessionBegin)
+                .Select(p => p.UserId)
+                .ToArrayAsync(cancellationToken);
+
+            foreach (var createdUser in createdUsers)
+            {
+                if (enrolledUserIds.Contains(createdUser.User.Id))
+                    continue;
+
+                await _playerService.Enroll(new NewPlayer
+                {
+                    GameId = request.Request.EnrollInGameId,
+                    UserId = createdUser.User.Id
+                }, actingUser, cancellationToken);
+            }
+        }
+
+        // as a convenience, we include the name of the sponsor assigned in the response. 
+        // this is currently the same for all created users, but you know. you never know.
+        var sponsorIds = createdUsers.Select(u => u.User.SponsorId).Distinct().ToArray();
+
+        // for reasons that currently melt my brain, trying to group this query by Id and Name
+        // to project to a dictionary on the server side caused insane errors, thanks EF (i'm pretty sure)
+        var sponsors = await _store
+            .WithNoTracking<Data.Sponsor>()
+            .Where(s => sponsorIds.Contains(s.Id))
+            .Select(s => new SimpleEntity { Id = s.Id, Name = s.Name })
+            .ToArrayAsync(cancellationToken);
+        var sponsorNames = sponsors
+            .GroupBy(s => new { s.Id, s.Name })
+            .ToDictionary(s => s.Key.Id, s => s.Key.Name);
+
+        return new TryCreateUsersResponse
+        {
+            Users = createdUsers.Select(u => new TryCreateUsersResponseUser
+            {
+                Id = u.User.Id,
+                Name = u.User.ApprovedName,
+                IsNewUser = u.IsNewUser,
+                EnrolledInGameId = request.Request.EnrollInGameId,
+                Sponsor = new SimpleEntity { Id = u.User.SponsorId, Name = sponsorNames[u.User.SponsorId] }
+            })
+        };
+    }
+}

--- a/src/Gameboard.Api/Features/User/User.cs
+++ b/src/Gameboard.Api/Features/User/User.cs
@@ -2,6 +2,8 @@
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Gameboard.Api;
@@ -33,7 +35,9 @@ public class User : IUserViewModel
 
 public class NewUser
 {
-    public string Id { get; set; }
+    public required string Id { get; set; }
+    public string SponsorId { get; set; }
+    public bool UnsetDefaultSponsorFlag { get; set; }
 }
 
 public class ChangedUser
@@ -108,4 +112,27 @@ public class TryCreateUserResult
 {
     public required bool IsNewUser { get; set; }
     public User User { get; set; }
+}
+
+public class TryCreateUsersRequest
+{
+    public required bool AllowSubsetCreation { get; set; }
+    public string EnrollInGameId { get; set; }
+    public required string SponsorId { get; set; }
+    public required bool UnsetDefaultSponsorFlag { get; set; }
+    public required IEnumerable<string> UserIds { get; set; }
+}
+
+public sealed class TryCreateUsersResponse
+{
+    public required IEnumerable<TryCreateUsersResponseUser> Users { get; set; }
+}
+
+public sealed class TryCreateUsersResponseUser
+{
+    public required string Id { get; set; }
+    public required string EnrolledInGameId { get; set; }
+    public required string Name { get; set; }
+    public required SimpleEntity Sponsor { get; set; }
+    public required bool IsNewUser { get; set; }
 }

--- a/src/Gameboard.Api/Features/User/UserController.cs
+++ b/src/Gameboard.Api/Features/User/UserController.cs
@@ -78,6 +78,11 @@ namespace Gameboard.Api.Controllers
             return result;
         }
 
+        [HttpPost("api/users")]
+        [Authorize]
+        public Task<TryCreateUsersResponse> TryCreateMany([FromBody] TryCreateUsersRequest request)
+            => _mediator.Send(new TryCreateUsersCommand(request));
+
         /// <summary>
         /// Get user-specific settings
         /// 

--- a/src/Gameboard.Api/Features/User/UserExceptions.cs
+++ b/src/Gameboard.Api/Features/User/UserExceptions.cs
@@ -1,5 +1,9 @@
 using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using Gameboard.Api.Common;
+using Gameboard.Api.Structure;
 
 namespace Gameboard.Api.Features.Users;
 
@@ -11,4 +15,10 @@ internal class IllegalApiKeyExpirationDate : GameboardException
 internal class ApiKeyNoName : GameboardException
 {
     public ApiKeyNoName() : base($"API keys are required to have a value in their `Name` property.") { }
+}
+
+internal class CantCreateExistingUsers : GameboardValidationException
+{
+    public CantCreateExistingUsers(IEnumerable<string> userIds)
+        : base($"Can't create {userIds.Count()} users: They already exist. (UserIds: {userIds.ToDelimited()})") { }
 }


### PR DESCRIPTION
Version 3.19.2 of Gameboard contains a new API endpoint and some bug fixes.

# New Endpoint

- POST `api/users` allows the creation of multiple users via the API. A future update to the web client will provide access to this feature through the app.
  - Currently requires a string Id per user to be created
  - The body of this request has a required `userIds` property of type string array.
  - It also has the following optional properties:
    - `allowSubsetCreation` - if `true` Gameboard will create any _non-existing_ ids as users. If `false`, existing Ids will cause the entire request to fail validation. (Defaults to `false`)
    - `enrollInGameId` - if non-empty, Gameboard will enroll all passed users (even those which already exist) in the specified game
    - `sponsorId` - if non-empty, Gameboard will assign all newly-created users to the specified sponsor. 
    - `unsetDefaultSponsorFlag` - if `true`, users created via this request will not be prompted to select their sponsor upon first login.

# Bug fixes

- Resolved an issue that could cause the app to attempt to deploy resources for all enrolled teams when predeployment is requested from the Admin -> Game -> Players screen.
- Resolved an issue that could prevent teams playing non-synchronized external games from launching as expected.