### PR TITLE
v3.24.0-beta1

### DIFF
--- a/.vscode/gameboard.code-snippets
+++ b/.vscode/gameboard.code-snippets
@@ -31,6 +31,7 @@
 			"}"
 		]
 	},
+	
 	"Create Gameboard Integration Test Suite": {
 		"scope": "csharp",
 		"description": "Create a Gameboard integration test suite",
@@ -38,12 +39,10 @@
 		"body": [
 			"namespace Gameboard.Api.Tests.Integration;",
 			"",
-			"public class ${0:Some}ControllerTests : IClassFixture<GameboardTestContext>",
+			"public class ${0:Some}ControllerTests(GameboardTestContext testContext) : IClassFixture<GameboardTestContext>",
 			"{",
-			"\tprivate readonly GameboardTestContext _testContext;",
+			"\tprivate readonly GameboardTestContext _testContext = testContext;",
 			"",
-			"\tpublic ${0:Some}ControllerTests(GameboardTestContext testContext",
-			"\t\t=> _testContext = testContext;",
 			"}"
 		]
 	}

--- a/src/Gameboard.Api.Tests.Unit/Tests/Common/Extensions/EfCoreProjectionExtensionsTests.cs
+++ b/src/Gameboard.Api.Tests.Unit/Tests/Common/Extensions/EfCoreProjectionExtensionsTests.cs
@@ -1,0 +1,25 @@
+using Gameboard.Api.Common;
+
+namespace Gameboard.Api.Tests.Unit;
+
+public class EfCoreProjectionExtensionsTests
+{
+    [Theory, GameboardAutoData]
+    public async Task ToLookupAsync_WithMultiples_ProducesSingleEntry(IFixture fixture)
+    {
+        // given one "group" with two members
+        var id = fixture.Create<string>();
+        var data = new List<SimpleEntity>()
+        {
+            new() { Id = id, Name = fixture.Create<string>() },
+            new() { Id = id, Name = fixture.Create<string>() }
+        }.BuildMock();
+
+        // when we lookup them
+        var result = await data.ToLookupAsync(e => e.Id, CancellationToken.None);
+
+        // we should get a dictionary with a single entry and two things in the list
+        result.Count.ShouldBe(1);
+        result[id].Count.ShouldBe(2);
+    }
+}

--- a/src/Gameboard.Api/Data/Extensions/EfCoreProjectionExtensions.cs
+++ b/src/Gameboard.Api/Data/Extensions/EfCoreProjectionExtensions.cs
@@ -9,11 +9,24 @@ namespace Gameboard.Api.Common;
 
 public static class EfCoreProjectionExtensions
 {
-    public static async Task<IDictionary<TKey, IEnumerable<TValue>>> ToLookupAsync<TKey, TValue>(this IQueryable<TValue> query, Func<TValue, TKey> keyProperty, CancellationToken cancellationToken)
+    public static async Task<IDictionary<TKey, List<TValue>>> ToLookupAsync<TKey, TValue>(this IQueryable<TValue> query, Func<TValue, TKey> keyProperty, CancellationToken cancellationToken)
     {
-        var result = await query.ToArrayAsync(cancellationToken);
+        var resultList = await query.ToArrayAsync(cancellationToken);
+        var retVal = new Dictionary<TKey, List<TValue>>();
 
-        return result.ToDictionary(keyProperty, kv => kv.ToEnumerable());
+        foreach (var result in resultList)
+        {
+            var keyValue = keyProperty(result);
+            if (retVal.TryGetValue(keyValue, out var existingList))
+            {
+                existingList.Add(result);
+            }
+            else
+            {
+                retVal.Add(keyValue, new List<TValue>([result]));
+            }
+        }
 
+        return retVal;
     }
 }

