### PR TITLE
v3.23.4

### DIFF
--- a/src/Gameboard.Api/Features/Player/Services/PlayerService.cs
+++ b/src/Gameboard.Api/Features/Player/Services/PlayerService.cs
@@ -413,6 +413,10 @@ public class PlayerService
         var mapped = _mapper.Map<BoardPlayer>(result);
         mapped.ChallengeDocUrl = CoreOptions.ChallengeDocUrl;
 
+        // get fully computed score
+        var score = await _scores.GetTeamScore(result.TeamId, CancellationToken.None);
+        mapped.Score = (int)Math.Floor(score.OverallScore.TotalScore);
+
         // handle relative urls in challenge text
         if (mapped.Challenges is not null)
         {

--- a/src/Gameboard.Api/Features/Reports/Queries/PracticeMode/PracticeModeReportModels.cs
+++ b/src/Gameboard.Api/Features/Reports/Queries/PracticeMode/PracticeModeReportModels.cs
@@ -72,6 +72,7 @@ public sealed class PracticeModeByUserReportChallenge
     public required string Name { get; set; }
     public required ReportGameViewModel Game { get; set; }
     public required double MaxPossibleScore { get; set; }
+    public required IEnumerable<string> Tags { get; set; }
 }
 
 public sealed class PracticeModeReportAttempt

--- a/src/Gameboard.Api/Features/Reports/Queries/PracticeMode/PracticeModeReportService.cs
+++ b/src/Gameboard.Api/Features/Reports/Queries/PracticeMode/PracticeModeReportService.cs
@@ -312,6 +312,9 @@ internal class PracticeModeReportService
         // alias the specs dictionary for convenience later
         var specs = ungroupedResults.Specs;
 
+        // screen out invisible tags 
+        var visibleTags = await _practiceService.GetVisibleChallengeTags(cancellationToken);
+
         // translate to records
         var records = groupByPlayerAndChallengeSpec.Select(c => new PracticeModeByUserReportRecord
         {
@@ -343,7 +346,8 @@ internal class PracticeModeReportService
                     Season = specs[c.Key.SpecId].Game.Season,
                     Track = specs[c.Key.SpecId].Game.Track
                 },
-                MaxPossibleScore = specs[c.Key.SpecId].Points
+                MaxPossibleScore = specs[c.Key.SpecId].Points,
+                Tags = visibleTags.Intersect(_challengeService.GetTags(specs[c.Key.SpecId]))
             },
             Attempts = c
                 .ToList()

--- a/src/Gameboard.Api/Features/Reports/ReportsController.cs
+++ b/src/Gameboard.Api/Features/Reports/ReportsController.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Gameboard.Api.Features.Challenges;
 using MediatR;
@@ -90,8 +91,8 @@ public class ReportsController(
         => _service.ListChallengeSpecs(gameId);
 
     [HttpGet("parameter/challenge-tags")]
-    public Task<IEnumerable<string>> GetChallengeTags()
-        => _service.ListChallengeTags();
+    public Task<IEnumerable<string>> GetChallengeTags(CancellationToken cancellationToken)
+        => _service.ListChallengeTags(cancellationToken);
 
     [HttpGet("parameter/games")]
     public Task<IEnumerable<SimpleEntity>> GetGames()


### PR DESCRIPTION
- Fixed an issue that could cause game cards to render strangely if their images were at unexpected aspect ratios
- Invisible challenge tags should no longer appear in the tags report filter
- The Practice Report's "Per-Challenge Performance" Tab now also shows tags
- Fixed an issue that could cause the competitive game state widget to display the score incorrectly