--- a/src/Gameboard.Api/Features/Certificates/CertificatesController.cs
+++ b/src/Gameboard.Api/Features/Certificates/CertificatesController.cs
@@ -50,18 +50,18 @@ public class CertificatesController(
     [HttpGet]
     [Route("{userId}/certificates/practice/{awardedForEntityId}")]
     [AllowAnonymous] // anyone can _try_, but we only serve them the cert if it's published (or if they're the owner)
-    public async Task<FileResult> GetPracticeCertificatePng([FromRoute] string userId, [FromRoute] string awardedForEntityId, CancellationToken cancellationToken)
+    public async Task<FileResult> GetPracticeCertificatePng([FromRoute] string userId, [FromRoute] string awardedForEntityId, [FromQuery] string requestedNameOverride, CancellationToken cancellationToken)
     {
-        var html = await _mediator.Send(new GetPracticeModeCertificateHtmlQuery(awardedForEntityId, userId, _actingUser.Get()), cancellationToken);
+        var html = await _mediator.Send(new GetPracticeModeCertificateHtmlQuery(awardedForEntityId, userId, _actingUser.Get(), requestedNameOverride), cancellationToken);
         return File(await _htmlToImage.ToPng($"{_actingUser.Get().Id}_{awardedForEntityId}", html, 3300, 2550), MimeTypes.ImagePng);
     }
 
     [HttpGet]
     [Route("{userId}/certificates/practice/{awardedForEntityId}/pdf")]
     [AllowAnonymous] // anyone can _try_, but we only serve them the cert if it's published (or if they're the owner)
-    public async Task<FileResult> GetPracticeCertificatePdf([FromRoute] string userId, [FromRoute] string awardedForEntityId, CancellationToken cancellationToken)
+    public async Task<FileResult> GetPracticeCertificatePdf([FromRoute] string userId, [FromRoute] string awardedForEntityId, [FromQuery] string requestedNameOverride, CancellationToken cancellationToken)
     {
-        var html = await _mediator.Send(new GetPracticeModeCertificateHtmlQuery(awardedForEntityId, userId, _actingUser.Get()), cancellationToken);
+        var html = await _mediator.Send(new GetPracticeModeCertificateHtmlQuery(awardedForEntityId, userId, _actingUser.Get(), requestedNameOverride), cancellationToken);
         return File(await _htmlToImage.ToPdf($"{_actingUser.Get().Id}_{awardedForEntityId}", html, 3300, 2550), MimeTypes.ApplicationPdf);
     }
 

--- a/src/Gameboard.Api/Features/Certificates/Requests/GetPracticeModeCertificateHtml/GetPracticeModeCertificateHtml.cs
+++ b/src/Gameboard.Api/Features/Certificates/Requests/GetPracticeModeCertificateHtml/GetPracticeModeCertificateHtml.cs
@@ -13,14 +13,15 @@ namespace Gameboard.Api.Features.Practice;
 
 public record GetPracticeModeCertificateHtmlQuery(string ChallengeSpecId, string CertificateOwnerUserId, User ActingUser, string RequestedName) : IRequest<string>;
 
-internal class GetPracticeModeCertificateHtmlHandler(
+internal class GetPracticeModeCertificateHtmlHandler
+(
     EntityExistsValidator<GetPracticeModeCertificateHtmlQuery, Data.User> actingUserExists,
     EntityExistsValidator<GetPracticeModeCertificateHtmlQuery, Data.User> certificateOwnerExists,
     ICertificatesService certificatesService,
     CoreOptions coreOptions,
     IPracticeService practiceService,
     IValidatorService<GetPracticeModeCertificateHtmlQuery> validatorService
-    ) : IRequestHandler<GetPracticeModeCertificateHtmlQuery, string>
+) : IRequestHandler<GetPracticeModeCertificateHtmlQuery, string>
 {
     private readonly ICertificatesService _certificatesService = certificatesService;
     private readonly CoreOptions _coreOptions = coreOptions;

--- a/src/Gameboard.Api/Features/Certificates/Requests/GetPracticeModeCertificateHtml/GetPracticeModeCertificateHtml.cs
+++ b/src/Gameboard.Api/Features/Certificates/Requests/GetPracticeModeCertificateHtml/GetPracticeModeCertificateHtml.cs
@@ -11,7 +11,7 @@ using MediatR;
 
 namespace Gameboard.Api.Features.Practice;
 
-public record GetPracticeModeCertificateHtmlQuery(string ChallengeSpecId, string CertificateOwnerUserId, User ActingUser) : IRequest<string>;
+public record GetPracticeModeCertificateHtmlQuery(string ChallengeSpecId, string CertificateOwnerUserId, User ActingUser, string RequestedName) : IRequest<string>;
 
 internal class GetPracticeModeCertificateHtmlHandler(
     EntityExistsValidator<GetPracticeModeCertificateHtmlQuery, Data.User> actingUserExists,
@@ -66,16 +66,18 @@ internal class GetPracticeModeCertificateHtmlHandler(
         """.Trim();
 
         if (!settings.CertificateHtmlTemplate.IsEmpty())
+        {
             innerTemplate = settings.CertificateHtmlTemplate
                 .Replace("{{challengeName}}", certificate.Challenge.Name)
                 .Replace("{{challengeDescription}}", certificate.Challenge.Description)
                 .Replace("{{date}}", certificate.Date.ToLocalTime().ToString("M/d/yyyy"))
                 .Replace("{{division}}", certificate.Game.Division)
-                .Replace("{{playerName}}", certificate.PlayerName)
+                .Replace("{{playerName}}", request.RequestedName.IsNotEmpty() ? request.RequestedName : certificate.PlayerName)
                 .Replace("{{score}}", certificate.Score.ToString())
                 .Replace("{{season}}", certificate.Game.Season)
                 .Replace("{{time}}", GetDurationDescription(certificate.Time))
                 .Replace("{{track}}", certificate.Game.Track);
+        }
 
         // compose final html and save to a temp file
         return outerTemplate.Replace("{{bodyContent}}", innerTemplate);

--- a/src/Gameboard.Api/Features/Certificates/Requests/GetPracticeModeCertificateHtml/GetPracticeModeCertificateModels.cs
+++ b/src/Gameboard.Api/Features/Certificates/Requests/GetPracticeModeCertificateHtml/GetPracticeModeCertificateModels.cs
@@ -1,0 +1,6 @@
+namespace Gameboard.Api.Features.Certificates;
+
+public sealed class GetPracticeModeCertificateRequest
+{
+    public string RequestNameOverride { get; set; }
+}

--- a/src/Gameboard.Api/Features/Certificates/Requests/GetPracticeModeCertificates.cs
+++ b/src/Gameboard.Api/Features/Certificates/Requests/GetPracticeModeCertificates.cs
@@ -10,23 +10,16 @@ namespace Gameboard.Api.Features.Practice;
 
 public record GetPracticeModeCertificatesQuery(string CertificateOwnerUserId, User ActingUser) : IRequest<IEnumerable<PracticeModeCertificate>>;
 
-internal class GetPracticeModeCertificatesHandler : IRequestHandler<GetPracticeModeCertificatesQuery, IEnumerable<PracticeModeCertificate>>
+internal class GetPracticeModeCertificatesHandler
+(
+    ICertificatesService certificatesService,
+    EntityExistsValidator<GetPracticeModeCertificatesQuery, Data.User> userExists,
+    IValidatorService<GetPracticeModeCertificatesQuery> validatorService
+) : IRequestHandler<GetPracticeModeCertificatesQuery, IEnumerable<PracticeModeCertificate>>
 {
-    private readonly ICertificatesService _certificatesService;
-    private readonly EntityExistsValidator<GetPracticeModeCertificatesQuery, Data.User> _userExists;
-    private readonly IValidatorService<GetPracticeModeCertificatesQuery> _validatorService;
-
-    public GetPracticeModeCertificatesHandler
-    (
-        ICertificatesService certificatesService,
-        EntityExistsValidator<GetPracticeModeCertificatesQuery, Data.User> userExists,
-        IValidatorService<GetPracticeModeCertificatesQuery> validatorService
-    )
-    {
-        _certificatesService = certificatesService;
-        _userExists = userExists;
-        _validatorService = validatorService;
-    }
+    private readonly ICertificatesService _certificatesService = certificatesService;
+    private readonly EntityExistsValidator<GetPracticeModeCertificatesQuery, Data.User> _userExists = userExists;
+    private readonly IValidatorService<GetPracticeModeCertificatesQuery> _validatorService = validatorService;
 
     public async Task<IEnumerable<PracticeModeCertificate>> Handle(GetPracticeModeCertificatesQuery request, CancellationToken cancellationToken)
     {

--- a/src/Gameboard.Api/Features/Challenge/Services/ChallengeService.cs
+++ b/src/Gameboard.Api/Features/Challenge/Services/ChallengeService.cs
@@ -151,7 +151,6 @@ public partial class ChallengeService
         catch (Exception ex)
         {
             Logger.LogWarning(message: $"Challenge registration failure: {ex.GetType().Name} -- {ex.Message}");
-            ExceptionDispatchInfo.Capture(ex.InnerException ?? ex).Throw();
             throw;
         }
         finally

--- a/src/Gameboard.Api/Features/Practice/PracticeService.cs
+++ b/src/Gameboard.Api/Features/Practice/PracticeService.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using AutoMapper;

--- a/src/Gameboard.Api/Features/Practice/SearchPracticeChallenges.cs
+++ b/src/Gameboard.Api/Features/Practice/SearchPracticeChallenges.cs
@@ -13,32 +13,22 @@ namespace Gameboard.Api.Features.Practice;
 
 public record SearchPracticeChallengesQuery(SearchFilter Filter) : IRequest<SearchPracticeChallengesResult>;
 
-internal class SearchPracticeChallengesHandler : IRequestHandler<SearchPracticeChallengesQuery, SearchPracticeChallengesResult>
+internal class SearchPracticeChallengesHandler
+(
+    IChallengeDocsService challengeDocsService,
+    IMapper mapper,
+    IPagingService pagingService,
+    IPracticeService practiceService,
+    ISlugService slugger,
+    IStore store
+) : IRequestHandler<SearchPracticeChallengesQuery, SearchPracticeChallengesResult>
 {
-    private readonly IChallengeDocsService _challengeDocsService;
-    private readonly IMapper _mapper;
-    private readonly IPagingService _pagingService;
-    private readonly IPracticeService _practiceService;
-    private readonly ISlugService _slugger;
-    private readonly IStore _store;
-
-    public SearchPracticeChallengesHandler
-    (
-        IChallengeDocsService challengeDocsService,
-        IMapper mapper,
-        IPagingService pagingService,
-        IPracticeService practiceService,
-        ISlugService slugger,
-        IStore store
-    )
-    {
-        _challengeDocsService = challengeDocsService;
-        _mapper = mapper;
-        _pagingService = pagingService;
-        _practiceService = practiceService;
-        _slugger = slugger;
-        _store = store;
-    }
+    private readonly IChallengeDocsService _challengeDocsService = challengeDocsService;
+    private readonly IMapper _mapper = mapper;
+    private readonly IPagingService _pagingService = pagingService;
+    private readonly IPracticeService _practiceService = practiceService;
+    private readonly ISlugService _slugger = slugger;
+    private readonly IStore _store = store;
 
     public async Task<SearchPracticeChallengesResult> Handle(SearchPracticeChallengesQuery request, CancellationToken cancellationToken)
     {
@@ -100,6 +90,7 @@ internal class SearchPracticeChallengesHandler : IRequestHandler<SearchPracticeC
                     s.Name.ToLower().Contains(term) ||
                     s.Description.ToLower().Contains(term) ||
                     s.Game.Name.ToLower().Contains(term) ||
+                    s.Game.Id.ToLower() == term ||
                     s.Text.ToLower().Contains(term) ||
                     (s.Tags.Contains(sluggedTerm) && sluggedSuggestedSearches.Contains(sluggedTerm))
             );

--- a/src/Gameboard.Api/Features/Reports/Queries/ChallengesReport/ChallengesReportModels.cs
+++ b/src/Gameboard.Api/Features/Reports/Queries/ChallengesReport/ChallengesReportModels.cs
@@ -31,6 +31,9 @@ public sealed class ChallengesReportRecord
     public required int DeployCompetitiveCount { get; set; }
     public required int DeployPracticeCount { get; set; }
     public required int DistinctPlayerCount { get; set; }
+    public required int PracticeSolveZeroCount { get; set; }
+    public required int PracticeSolvePartialCount { get; set; }
+    public required int PracticeSolveCompleteCount { get; set; }
     public required int SolveZeroCount { get; set; }
     public required int SolvePartialCount { get; set; }
     public required int SolveCompleteCount { get; set; }
@@ -70,10 +73,20 @@ public sealed class ChallengesReportExportRecord
     public required int DeployCompetitiveCount { get; set; }
     public required int DeployPracticeCount { get; set; }
     public required int DistinctPlayerCount { get; set; }
+
+    // these solve counts are for competitive
     public required int SolveZeroCount { get; set; }
     public required int SolvePartialCount { get; set; }
     public required int SolveCompleteCount { get; set; }
     public required double? SolveZeroPct { get; set; }
     public required double? SolvePartialPct { get; set; }
     public required double? SolveCompletePct { get; set; }
+
+    // these are for practice
+    public required int PracticeSolveZeroCount { get; set; }
+    public required int PracticeSolvePartialCount { get; set; }
+    public required int PracticeSolveCompleteCount { get; set; }
+    public required double? PracticeSolveZeroPct { get; set; }
+    public required double? PracticeSolvePartialPct { get; set; }
+    public required double? PracticeSolveCompletePct { get; set; }
 }

--- a/src/Gameboard.Api/Features/Reports/Queries/ChallengesReport/ChallengesReportService.cs
+++ b/src/Gameboard.Api/Features/Reports/Queries/ChallengesReport/ChallengesReportService.cs
@@ -50,8 +50,8 @@ internal class ChallengesReportService(IPracticeService practiceService, IReport
             query = query.Where(cs => tracksCriteria.Contains(cs.Game.Track.ToLower()));
 
         // the date filters apply to challenges, not to specs
-        DateTimeOffset? startDateStart = parameters.StartDateStart.HasValue ? parameters.StartDateStart.Value.ToUniversalTime() : null;
-        DateTimeOffset? startDateEnd = parameters.StartDateEnd.HasValue ? parameters.StartDateEnd.Value.ToEndDate().ToUniversalTime() : null;
+        var startDateStart = parameters.StartDateStart.HasValue ? parameters.StartDateStart.Value.ToUniversalTime() : default(DateTimeOffset?);
+        var startDateEnd = parameters.StartDateEnd.HasValue ? parameters.StartDateEnd.Value.ToEndDate().ToUniversalTime() : default(DateTimeOffset?);
         Expression<Func<Data.Challenge, bool>> startDateCondition = c => true;
         Expression<Func<Data.Challenge, bool>> endDateCondition = c => true;
 
@@ -122,18 +122,30 @@ internal class ChallengesReportService(IPracticeService practiceService, IReport
                     .Select(p => p.UserId)
                     .Distinct()
                     .Count(),
-                SolveZeroCount = group
+                CompetitiveSolveZeroCount = group
                     .Where(c => c.Score == 0)
                     .Where(c => c.PlayerMode == PlayerMode.Competition)
                     .Count(),
-                SolvePartialCount = group
+                CompetitiveSolvePartialCount = group
                     .Where(c => c.Score > 0 && c.Score < c.Points)
                     .Where(c => c.PlayerMode == PlayerMode.Competition)
                     .Count(),
-                SolveCompleteCount = group
+                CompetitiveSolveCompleteCount = group
                     .Where(c => c.Score >= c.Points)
                     .Where(c => c.PlayerMode == PlayerMode.Competition)
-                    .Count()
+                    .Count(),
+                PracticeSolveZeroCount = group
+                    .Where(c => c.Score == 0)
+                    .Where(c => c.PlayerMode == PlayerMode.Practice)
+                    .Count(),
+                PracticeSolvePartialCount = group
+                    .Where(c => c.Score > 0 && c.Score < c.Points)
+                    .Where(c => c.PlayerMode == PlayerMode.Practice)
+                    .Count(),
+                PracticeSolveCompleteCount = group
+                    .Where(c => c.Score >= c.Points)
+                    .Where(c => c.PlayerMode == PlayerMode.Practice)
+                    .Count(),
             }, cancellationToken);
 
         // we currently restrict tags we show on challenges (to avoid polluting the UI with internal tags).
@@ -162,12 +174,15 @@ internal class ChallengesReportService(IPracticeService practiceService, IReport
                 Tags = tags,
                 AvgCompleteSolveTimeMs = aggregations?.AvgCompleteSolveTimeMs,
                 AvgScore = aggregations?.AvgScore,
-                DeployCompetitiveCount = aggregations is not null ? aggregations.DeployCompetitiveCount : 0,
-                DeployPracticeCount = aggregations is not null ? aggregations.DeployPracticeCount : 0,
-                DistinctPlayerCount = aggregations is not null ? aggregations.DistinctPlayerCount : 0,
-                SolveZeroCount = aggregations is not null ? aggregations.SolveZeroCount : 0,
-                SolvePartialCount = aggregations is not null ? aggregations.SolvePartialCount : 0,
-                SolveCompleteCount = aggregations is not null ? aggregations.SolveCompleteCount : 0
+                DeployCompetitiveCount = aggregations?.DeployCompetitiveCount ?? 0,
+                DeployPracticeCount = aggregations?.DeployPracticeCount ?? 0,
+                DistinctPlayerCount = aggregations?.DistinctPlayerCount ?? 0,
+                PracticeSolveZeroCount = aggregations?.PracticeSolveZeroCount ?? 0,
+                PracticeSolvePartialCount = aggregations?.PracticeSolvePartialCount ?? 0,
+                PracticeSolveCompleteCount = aggregations?.PracticeSolveCompleteCount ?? 0,
+                SolveZeroCount = aggregations?.CompetitiveSolveZeroCount ?? 0,
+                SolvePartialCount = aggregations?.CompetitiveSolvePartialCount ?? 0,
+                SolveCompleteCount = aggregations?.CompetitiveSolveCompleteCount ?? 0
             };
         });
 

--- a/src/Gameboard.Api/Features/Reports/Queries/ChallengesReport/GetChallengesReportExport.cs
+++ b/src/Gameboard.Api/Features/Reports/Queries/ChallengesReport/GetChallengesReportExport.cs
@@ -10,20 +10,14 @@ namespace Gameboard.Api.Features.Reports;
 
 public record GetChallengesReportExportQuery(ChallengesReportParameters Parameters) : IRequest<IEnumerable<ChallengesReportExportRecord>>, IReportQuery;
 
-internal class GetChallengesReportExportHandler : IRequestHandler<GetChallengesReportExportQuery, IEnumerable<ChallengesReportExportRecord>>
+internal class GetChallengesReportExportHandler
+(
+    IChallengesReportService challengesReportService,
+    ReportsQueryValidator validator
+) : IRequestHandler<GetChallengesReportExportQuery, IEnumerable<ChallengesReportExportRecord>>
 {
-    private readonly IChallengesReportService _challengesReportService;
-    private readonly ReportsQueryValidator _reportsQueryValidator;
-
-    public GetChallengesReportExportHandler
-    (
-        IChallengesReportService challengesReportService,
-        ReportsQueryValidator validator
-    )
-    {
-        _challengesReportService = challengesReportService;
-        _reportsQueryValidator = validator;
-    }
+    private readonly IChallengesReportService _challengesReportService = challengesReportService;
+    private readonly ReportsQueryValidator _reportsQueryValidator = validator;
 
     public async Task<IEnumerable<ChallengesReportExportRecord>> Handle(GetChallengesReportExportQuery request, CancellationToken cancellationToken)
     {
@@ -48,6 +42,12 @@ internal class GetChallengesReportExportHandler : IRequestHandler<GetChallengesR
             DeployCompetitiveCount = r.DeployCompetitiveCount,
             DeployPracticeCount = r.DeployPracticeCount,
             DistinctPlayerCount = r.DistinctPlayerCount,
+            PracticeSolveZeroCount = r.PracticeSolveZeroCount,
+            PracticeSolvePartialCount = r.PracticeSolvePartialCount,
+            PracticeSolveCompleteCount = r.PracticeSolveCompleteCount,
+            PracticeSolveZeroPct = r.DeployPracticeCount > 0 ? ((double)r.PracticeSolveZeroCount / r.DeployPracticeCount) : null,
+            PracticeSolvePartialPct = r.DeployPracticeCount > 0 ? ((double)r.PracticeSolvePartialCount / r.DeployPracticeCount) : null,
+            PracticeSolveCompletePct = r.DeployPracticeCount > 0 ? ((double)r.PracticeSolveCompleteCount / r.DeployPracticeCount) : null,
             SolveZeroCount = r.SolveZeroCount,
             SolvePartialCount = r.SolvePartialCount,
             SolveCompleteCount = r.SolveCompleteCount,

--- a/src/Gameboard.Api/Structure/AppSettings.cs
+++ b/src/Gameboard.Api/Structure/AppSettings.cs
@@ -29,13 +29,6 @@ public class ApiKeyOptions
     public int RandomCharactersLength { get; set; } = 36;
 }
 
-public sealed class BehaviorSettings
-{
-    public required bool NameChangesAllow { get; set; } = true;
-    public required bool NameChangesRequireApproval { get; set; } = true;
-    public required bool NamesImportFromIdp { get; set; } = true;
-}
-
 public class LoggingSettings
 {
     public bool EnableHttpLogging { get; set; } = false;


### PR DESCRIPTION
Version 3.24.0 of Gameboard includes new features, enhancements, and bug fixes.

# New features

## Practice Area

- The Practice Area now sports a brand new "Sticky Challenge Panel". This panel floats to the side and follows the player's scroll as they proceed through longer challenge documents (like the ones you might find in a longer practice lab or similar). It allows them to launch virtual machine consoles and enter responses without having to scroll to the bottom of the challenge.
  - Eligible users will be notified about the panel upon first arrival to the page after the release.
  - This panel is currently only available to users who have a browser window of at least 1400px or greater in width.
  - Use of the sticky panel is toggleable, and the user preference will be remembered across challenges and visits to the practice area.
  - The non-sticky panel now has a sticky footer that provides one-click access to the sticky panel, support code, and ticket creation.
- Practice challenges may now have Sections! (resolves #491)
  - Challenges created with a supported engine (e.g. [TopoMojo](https://github.com/cmu-sei/TopoMojo)) may now have their questions broken out into sections.
  - Sections can be presented sequentially, can have their own names and markdown content, and can be gated by prerequisite performance.
  - For more details on sections, see the TopoMojo release notes [here](https://github.com/cmu-sei/TopoMojo/releases/tag/2.3.2).
- Clicking on a game name in the practice challenge list now filters the list by that game (resolves #504)
- Users with the appropriate permission can now separately configure the default submission limit for practice challenges in Admin -> Practice Area. If this value is unset, users will be permitted an unlimited number of submissions attempts (but will still be subject to typical session length limits, and their session will end upon successful solution).

## New Helm-Chart-Level Settings

App admins can now take advantage of new settings to customize Gameboard's behavior:

- **Auto Log In/Out (web app)** - New settings have been added to the web app that allow admins to customize the log in/out experience 
  - `oidc.autoLogin` - If enabled, immediately redirects the user to the identity provider on arrival to the site (disabled by default).
  - `oidc.autoLogout`- If disabled, causes manual logout to log the user out of Gameboard but not its identity provider (enabled by default)
- **Name Management Rules (API)** - New settings have been added to the API to allow admins flexibility in the administration of user name changes (Resolves #518)
  - `Core__NameChangeIsEnabled` - If `false`, prevents non-elevated users from submitting name change requests (`true` by default)
  - `Core__NameChangeRequiresApproval` - if `false`, allows name changes to occur without manual authorization from an elevated users (`true` by default`)

## Other new features

- Gameboard now has a default favicon! Big ups to @sei-jbooz, who, I'm sure, will soon be adding "Front End Visual Designer" to his already-lengthy job title.
- When generating a practice certificate, it is now possible to provide a different name to be displayed rather than the Gameboard username. This feature will come to competitive certs in a future release. (Partially addresses #254).

# Enhancements

- Gameboard has had a light "theming" pass for a more consistent visual experience. In general, you'll notice a lot less blue and a lot more green.
- The Challenges Report now includes solve/partial/zero statistics in practice mode in addition to competitive mode.

# Bug fixes

- Resolved an issue that could cause the app to appear to hang on authentication redirect (Resolves #488)
- Resolved an issue that could cause a practice challenge's solution guide to fail to display even when available
- Resolved an issue that could cause team sessions to fail to launch

# App health

- Packages and GH Actions have had their versions updated.
- The Practice Area has been slightly refactored for efficient and reliable performance.