### PR TITLE
v3.25.0

### DIFF
--- a/src/Gameboard.Api.Tests.Integration/Tests/Features/Practice/SearchPracticeChallengesTests.cs
+++ b/src/Gameboard.Api.Tests.Integration/Tests/Features/Practice/SearchPracticeChallengesTests.cs
@@ -31,10 +31,12 @@ public class SearchPracticeChallengesTests(GameboardTestContext testContext) : I
 
                 state.Add<Data.Game>(fixture, game =>
                 {
+                    game.IsPublished = true;
                     game.Specs = state.Build<Data.ChallengeSpec>(fixture, spec =>
                     {
                         game.PlayerMode = PlayerMode.Practice;
                         spec.Tags = tag;
+                        spec.IsHidden = false;
                     }).ToCollection();
                 });
             }

--- a/src/Gameboard.Api.Tests.Integration/Tests/Features/Practice/SearchPracticeChallengesTests.cs
+++ b/src/Gameboard.Api.Tests.Integration/Tests/Features/Practice/SearchPracticeChallengesTests.cs
@@ -32,11 +32,11 @@ public class SearchPracticeChallengesTests(GameboardTestContext testContext) : I
                 state.Add<Data.Game>(fixture, game =>
                 {
                     game.IsPublished = true;
+                    game.PlayerMode = PlayerMode.Practice;
+
                     game.Specs = state.Build<Data.ChallengeSpec>(fixture, spec =>
                     {
-                        game.PlayerMode = PlayerMode.Practice;
                         spec.Tags = tag;
-                        spec.IsHidden = false;
                     }).ToCollection();
                 });
             }
@@ -65,6 +65,9 @@ public class SearchPracticeChallengesTests(GameboardTestContext testContext) : I
                 // note there are no suggested searches in this db
                 state.Add<Data.Game>(fixture, game =>
                 {
+                    game.PlayerMode = PlayerMode.Practice;
+                    game.IsPublished = true;
+
                     game.Specs = state.Build<Data.ChallengeSpec>(fixture, spec =>
                     {
                         game.PlayerMode = PlayerMode.Practice;

--- a/src/Gameboard.Api.Tests.Integration/Tests/Features/Teams/StartTeamSessionTests.cs
+++ b/src/Gameboard.Api.Tests.Integration/Tests/Features/Teams/StartTeamSessionTests.cs
@@ -1,7 +1,7 @@
 using Gameboard.Api.Common;
 using Gameboard.Api.Features.Teams;
 using Gameboard.Api.Structure;
-using ServiceStack;
+using StackExchange.Redis;
 
 namespace Gameboard.Api.Tests.Integration.Teams;
 
@@ -159,4 +159,47 @@ public class TeamControllerStartTeamSessionTests(GameboardTestContext testContex
     // Users can team up, leave the team, join a different team, then start sessions on the original and the new team
     // Admins can start sessions for non-admins
     // Non-admins can't start sessions for other teams
+    [Theory, GbIntegrationAutoData]
+    public async Task Team_WhenStartingOtherTeamSession_FailsValidation
+    (
+        string actingTeamId,
+        string actingUserId,
+        string targetPlayerId,
+        IFixture fixture
+    )
+    {
+        // given two players registered for the same game
+        await _testContext.WithDataState(state =>
+        {
+            state.Add<Data.Game>(fixture, game =>
+            {
+                game.Players =
+                [
+                    // the person who's starting a session
+                    state.Build<Data.Player>(fixture, p =>
+                    {
+                        p.Id = fixture.Create<string>();
+                        p.Role = PlayerRole.Manager;
+                        p.TeamId = actingTeamId;
+                        p.User = state.Build<Data.User>(fixture, u => u.Id = actingUserId);
+                    }),
+                    state.Build<Data.Player>(fixture, p =>
+                    {
+                        p.Id = targetPlayerId;
+                        p.Role = PlayerRole.Manager;
+                        p.TeamId = actingTeamId;
+                        p.User = state.Build<Data.User>(fixture);
+                    })
+                ];
+            });
+        });
+
+        // when the first player tries to start the second's session
+        var response = await _testContext
+            .CreateHttpClientWithActingUser(u => u.Id = actingUserId)
+            .PutAsync($"api/player/{targetPlayerId}/start", null);
+
+        // then the response should have a failure code
+        response.IsSuccessStatusCode.ShouldBeFalse();
+    }
 }

--- a/src/Gameboard.Api.Tests.Integration/Tests/Features/Teams/StartTeamSessionTests.cs
+++ b/src/Gameboard.Api.Tests.Integration/Tests/Features/Teams/StartTeamSessionTests.cs
@@ -142,7 +142,7 @@ public class TeamControllerStartTeamSessionTests(GameboardTestContext testContex
         await httpClient
             .PutAsync($"api/team/{teamId}/manager/{finalCaptainPlayerId}", new PromoteToManagerRequest
             {
-                CurrentManagerPlayerId = initialCaptainPlayerId,
+                CurrentCaptainId = initialCaptainPlayerId,
                 NewManagerPlayerId = finalCaptainPlayerId,
                 TeamId = teamId
             }.ToJsonBody());

--- a/src/Gameboard.Api.Tests.Unit/Tests/Features/Challenges/ChallengeServiceTests.cs
+++ b/src/Gameboard.Api.Tests.Unit/Tests/Features/Challenges/ChallengeServiceTests.cs
@@ -8,7 +8,6 @@ using Gameboard.Api.Features.Teams;
 using Gameboard.Api.Features.Users;
 using Gameboard.Api.Services;
 using MediatR;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 
 namespace Gameboard.Api.Tests.Unit;
@@ -113,7 +112,6 @@ public class ChallengeServiceTests
             A.Fake<ILogger<ChallengeService>>(),
             A.Fake<IMapper>(),
             A.Fake<IMediator>(),
-            A.Fake<IMemoryCache>(),
             A.Fake<INowService>(),
             A.Fake<IPracticeService>(),
             A.Fake<IUserRolePermissionsService>(),
@@ -237,7 +235,6 @@ public class ChallengeServiceTests
             A.Fake<ILogger<ChallengeService>>(),
             A.Fake<IMapper>(),
             A.Fake<IMediator>(),
-            A.Fake<IMemoryCache>(),
             A.Fake<INowService>(),
             A.Fake<IPracticeService>(),
             A.Fake<IUserRolePermissionsService>(),

--- a/src/Gameboard.Api.Tests.Unit/Tests/Features/Player/PlayerServiceTests.cs
+++ b/src/Gameboard.Api.Tests.Unit/Tests/Features/Player/PlayerServiceTests.cs
@@ -6,20 +6,6 @@ namespace Gameboard.Api.Tests.Unit;
 public class PlayerServiceTests
 {
     [Theory, GameboardAutoData]
-    public async Task Standings_WhenGameIdIsEmpty_ReturnsEmptyArray(IFixture fixture)
-    {
-        // arrange
-        var sut = fixture.Create<PlayerService>();
-        var filterParams = A.Fake<PlayerDataFilter>();
-
-        // act
-        var result = await sut.Standings(filterParams);
-
-        // assert
-        result.ShouldBe(Array.Empty<Standing>());
-    }
-
-    [Theory, GameboardAutoData]
     public async Task MakeCertificates_WhenScoreZero_ReturnsEmptyArray(IFixture fixture)
     {
         // arrange

--- a/src/Gameboard.Api.Tests.Unit/Tests/Features/Practice/SearchPracticeChallengesTests.cs
+++ b/src/Gameboard.Api.Tests.Unit/Tests/Features/Practice/SearchPracticeChallengesTests.cs
@@ -1,5 +1,3 @@
-using System.Security.Cryptography.Pkcs;
-using AutoMapper;
 using Gameboard.Api.Common;
 using Gameboard.Api.Common.Services;
 using Gameboard.Api.Data;

--- a/src/Gameboard.Api.Tests.Unit/Tests/Features/Practice/SearchPracticeChallengesTests.cs
+++ b/src/Gameboard.Api.Tests.Unit/Tests/Features/Practice/SearchPracticeChallengesTests.cs
@@ -52,6 +52,7 @@ public class SearchPracticeChallengesTests
             Disabled = false,
             Game = new Data.Game
             {
+                IsPublished = true,
                 Name = fixture.Create<string>(),
                 PlayerMode = PlayerMode.Practice
             }

--- a/src/Gameboard.Api.Tests.Unit/Tests/Features/Practice/SearchPracticeChallengesTests.cs
+++ b/src/Gameboard.Api.Tests.Unit/Tests/Features/Practice/SearchPracticeChallengesTests.cs
@@ -1,9 +1,11 @@
+using System.Security.Cryptography.Pkcs;
 using AutoMapper;
 using Gameboard.Api.Common;
 using Gameboard.Api.Common.Services;
 using Gameboard.Api.Data;
 using Gameboard.Api.Features.Challenges;
 using Gameboard.Api.Features.Practice;
+using Gameboard.Api.Features.Users;
 using Microsoft.EntityFrameworkCore;
 
 namespace Gameboard.Api.Tests.Unit;
@@ -32,9 +34,8 @@ public class SearchPracticeChallengesTests
         var sut = GetSutWithResults(fixture, disabledSpec);
 
         // when a query for all challenges is issued
-        var result = await sut
-            .BuildQuery(string.Empty, Array.Empty<string>())
-            .ToArrayAsync(CancellationToken.None);
+        var query = await sut.BuildQuery(string.Empty, []);
+        var result = await query.ToArrayAsync(CancellationToken.None);
 
         // then we expect no results
         result.Length.ShouldBe(0);
@@ -61,9 +62,8 @@ public class SearchPracticeChallengesTests
         var sut = GetSutWithResults(fixture, enabledSpec);
 
         // when a query for all challenges is issued
-        var result = await sut
-            .BuildQuery(string.Empty, Array.Empty<string>())
-            .ToArrayAsync(CancellationToken.None);
+        var query = await sut.BuildQuery(string.Empty, []);
+        var result = await query.ToArrayAsync(CancellationToken.None);
 
         // then we expect one result
         result.Length.ShouldBe(1);
@@ -81,8 +81,8 @@ public class SearchPracticeChallengesTests
         var sut = new SearchPracticeChallengesHandler
         (
             A.Fake<IChallengeDocsService>(),
-            A.Fake<IMapper>(),
             A.Fake<IPagingService>(),
+            A.Fake<IUserRolePermissionsService>(),
             A.Fake<IPracticeService>(),
             A.Fake<ISlugService>(),
             store

--- a/src/Gameboard.Api/Features/Admin/Requests/GetGameCenterContext/GetGameCenterContext.cs
+++ b/src/Gameboard.Api/Features/Admin/Requests/GetGameCenterContext/GetGameCenterContext.cs
@@ -16,32 +16,22 @@ namespace Gameboard.Api.Features.Admin;
 
 public record GetGameCenterContextQuery(string GameId) : IRequest<GameCenterContext>;
 
-internal class GetGameCenterContextHandler : IRequestHandler<GetGameCenterContextQuery, GameCenterContext>
+internal class GetGameCenterContextHandler
+(
+    EntityExistsValidator<GetGameCenterContextQuery, Data.Game> gameExists,
+    INowService now,
+    IStore store,
+    ITeamService teamService,
+    TicketService ticketService,
+    IValidatorService<GetGameCenterContextQuery> validator
+) : IRequestHandler<GetGameCenterContextQuery, GameCenterContext>
 {
-    private readonly EntityExistsValidator<GetGameCenterContextQuery, Data.Game> _gameExists;
-    private readonly INowService _now;
-    private readonly IStore _store;
-    private readonly ITeamService _teamService;
-    private readonly TicketService _ticketService;
-    private readonly IValidatorService<GetGameCenterContextQuery> _validator;
-
-    public GetGameCenterContextHandler
-    (
-        EntityExistsValidator<GetGameCenterContextQuery, Data.Game> gameExists,
-        INowService now,
-        IStore store,
-        ITeamService teamService,
-        TicketService ticketService,
-        IValidatorService<GetGameCenterContextQuery> validator
-    )
-    {
-        _gameExists = gameExists;
-        _now = now;
-        _store = store;
-        _teamService = teamService;
-        _ticketService = ticketService;
-        _validator = validator;
-    }
+    private readonly EntityExistsValidator<GetGameCenterContextQuery, Data.Game> _gameExists = gameExists;
+    private readonly INowService _now = now;
+    private readonly IStore _store = store;
+    private readonly ITeamService _teamService = teamService;
+    private readonly TicketService _ticketService = ticketService;
+    private readonly IValidatorService<GetGameCenterContextQuery> _validator = validator;
 
     public async Task<GameCenterContext> Handle(GetGameCenterContextQuery request, CancellationToken cancellationToken)
     {
@@ -86,8 +76,11 @@ internal class GetGameCenterContextHandler : IRequestHandler<GetGameCenterContex
             })
             .SingleOrDefaultAsync(cancellationToken);
 
-        var openTicketCount = await _ticketService
-            .GetGameOpenTickets(request.GameId)
+        var gameTotalTicketCount = await _ticketService
+            .GetGameTicketsQuery(request.GameId)
+            .CountAsync(cancellationToken);
+        var gameOpenTicketCount = await _ticketService
+            .GetGameOpenTicketsQuery(request.GameId)
             .CountAsync(cancellationToken);
 
         var topScore = await _store
@@ -185,7 +178,8 @@ internal class GetGameCenterContextHandler : IRequestHandler<GetGameCenterContex
             // aggregates
             ChallengeCount = challengeData?.ChallengeCount ?? 0,
             PointsAvailable = challengeData?.PointsAvailable ?? 0,
-            OpenTicketCount = openTicketCount
+            OpenTicketCount = gameTotalTicketCount,
+            TotalTicketCount = gameTotalTicketCount
         };
     }
 }

--- a/src/Gameboard.Api/Features/Admin/Requests/GetGameCenterContext/GetGameCenterContext.cs
+++ b/src/Gameboard.Api/Features/Admin/Requests/GetGameCenterContext/GetGameCenterContext.cs
@@ -178,7 +178,7 @@ internal class GetGameCenterContextHandler
             // aggregates
             ChallengeCount = challengeData?.ChallengeCount ?? 0,
             PointsAvailable = challengeData?.PointsAvailable ?? 0,
-            OpenTicketCount = gameTotalTicketCount,
+            OpenTicketCount = gameOpenTicketCount,
             TotalTicketCount = gameTotalTicketCount
         };
     }

--- a/src/Gameboard.Api/Features/Admin/Requests/GetGameCenterContext/GetGameCenterContextModels.cs
+++ b/src/Gameboard.Api/Features/Admin/Requests/GetGameCenterContext/GetGameCenterContextModels.cs
@@ -15,6 +15,7 @@ public sealed class GameCenterContext
 
     public required int ChallengeCount { get; set; }
     public required int OpenTicketCount { get; set; }
+    public required int TotalTicketCount { get; set; }
 
     public required bool HasScoreboard { get; set; }
     public required bool IsExternal { get; set; }

--- a/src/Gameboard.Api/Features/Challenge/Challenge.cs
+++ b/src/Gameboard.Api/Features/Challenge/Challenge.cs
@@ -49,6 +49,18 @@ public class ChallengeSummary
     public bool IsActive { get; set; }
 }
 
+public sealed class ChallengeLaunchCacheEntry
+{
+    public required string TeamId { get; set; }
+    public required IList<ChallengeLaunchCacheEntrySpec> Specs { get; set; } = [];
+}
+
+public sealed class ChallengeLaunchCacheEntrySpec
+{
+    public required string GameId { get; set; }
+    public required string SpecId { get; set; }
+}
+
 public class UserActiveChallenge
 {
     public required string Id { get; set; }

--- a/src/Gameboard.Api/Features/Challenge/ChallengeMapper.cs
+++ b/src/Gameboard.Api/Features/Challenge/ChallengeMapper.cs
@@ -49,15 +49,13 @@ namespace Gameboard.Api.Services
                 .ForMember(d => d.LastScoreTime, opt => opt.MapFrom(s => s.Challenge.LastScoreTime))
                 .ForMember(d => d.Score, opt => opt.MapFrom(s => s.Challenge.Score))
                 .ForMember(d => d.HasDeployedGamespace, opt => opt.MapFrom(s => s.Vms != null && s.Vms.Any()))
-                .ForMember(d => d.State, opt => opt.MapFrom(s => JsonSerializer.Serialize(s, JsonOptions)))
-            ;
+                .ForMember(d => d.State, opt => opt.MapFrom(s => JsonSerializer.Serialize(s, JsonOptions)));
 
             CreateMap<Data.Challenge, Challenge>()
                 .ForMember(d => d.Score, opt => opt.MapFrom(s => (int)Math.Floor(s.Score)))
                 .ForMember(d => d.State, opt => opt.MapFrom(s =>
                     JsonSerializer.Deserialize<GameEngineGameState>(s.State, JsonOptions))
-                )
-            ;
+                );
 
             CreateMap<Data.Player, ChallengePlayer>()
                 .ForMember(cp => cp.IsManager, o => o.MapFrom(p => p.Role == PlayerRole.Manager));
@@ -67,7 +65,7 @@ namespace Gameboard.Api.Services
                 .ForMember(d => d.Events, o => o.MapFrom(c => c.Events.OrderBy(e => e.Timestamp)))
                 .ForMember(s => s.Players, o => o.MapFrom(d => new ChallengePlayer[]
                 {
-                    new ChallengePlayer
+                    new()
                     {
                         Id = d.PlayerId,
                         Name = d.Player.Name,

--- a/src/Gameboard.Api/Features/Challenge/Services/ChallengeService.cs
+++ b/src/Gameboard.Api/Features/Challenge/Services/ChallengeService.cs
@@ -470,7 +470,7 @@ public partial class ChallengeService
         // load and regrade
         var challenge = await _challengeStore.Retrieve(id);
         // preserve the score prior to regrade
-        double currentScore = challenge.Score;
+        var currentScore = challenge.Score;
         // who's regrading?
         var actingUserId = _actingUserService.Get()?.Id;
 
@@ -533,7 +533,7 @@ public partial class ChallengeService
         if (challenges == null || !challenges.Any())
             return;
 
-        Logger.LogInformation($"Archiving {challenges.Count()} challenges.");
+        Logger.LogInformation("Archiving {challengeCount} challenges.", challenges.Count());
         var toArchiveIds = challenges.Select(c => c.Id).ToArray();
 
         var teamMemberMap = await _store

--- a/src/Gameboard.Api/Features/ChallengeSpec/ChallengeSpecMapper.cs
+++ b/src/Gameboard.Api/Features/ChallengeSpec/ChallengeSpecMapper.cs
@@ -37,10 +37,10 @@ namespace Gameboard.Api.Services
         private static partial Regex TagsSplitRegex();
 
         // EF advises to make this mapping a static method to avoid memory leaks
-        private static IEnumerable<string> StringTagsToEnumerableStringTags(string tagsIn)
+        public static IEnumerable<string> StringTagsToEnumerableStringTags(string tagsIn)
         {
             if (tagsIn.IsEmpty())
-                return Array.Empty<string>();
+                return [];
 
             return TagsSplitRegex().Split(tagsIn);
         }

--- a/src/Gameboard.Api/Features/Game/GameExceptions.cs
+++ b/src/Gameboard.Api/Features/Game/GameExceptions.cs
@@ -87,7 +87,14 @@ internal class PracticeSessionLimitReached : GameboardValidationException
 
 internal class SessionLimitReached : GameboardValidationException
 {
-    public SessionLimitReached(string teamId, string gameId, int sessions, int sessionLimit) : base($"Can't start a new game ({gameId}) for team \"{teamId}\". The session limit is {sessionLimit}, and the team has {sessions} sessions.") { }
+    public SessionLimitReached(string teamId, SimpleEntity game, int sessions, int sessionLimit)
+        : base($"""Can't start a new "{game.Name}" session for for team \"{teamId}\". The session limit is {sessionLimit}, and the team has {sessions} sessions.""") { }
+}
+
+internal class GameSessionLimitReached : GameboardValidationException
+{
+    public GameSessionLimitReached(SimpleEntity game, int sessionLimit, int currentSessionCount)
+        : base($"""Can't start new session(s) for "{game.Name}". There are {currentSessionCount} session active, and its limit is {sessionLimit}.""") { }
 }
 
 internal class SpecNotFound : GameboardException

--- a/src/Gameboard.Api/Features/Game/GameService.cs
+++ b/src/Gameboard.Api/Features/Game/GameService.cs
@@ -3,8 +3,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -14,8 +16,6 @@ using YamlDotNet.Serialization.NamingConventions;
 using Gameboard.Api.Common.Services;
 using Microsoft.AspNetCore.Http;
 using Gameboard.Api.Data;
-using System.IO;
-using System.Threading;
 using Gameboard.Api.Features.Users;
 
 namespace Gameboard.Api.Services;
@@ -112,15 +112,14 @@ public class GameService(
     {
         var gameSessionData = await _store
             .WithNoTracking<Data.Game>()
-                .Include(g => g.Players)
             .Where(g => g.Id == gameId)
-            .Where(g => g.Players.Any(p => _now.Get() < p.SessionEnd))
             .Select(g => new
             {
                 g.Id,
                 g.SessionLimit,
                 Teams = g
                     .Players
+                    .Where(p => _now.Get() < p.SessionEnd)
                     .Select(p => p.TeamId)
                     .Distinct()
             })

--- a/src/Gameboard.Api/Features/Game/Requests/GetGamePlayState/GetGamePlayState.cs
+++ b/src/Gameboard.Api/Features/Game/Requests/GetGamePlayState/GetGamePlayState.cs
@@ -48,7 +48,9 @@ internal class GetGamePlayStateHandler(
             .AddValidator((req, ctx) =>
             {
                 if (gameId.IsEmpty())
-                    ctx.AddValidationException(new TeamHasNoPlayersException(request.TeamId));
+                {
+                    throw new ResourceNotFound<Team>(request.TeamId);
+                }
             })
             .Validate(request, cancellationToken);
 

--- a/src/Gameboard.Api/Features/Player/PlayerController.cs
+++ b/src/Gameboard.Api/Features/Player/PlayerController.cs
@@ -86,13 +86,13 @@ public class PlayerController(
     {
         await AuthorizeAny
         (
-            () => _permissionsService.IsActingUserAsync(model.Id),
+            () => IsSelf(model.Id),
             () => _permissionsService.Can(PermissionKey.Teams_ApproveNameChanges)
         );
 
         await Validate(model);
 
-        var result = await PlayerService.Update(model, Actor, await _permissionsService.Can(PermissionKey.Teams_ApproveNameChanges));
+        var result = await PlayerService.Update(model, Actor);
         return Mapper.Map<PlayerUpdatedViewModel>(result);
     }
 
@@ -120,12 +120,11 @@ public class PlayerController(
     /// Delete a player enrollment
     /// </summary>
     /// <param name="playerId"></param>
-    /// <param name="asAdmin"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     [HttpDelete("/api/player/{playerId}")]
     [Authorize]
-    public async Task Unenroll([FromRoute] string playerId, [FromQuery] bool asAdmin, CancellationToken cancellationToken)
+    public async Task Unenroll([FromRoute] string playerId, CancellationToken cancellationToken)
     {
         await AuthorizeAny
         (

--- a/src/Gameboard.Api/Features/Player/PlayerController.cs
+++ b/src/Gameboard.Api/Features/Player/PlayerController.cs
@@ -233,13 +233,13 @@ public class PlayerController
         await AuthorizeAny
         (
             () => _permissionsService.Can(PermissionKey.Teams_Enroll),
-            () => IsSelf(promoteRequest.CurrentManagerPlayerId)
+            () => IsSelf(promoteRequest.CurrentCaptainId)
         );
 
         var model = new PromoteToManagerRequest
         {
             Actor = Actor,
-            CurrentManagerPlayerId = promoteRequest.CurrentManagerPlayerId,
+            CurrentCaptainId = promoteRequest.CurrentCaptainId,
             NewManagerPlayerId = playerId,
             TeamId = teamId
         };

--- a/src/Gameboard.Api/Features/Player/PlayerController.cs
+++ b/src/Gameboard.Api/Features/Player/PlayerController.cs
@@ -21,7 +21,8 @@ using Microsoft.Extensions.Logging;
 namespace Gameboard.Api.Controllers;
 
 [Authorize]
-public class PlayerController(
+public class PlayerController
+(
     IActingUserService actingUserService,
     ILogger<PlayerController> logger,
     IDistributedCache cache,
@@ -31,7 +32,7 @@ public class PlayerController(
     IMapper _mapper,
     IUserRolePermissionsService permissionsService,
     ITeamService teamService
-    ) : GameboardLegacyController(actingUserService, logger, cache, validator)
+) : GameboardLegacyController(actingUserService, logger, cache, validator)
 {
     private readonly IMapper Mapper = _mapper;
     private readonly IMediator _mediator = mediator;
@@ -96,13 +97,13 @@ public class PlayerController(
         return Mapper.Map<PlayerUpdatedViewModel>(result);
     }
 
-    [HttpPut("api/player/{playerId}/ready")]
     [Authorize]
+    [HttpPut("api/player/{playerId}/ready")]
     public Task UpdatePlayerReady([FromRoute] string playerId, [FromBody] PlayerReadyUpdate readyUpdate)
         => _mediator.Send(new UpdatePlayerReadyStateCommand(playerId, readyUpdate.IsReady, Actor));
 
-    [HttpPut("api/player/{playerId}/start")]
     [Authorize]
+    [HttpPut("api/player/{playerId}/start")]
     public async Task<Player> Start(string playerId)
     {
         await AuthorizeAny
@@ -122,8 +123,8 @@ public class PlayerController(
     /// <param name="playerId"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    [HttpDelete("/api/player/{playerId}")]
     [Authorize]
+    [HttpDelete("/api/player/{playerId}")]
     public async Task Unenroll([FromRoute] string playerId, CancellationToken cancellationToken)
     {
         await AuthorizeAny

--- a/src/Gameboard.Api/Features/Player/PlayerController.cs
+++ b/src/Gameboard.Api/Features/Player/PlayerController.cs
@@ -206,7 +206,7 @@ public class PlayerController(
     {
         await AuthorizeAny
         (
-            () => _permissionsService.IsActingUserAsync(id),
+            () => IsSelf(id),
             () => _permissionsService.Can(PermissionKey.Teams_Enroll)
         );
 

--- a/src/Gameboard.Api/Features/Player/PlayerExceptions.cs
+++ b/src/Gameboard.Api/Features/Player/PlayerExceptions.cs
@@ -83,6 +83,7 @@ internal class RegistrationIsClosed : GameboardValidationException
 internal class SessionAlreadyStarted : GameboardValidationException
 {
     internal SessionAlreadyStarted(string playerId, string why) : base($"Player {playerId}'s session was started. {why}.") { }
+    internal SessionAlreadyStarted(string teamId) : base($"Session for team {teamId} already started.") { }
 }
 
 internal class SessionNotActive : GameboardException

--- a/src/Gameboard.Api/Features/Player/PlayerMapper.cs
+++ b/src/Gameboard.Api/Features/Player/PlayerMapper.cs
@@ -44,14 +44,22 @@ public class PlayerMapper : Profile
             .ForMember(vm => vm.PreUpdateName, opts => opts.Ignore());
 
         CreateMap<Data.Player, Team>()
-            .AfterMap((player, team) => team.Members = new List<TeamMember>
+            .AfterMap((player, team) =>
             {
-                new()
+                team.Members =
+                [
+                    new()
+                    {
+                        Id = player.Id,
+                        ApprovedName = player.ApprovedName,
+                        Role = player.Role,
+                        UserId = player.UserId
+                    }
+                ];
+
+                if (team.Members.Any() && !team.Members.Any(p => p.Role == PlayerRole.Manager))
                 {
-                    Id = player.Id,
-                    ApprovedName = player.ApprovedName,
-                    Role = player.Role,
-                    UserId = player.UserId
+                    team.Members.OrderBy(p => p.ApprovedName).First().Role = PlayerRole.Manager;
                 }
             });
     }

--- a/src/Gameboard.Api/Features/Player/PlayerValidator.cs
+++ b/src/Gameboard.Api/Features/Player/PlayerValidator.cs
@@ -133,11 +133,11 @@ public class PlayerValidator(
         // INDEPENDENT OF ADMIN
         var currentManager = await _store
             .WithNoTracking<Data.Player>()
-            .SingleOrDefaultAsync(p => p.Id == model.CurrentManagerPlayerId)
-            ?? throw new ResourceNotFound<Player>(model.CurrentManagerPlayerId, $"Couldn't resolve the player record for current manager {model.CurrentManagerPlayerId}.");
+            .SingleOrDefaultAsync(p => p.Id == model.CurrentCaptainId)
+            ?? throw new ResourceNotFound<Player>(model.CurrentCaptainId, $"Couldn't resolve the player record for current manager {model.CurrentCaptainId}.");
 
         if (!currentManager.IsManager)
-            throw new PlayerIsntManager(model.CurrentManagerPlayerId, "Calls to this endpoint must supply the correct ID of the current manager.");
+            throw new PlayerIsntManager(model.CurrentCaptainId, "Calls to this endpoint must supply the correct ID of the current manager.");
 
         var newManager = await _store
             .WithNoTracking<Data.Player>()

--- a/src/Gameboard.Api/Features/Practice/PracticeModels.cs
+++ b/src/Gameboard.Api/Features/Practice/PracticeModels.cs
@@ -20,11 +20,6 @@ public sealed class PracticeSession
     public required string UserId { get; set; }
 }
 
-public sealed class SearchPracticeChallengesResult
-{
-    public required PagedEnumerable<ChallengeSpecSummary> Results { get; set; }
-}
-
 public sealed class PracticeModeSettingsApiModel
 {
     public int? AttemptLimit { get; set; }

--- a/src/Gameboard.Api/Features/Practice/Requests/SearchPracticeChallenges/SearchPracticeChallenges.cs
+++ b/src/Gameboard.Api/Features/Practice/Requests/SearchPracticeChallenges/SearchPracticeChallenges.cs
@@ -104,7 +104,7 @@ internal class SearchPracticeChallengesHandler
             // without the permission, neither spec nor the game can be hidden
             q = q
                 .Where(s => !s.IsHidden)
-                .Where(g => !g.IsHidden);
+                .Where(s => s.Game.IsPublished);
         }
 
         if (filterTerm.IsNotEmpty())

--- a/src/Gameboard.Api/Features/Practice/Requests/SearchPracticeChallenges/SearchPracticeChallenges.cs
+++ b/src/Gameboard.Api/Features/Practice/Requests/SearchPracticeChallenges/SearchPracticeChallenges.cs
@@ -2,10 +2,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using AutoMapper;
 using Gameboard.Api.Common.Services;
 using Gameboard.Api.Data;
 using Gameboard.Api.Features.Challenges;
+using Gameboard.Api.Features.Users;
+using Gameboard.Api.Services;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 
@@ -16,16 +17,16 @@ public record SearchPracticeChallengesQuery(SearchFilter Filter) : IRequest<Sear
 internal class SearchPracticeChallengesHandler
 (
     IChallengeDocsService challengeDocsService,
-    IMapper mapper,
     IPagingService pagingService,
+    IUserRolePermissionsService permissionsService,
     IPracticeService practiceService,
     ISlugService slugger,
     IStore store
 ) : IRequestHandler<SearchPracticeChallengesQuery, SearchPracticeChallengesResult>
 {
     private readonly IChallengeDocsService _challengeDocsService = challengeDocsService;
-    private readonly IMapper _mapper = mapper;
     private readonly IPagingService _pagingService = pagingService;
+    private readonly IUserRolePermissionsService _permissionsService = permissionsService;
     private readonly IPracticeService _practiceService = practiceService;
     private readonly ISlugService _slugger = slugger;
     private readonly IStore _store = store;
@@ -36,8 +37,28 @@ internal class SearchPracticeChallengesHandler
         var settings = await _practiceService.GetSettings(cancellationToken);
         var sluggedSuggestedSearches = settings.SuggestedSearches.Select(search => _slugger.Get(search));
 
-        var query = BuildQuery(request.Filter.Term, sluggedSuggestedSearches);
-        var results = await _mapper.ProjectTo<ChallengeSpecSummary>(query).ToArrayAsync(cancellationToken);
+        var query = await BuildQuery(request.Filter.Term, sluggedSuggestedSearches);
+        var results = await _store
+            .WithNoTracking<Data.ChallengeSpec>()
+            .Select(s => new PracticeChallengeView
+            {
+                Id = s.Id,
+                Name = s.Name,
+                Description = s.Description,
+                Text = s.Text,
+                AverageDeploySeconds = s.AverageDeploySeconds,
+                IsHidden = s.IsHidden,
+                SolutionGuideUrl = s.SolutionGuideUrl,
+                Tags = ChallengeSpecMapper.StringTagsToEnumerableStringTags(s.Tags),
+                Game = new PracticeChallengeViewGame
+                {
+                    Id = s.Game.Id,
+                    Name = s.Game.Name,
+                    Logo = s.Game.Logo,
+                    IsHidden = !s.Game.IsPublished
+                }
+            })
+            .ToArrayAsync(cancellationToken);
 
         foreach (var result in results)
         {
@@ -69,14 +90,23 @@ internal class SearchPracticeChallengesHandler
     /// <param name="filterTerm"></param>
     /// <param name="sluggedSuggestedSearches"></param>
     /// <returns></returns>
-    internal IQueryable<Data.ChallengeSpec> BuildQuery(string filterTerm, IEnumerable<string> sluggedSuggestedSearches)
+    internal async Task<IQueryable<Data.ChallengeSpec>> BuildQuery(string filterTerm, IEnumerable<string> sluggedSuggestedSearches)
     {
+        var canViewHidden = await _permissionsService.Can(PermissionKey.Games_ViewUnpublished);
+
         var q = _store
             .WithNoTracking<Data.ChallengeSpec>()
             .Include(s => s.Game)
             .Where(s => s.Game.PlayerMode == PlayerMode.Practice)
-            .Where(s => !s.Disabled)
-            .Where(s => !s.IsHidden);
+            .Where(s => !s.Disabled);
+
+        if (!canViewHidden)
+        {
+            // without the permission, neither spec nor the game can be hidden
+            q = q
+                .Where(s => !s.IsHidden)
+                .Where(g => !g.IsHidden);
+        }
 
         if (filterTerm.IsNotEmpty())
         {

--- a/src/Gameboard.Api/Features/Practice/Requests/SearchPracticeChallenges/SearchPracticeChallenges.cs
+++ b/src/Gameboard.Api/Features/Practice/Requests/SearchPracticeChallenges/SearchPracticeChallenges.cs
@@ -38,8 +38,7 @@ internal class SearchPracticeChallengesHandler
         var sluggedSuggestedSearches = settings.SuggestedSearches.Select(search => _slugger.Get(search));
 
         var query = await BuildQuery(request.Filter.Term, sluggedSuggestedSearches);
-        var results = await _store
-            .WithNoTracking<Data.ChallengeSpec>()
+        var results = await query
             .Select(s => new PracticeChallengeView
             {
                 Id = s.Id,

--- a/src/Gameboard.Api/Features/Practice/Requests/SearchPracticeChallenges/SearchPracticeChallengesModels.cs
+++ b/src/Gameboard.Api/Features/Practice/Requests/SearchPracticeChallenges/SearchPracticeChallengesModels.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+
+namespace Gameboard.Api.Features.Practice;
+
+public sealed class SearchPracticeChallengesResult
+{
+    public required PagedEnumerable<PracticeChallengeView> Results { get; set; }
+}
+
+public sealed class PracticeChallengeView
+{
+    public required string Id { get; set; }
+    public required string Name { get; set; }
+    public required string Description { get; set; }
+    public required string Text { get; set; }
+    public required PracticeChallengeViewGame Game { get; set; }
+    public required int AverageDeploySeconds { get; set; }
+    public required bool IsHidden { get; set; }
+    public required string SolutionGuideUrl { get; set; }
+    public required IEnumerable<string> Tags { get; set; }
+}
+
+public sealed class PracticeChallengeViewGame
+{
+    public required string Id { get; set; }
+    public required string Name { get; set; }
+    public required string Logo { get; set; }
+    public required bool IsHidden { get; set; }
+}

--- a/src/Gameboard.Api/Features/Reports/Queries/PlayersReport/PlayersReportService.cs
+++ b/src/Gameboard.Api/Features/Reports/Queries/PlayersReport/PlayersReportService.cs
@@ -2,7 +2,6 @@ using System;
 using System.Linq;
 using Gameboard.Api.Data;
 using Microsoft.EntityFrameworkCore;
-using ServiceStack;
 
 namespace Gameboard.Api.Features.Reports;
 
@@ -11,16 +10,10 @@ public interface IPlayersReportService
     IQueryable<PlayersReportRecord> GetQuery(PlayersReportParameters parameters);
 }
 
-internal class PlayersReportService : IPlayersReportService
+internal class PlayersReportService(IReportsService reportsService, IStore store) : IPlayersReportService
 {
-    private readonly IReportsService _reportsService;
-    private readonly IStore _store;
-
-    public PlayersReportService(IReportsService reportsService, IStore store)
-    {
-        _reportsService = reportsService;
-        _store = store;
-    }
+    private readonly IReportsService _reportsService = reportsService;
+    private readonly IStore _store = store;
 
     public IQueryable<PlayersReportRecord> GetQuery(PlayersReportParameters parameters)
     {

--- a/src/Gameboard.Api/Features/Teams/Requests/AddPlayerToTeam/AddPlayerToTeam.cs
+++ b/src/Gameboard.Api/Features/Teams/Requests/AddPlayerToTeam/AddPlayerToTeam.cs
@@ -17,7 +17,8 @@ namespace Gameboard.Api.Features.Teams;
 
 public record AddPlayerToTeamCommand(string PlayerId, string InvitationCode) : IRequest<Api.Player>;
 
-internal class AddPlayerToTeamHandler(
+internal class AddPlayerToTeamHandler
+(
     IActingUserService actingUserService,
     IInternalHubBus hubBus,
     IMapper mapper,
@@ -27,7 +28,8 @@ internal class AddPlayerToTeamHandler(
     EntityExistsValidator<Data.Player> playerExists,
     IStore store,
     ITeamService teamService,
-    IValidatorService<AddPlayerToTeamCommand> validatorService) : IRequestHandler<AddPlayerToTeamCommand, Api.Player>
+    IValidatorService<AddPlayerToTeamCommand> validatorService
+) : IRequestHandler<AddPlayerToTeamCommand, Api.Player>
 {
     private readonly IActingUserService _actingUserService = actingUserService;
     private readonly IInternalHubBus _hubBus = hubBus;

--- a/src/Gameboard.Api/Features/Teams/Requests/AddToTeam/AddToTeam.cs
+++ b/src/Gameboard.Api/Features/Teams/Requests/AddToTeam/AddToTeam.cs
@@ -1,0 +1,137 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Gameboard.Api.Common.Services;
+using Gameboard.Api.Data;
+using Gameboard.Api.Features.Games;
+using Gameboard.Api.Features.Player;
+using Gameboard.Api.Services;
+using Gameboard.Api.Structure.MediatR;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using ServiceStack;
+
+namespace Gameboard.Api.Features.Teams;
+
+public record AddToTeamCommand(string TeamId, string UserId) : IRequest<AddToTeamResponse>;
+
+internal sealed class AddToTeamCommandHandler
+(
+    IActingUserService actingUser,
+    PlayerService playerService,
+    IStore store,
+    ITeamService teamService,
+    IValidatorService validator
+) : IRequestHandler<AddToTeamCommand, AddToTeamResponse>
+{
+    private readonly IActingUserService _actingUser = actingUser;
+    private readonly PlayerService _playerService = playerService;
+    private readonly IStore _store = store;
+    private readonly ITeamService _teamService = teamService;
+    private readonly IValidatorService _validator = validator;
+
+    public async Task<AddToTeamResponse> Handle(AddToTeamCommand request, CancellationToken cancellationToken)
+    {
+        await _validator
+            .Auth
+            (
+                c => c
+                    .RequirePermissions(Users.PermissionKey.Teams_Enroll)
+                    .Unless
+                    (
+                        async () => await _store
+                            .WithNoTracking<Data.Player>()
+                            .Where(p => p.TeamId == request.TeamId && p.Role == PlayerRole.Manager)
+                            .Where(p => p.UserId == _actingUser.Get().Id)
+                            .AnyAsync(cancellationToken)
+                    )
+            )
+            .AddValidator(async ctx =>
+            {
+                // team hasn't started playing
+                var team = await _teamService.GetTeam(request.TeamId);
+                if (team.SessionBegin.IsNotEmpty())
+                {
+                    ctx.AddValidationException(new SessionAlreadyStarted(request.TeamId));
+                }
+
+                // team's current roster has to be < max
+                var gameId = await _teamService.GetGameId(request.TeamId, cancellationToken);
+                var maxTeamSize = await _store
+                    .WithNoTracking<Data.Game>()
+                    .Where(g => g.Id == gameId)
+                    .Select(g => g.MaxTeamSize)
+                    .SingleAsync(cancellationToken);
+
+                if (team.Members.Count() >= maxTeamSize)
+                {
+                    ctx.AddValidationException(new TeamIsFull(new SimpleEntity { Id = team.TeamId, Name = team.ApprovedName }, team.Members.Count(), maxTeamSize));
+                }
+
+                // if the player is joining a competitive team, they can't have played this game
+                // competitively before
+                if (team.Mode == PlayerMode.Competition)
+                {
+                    var priorPlayer = await _store
+                        .WithNoTracking<Data.Player>()
+                        .Where(p => p.UserId == request.UserId && p.TeamId != team.TeamId)
+                        .Where(p => p.GameId == team.GameId)
+                        .Where(p => p.Mode == PlayerMode.Competition)
+                        .WhereDateIsNotEmpty(p => p.SessionBegin)
+                        .Select(p => new
+                        {
+                            p.Id,
+                            p.ApprovedName,
+                            Game = new SimpleEntity { Id = p.GameId, Name = p.Game.Name },
+                            User = new SimpleEntity { Id = p.UserId, Name = p.User.ApprovedName },
+                            p.SessionBegin,
+                            p.TeamId
+                        })
+                        .SingleOrDefaultAsync(cancellationToken);
+
+                    if (priorPlayer is not null)
+                    {
+                        ctx.AddValidationException(new UserAlreadyPlayed(priorPlayer.User, priorPlayer.Game, priorPlayer.TeamId, priorPlayer.SessionBegin));
+                    }
+                }
+            })
+            // 
+            .Validate(cancellationToken);
+
+        // first find the team they're meant to join
+        var team = await _teamService.GetTeam(request.TeamId);
+
+        // first ensure the person is enrolled
+        var existingPlayerId = await _store
+            .WithNoTracking<Data.Player>()
+            .Where(p => p.UserId == request.UserId)
+            .Where(p => p.TeamId != request.TeamId)
+            .WhereDateIsEmpty(p => p.SessionBegin)
+            .Where(p => p.GameId == team.GameId)
+            .Select(p => p.Id)
+            .SingleOrDefaultAsync(cancellationToken);
+
+        if (existingPlayerId.IsEmpty())
+        {
+            var existingPlayer = await _playerService.Enroll
+            (
+                new NewPlayer { GameId = team.GameId, UserId = request.UserId },
+                _actingUser.Get(),
+                cancellationToken
+            );
+
+            existingPlayerId = existingPlayer.Id;
+        }
+
+        var players = await _teamService.AddPlayers(request.TeamId, cancellationToken, existingPlayerId);
+        var addedPlayer = players.Single();
+
+        return new AddToTeamResponse
+        {
+            Game = new SimpleEntity { Id = addedPlayer.GameId, Name = addedPlayer.GameName },
+            Player = new SimpleEntity { Id = addedPlayer.Id, Name = addedPlayer.ApprovedName },
+            Team = new SimpleEntity { Id = team.TeamId, Name = team.ApprovedName },
+            User = new SimpleEntity { Id = addedPlayer.UserId, Name = addedPlayer.UserApprovedName }
+        };
+    }
+}

--- a/src/Gameboard.Api/Features/Teams/Requests/AddToTeam/AddToTeamModels.cs
+++ b/src/Gameboard.Api/Features/Teams/Requests/AddToTeam/AddToTeamModels.cs
@@ -1,0 +1,18 @@
+using System;
+using Gameboard.Api.Structure;
+
+namespace Gameboard.Api.Features.Teams;
+
+public sealed class AddToTeamResponse
+{
+    public required SimpleEntity Game { get; set; }
+    public required SimpleEntity Player { get; set; }
+    public required SimpleEntity Team { get; set; }
+    public required SimpleEntity User { get; set; }
+}
+
+internal sealed class UserAlreadyPlayed : GameboardValidationException
+{
+    public UserAlreadyPlayed(SimpleEntity user, SimpleEntity game, string teamId, DateTimeOffset sessionStart)
+        : base($"""User "{user.Name}" already played game {game.Name} on {sessionStart} (team {teamId})""") { }
+}

--- a/src/Gameboard.Api/Features/Teams/Requests/AdminEnrollTeam/AdminEnrollTeam.cs
+++ b/src/Gameboard.Api/Features/Teams/Requests/AdminEnrollTeam/AdminEnrollTeam.cs
@@ -84,7 +84,10 @@ internal class AdminEnrollTeamHandler
         // TODO: kinda yucky. Want to share logic about what it means to be added to a team, but all the validation around that
         // is in teamService
         var playersToAdd = createdPlayers.Where(p => p.Id != captainPlayer.Id).Select(p => p.Id).ToArray();
-        await _teamService.AddPlayers(captainPlayer.TeamId, cancellationToken, playersToAdd);
+        if (playersToAdd.Length > 0)
+        {
+            await _teamService.AddPlayers(captainPlayer.TeamId, cancellationToken, playersToAdd);
+        }
 
         // make the captain the actual captain
         await _teamService.PromoteCaptain(captainPlayer.TeamId, captainPlayer.Id, actingUser, cancellationToken);

--- a/src/Gameboard.Api/Features/Teams/Requests/AdminEnrollTeam/AdminEnrollTeam.cs
+++ b/src/Gameboard.Api/Features/Teams/Requests/AdminEnrollTeam/AdminEnrollTeam.cs
@@ -27,32 +27,22 @@ public record AdminEnrollTeamRequest
     PlayerMode PlayerMode = PlayerMode.Competition
 ) : IRequest<AdminEnrollTeamResponse>;
 
-internal class AdminEnrollTeamHandler : IRequestHandler<AdminEnrollTeamRequest, AdminEnrollTeamResponse>
+internal class AdminEnrollTeamHandler
+(
+    IActingUserService actingUserService,
+    IGuidService guids,
+    PlayerService playerService,
+    IStore store,
+    ITeamService teamService,
+    IGameboardRequestValidator<AdminEnrollTeamRequest> validator
+) : IRequestHandler<AdminEnrollTeamRequest, AdminEnrollTeamResponse>
 {
-    private readonly IActingUserService _actingUserService;
-    private readonly IGuidService _guids;
-    private readonly PlayerService _playerService;
-    private readonly IStore _store;
-    private readonly ITeamService _teamService;
-    private readonly IGameboardRequestValidator<AdminEnrollTeamRequest> _validator;
-
-    public AdminEnrollTeamHandler
-    (
-        IActingUserService actingUserService,
-        IGuidService guids,
-        PlayerService playerService,
-        IStore store,
-        ITeamService teamService,
-        IGameboardRequestValidator<AdminEnrollTeamRequest> validator
-    )
-    {
-        _actingUserService = actingUserService;
-        _guids = guids;
-        _playerService = playerService;
-        _store = store;
-        _teamService = teamService;
-        _validator = validator;
-    }
+    private readonly IActingUserService _actingUserService = actingUserService;
+    private readonly IGuidService _guids = guids;
+    private readonly PlayerService _playerService = playerService;
+    private readonly IStore _store = store;
+    private readonly ITeamService _teamService = teamService;
+    private readonly IGameboardRequestValidator<AdminEnrollTeamRequest> _validator = validator;
 
     public async Task<AdminEnrollTeamResponse> Handle(AdminEnrollTeamRequest request, CancellationToken cancellationToken)
     {
@@ -91,7 +81,8 @@ internal class AdminEnrollTeamHandler : IRequestHandler<AdminEnrollTeamRequest, 
         }
 
         // team everyone up
-        // TODO: kinda yucky. Want to share logic about what it means to be added to a team, but all the validation around
+        // TODO: kinda yucky. Want to share logic about what it means to be added to a team, but all the validation around that
+        // is in teamService
         var playersToAdd = createdPlayers.Where(p => p.Id != captainPlayer.Id).Select(p => p.Id).ToArray();
         await _teamService.AddPlayers(captainPlayer.TeamId, cancellationToken, playersToAdd);
 

--- a/src/Gameboard.Api/Features/Teams/Requests/RemoveFromTeam/RemoveFromTeam.cs
+++ b/src/Gameboard.Api/Features/Teams/Requests/RemoveFromTeam/RemoveFromTeam.cs
@@ -1,0 +1,94 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Gameboard.Api.Common.Services;
+using Gameboard.Api.Data;
+using Gameboard.Api.Features.Player;
+using Gameboard.Api.Features.Users;
+using Gameboard.Api.Structure.MediatR;
+using Gameboard.Api.Structure.MediatR.Validators;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Gameboard.Api.Features.Teams;
+
+public record RemoveFromTeamCommand(string PlayerId) : IRequest<RemoveFromTeamResponse>;
+
+internal sealed class RemoveFromTeamHandler
+(
+    IGuidService guids,
+    EntityExistsValidator<Data.Player> playerExists,
+    IStore store,
+    IValidatorService validatorService
+) : IRequestHandler<RemoveFromTeamCommand, RemoveFromTeamResponse>
+{
+    private readonly IGuidService _guids = guids;
+    private readonly EntityExistsValidator<Data.Player> _playerExists = playerExists;
+    private readonly IStore _store = store;
+    private readonly IValidatorService _validator = validatorService;
+
+    public async Task<RemoveFromTeamResponse> Handle(RemoveFromTeamCommand request, CancellationToken cancellationToken)
+    {
+        await _validator
+            .Auth(c => c.RequirePermissions(PermissionKey.Teams_Enroll))
+            .AddValidator(_playerExists.UseValue(request.PlayerId))
+            .AddValidator(async ctx =>
+            {
+                var playerData = await _store
+                    .WithNoTracking<Data.Player>()
+                    .Where(p => p.Id == request.PlayerId)
+                    .Select(p => new
+                    {
+                        p.Id,
+                        p.ApprovedName,
+                        p.SessionBegin,
+                        p.Role,
+                        p.TeamId
+                    })
+                    .SingleOrDefaultAsync(cancellationToken);
+
+                // if they started the session already, tough nuggets
+                if (!playerData.SessionBegin.IsEmpty())
+                {
+                    ctx.AddValidationException(new SessionAlreadyStarted(request.PlayerId, "This player can't be removed from the team."));
+                }
+
+                // you can't remove the captain (unenroll them instead)
+                if (playerData.Role == PlayerRole.Manager)
+                {
+                    ctx.AddValidationException(new CantRemoveCaptain(new SimpleEntity { Id = playerData.Id, Name = playerData.ApprovedName }, playerData.TeamId));
+                }
+
+                // in theory the last remaining player should be the captain and should get caught by above,
+                // but because the schema is weird (shoutout #553), check anyway
+                var hasRemainingTeammates = await _store
+                    .WithNoTracking<Data.Player>()
+                    .Where(p => p.TeamId == playerData.TeamId)
+                    .Where(p => p.Id != request.PlayerId)
+                    .AnyAsync(cancellationToken);
+
+                if (!hasRemainingTeammates)
+                {
+                    ctx.AddValidationException(new CantRemoveLastTeamMember(new SimpleEntity { Id = playerData.Id, Name = playerData.ApprovedName }, playerData.TeamId));
+                }
+            })
+            .Validate(cancellationToken);
+
+        await _store
+            .WithNoTracking<Data.Player>()
+            .Where(p => p.Id == request.PlayerId)
+            .ExecuteUpdateAsync(up => up.SetProperty(p => p.TeamId, _guids.Generate()), cancellationToken);
+
+        return await _store
+            .WithNoTracking<Data.Player>()
+            .Where(p => p.Id == request.PlayerId)
+            .Select(p => new RemoveFromTeamResponse
+            {
+                Player = new SimpleEntity { Id = p.Id, Name = p.ApprovedName },
+                Game = new SimpleEntity { Id = p.GameId, Name = p.Game.Name },
+                TeamId = p.TeamId,
+                UserId = new SimpleEntity { Id = p.UserId, Name = p.User.ApprovedName }
+            })
+            .SingleAsync(cancellationToken);
+    }
+}

--- a/src/Gameboard.Api/Features/Teams/Requests/RemoveFromTeam/RemoveFromTeamModels.cs
+++ b/src/Gameboard.Api/Features/Teams/Requests/RemoveFromTeam/RemoveFromTeamModels.cs
@@ -1,0 +1,9 @@
+namespace Gameboard.Api.Features.Teams;
+
+public record RemoveFromTeamResponse
+{
+    public required SimpleEntity Game { get; set; }
+    public required SimpleEntity Player { get; set; }
+    public required string TeamId { get; set; }
+    public required SimpleEntity UserId { get; set; }
+}

--- a/src/Gameboard.Api/Features/Teams/Services/TeamService.cs
+++ b/src/Gameboard.Api/Features/Teams/Services/TeamService.cs
@@ -52,7 +52,7 @@ internal class TeamService
     IInternalHubBus teamHubService,
     IPracticeService practiceService,
     IStore store
-    ) : ITeamService
+) : ITeamService
 {
     private readonly IActingUserService _actingUserService = actingUserService;
     private readonly IGameEngineService _gameEngine = gameEngine;
@@ -352,7 +352,7 @@ internal class TeamService
             .ToDictionaryAsync(gr => gr.Key, gr => gr.ToArray());
 
         if (teamPlayers.Count == 0)
-            return Array.Empty<Team>();
+            return [];
 
         foreach (var teamId in teamPlayers.Keys)
         {
@@ -459,13 +459,13 @@ internal class TeamService
 
         // if the team has a captain (manager), yay
         // if they have too many, boo (pick one by name which is stupid but stupid things happen sometimes)
-        // if they don't have one, pick by name among all players
+        // if they don't have one, pick by registration date among all players
         var captains = players.Where(p => p.IsManager);
 
         if (captains.Count() == 1)
             return captains.Single();
         else if (captains.Count() > 1)
-            return captains.OrderBy(c => c.ApprovedName).First();
+            return captains.OrderBy(c => c.WhenCreated).First();
 
         return players.OrderBy(p => p.ApprovedName).First();
     }

--- a/src/Gameboard.Api/Features/Teams/Services/TeamService.cs
+++ b/src/Gameboard.Api/Features/Teams/Services/TeamService.cs
@@ -408,7 +408,9 @@ internal class TeamService
             .ToListAsync(cancellationToken);
 
         if (teamPlayers.Count == 0)
-            throw new TeamHasNoPlayersException(teamId);
+        {
+            throw new ResourceNotFound<Team>(teamId);
+        }
 
         var captainFound = false;
         foreach (var player in teamPlayers)

--- a/src/Gameboard.Api/Features/Teams/TeamController.cs
+++ b/src/Gameboard.Api/Features/Teams/TeamController.cs
@@ -23,6 +23,14 @@ public class TeamController(
     private readonly IMediator _mediator = mediator;
     private readonly ITeamService _teamService = teamService;
 
+    [HttpDelete("{teamId}/players/{playerId}")]
+    public Task<RemoveFromTeamResponse> RemovePlayer([FromRoute] string teamId, [FromRoute] string playerId)
+        => _mediator.Send(new RemoveFromTeamCommand(playerId));
+
+    [HttpPut("{teamId}/players")]
+    public Task<AddToTeamResponse> AddUser([FromRoute] string teamId, [FromBody] AddToTeamCommand request)
+        => _mediator.Send(request);
+
     [HttpGet("{teamId}")]
     public async Task<Team> GetTeam(string teamId)
         => await _mediator.Send(new GetTeamQuery(teamId, _actingUserService.Get()));

--- a/src/Gameboard.Api/Features/Teams/TeamExceptions.cs
+++ b/src/Gameboard.Api/Features/Teams/TeamExceptions.cs
@@ -15,6 +15,18 @@ internal class CantJoinTeamBecausePlayerCount : GameboardValidationException
         : base($"Can't add {playersToJoin} player(s) to the team. This team has {teamSizeCurrent} player(s) (min team size is {teamSizeMin}, max team size is {teamSizeMax}).") { }
 }
 
+internal class CantRemoveCaptain : GameboardValidationException
+{
+    public CantRemoveCaptain(SimpleEntity player, string teamId)
+        : base($"Can't remove player {player.Name} from the team {teamId} - they're the captain.") { }
+}
+
+internal class CantRemoveLastTeamMember : GameboardValidationException
+{
+    public CantRemoveLastTeamMember(SimpleEntity player, string teamId)
+        : base($"""Can't remove the last member ("{player.Name}") of a team {teamId}.""") { }
+}
+
 internal class CantResolveTeamFromCode : GameboardValidationException
 {
     internal CantResolveTeamFromCode(string code, string[] teamIds)
@@ -65,11 +77,6 @@ internal class RequiresSameSponsor : GameboardValidationException
         : base($"Game {gameId} requires that all players have the same sponsor. The inviting player {managerPlayerId} has sponsor {managerSponsor}, while player {playerId} has sponsor {playerSponsor}.") { }
 }
 
-internal class TeamHasNoPlayersException : GameboardValidationException
-{
-    public TeamHasNoPlayersException(string teamId) : base($"Team {teamId} has no players.") { }
-}
-
 internal class TeamsAreFromMultipleGames : GameboardException
 {
     public TeamsAreFromMultipleGames(IEnumerable<string> teamIds, IEnumerable<string> gameIds)
@@ -78,6 +85,8 @@ internal class TeamsAreFromMultipleGames : GameboardException
 
 internal class TeamIsFull : GameboardValidationException
 {
+    internal TeamIsFull(SimpleEntity team, int teamSize, int maxTeamSize)
+        : base($"""Team {team.Name} has {teamSize} players, and the max team size is {maxTeamSize}.""") { }
     internal TeamIsFull(string invitingPlayerId, int teamSize, int maxTeamSize)
         : base($"Inviting player {invitingPlayerId} has {teamSize} players on their team, and the max team size for this game is {maxTeamSize}.") { }
 }

--- a/src/Gameboard.Api/Features/Teams/TeamsModels.cs
+++ b/src/Gameboard.Api/Features/Teams/TeamsModels.cs
@@ -76,6 +76,7 @@ public class Team
     public string GameId { get; set; }
     public DateTimeOffset SessionBegin { get; set; }
     public DateTimeOffset SessionEnd { get; set; }
+    public PlayerMode Mode { get; set; }
     public int Rank { get; set; }
     public int Score { get; set; }
     public long Time { get; set; }
@@ -87,9 +88,9 @@ public class Team
     public required SimpleEntity AdvancedFromPlayer { get; set; }
     public required string AdvancedFromTeamId { get; set; }
     public required double? AdvancedWithScore { get; set; }
-    public IEnumerable<TeamChallenge> Challenges { get; set; } = new List<TeamChallenge>();
-    public IEnumerable<TeamMember> Members { get; set; } = new List<TeamMember>();
-    public IEnumerable<Sponsor> Sponsors { get; set; } = new List<Sponsor>();
+    public IEnumerable<TeamChallenge> Challenges { get; set; } = [];
+    public IEnumerable<TeamMember> Members { get; set; } = [];
+    public IEnumerable<Sponsor> Sponsors { get; set; } = [];
 }
 
 public class TeamSummary

--- a/src/Gameboard.Api/Features/Teams/TeamsModels.cs
+++ b/src/Gameboard.Api/Features/Teams/TeamsModels.cs
@@ -7,7 +7,7 @@ namespace Gameboard.Api.Features.Teams;
 public class PromoteToManagerRequest
 {
     public User Actor { get; set; }
-    public string CurrentManagerPlayerId { get; set; }
+    public string CurrentCaptainId { get; set; }
     public string NewManagerPlayerId { get; set; }
     public string TeamId { get; set; }
 }

--- a/src/Gameboard.Api/Features/Ticket/TicketController.cs
+++ b/src/Gameboard.Api/Features/Ticket/TicketController.cs
@@ -1,7 +1,6 @@
 // Copyright 2021 Carnegie Mellon University. All Rights Reserved.
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using AutoMapper;
@@ -41,10 +40,11 @@ public class TicketController(
     /// Gets ticket details
     /// </summary>
     /// <param name="id"></param>
+    /// <param name="sortDirection">The direction in which activity on this ticket will be ordered (by timestamp)</param>
     /// <returns></returns>
     [HttpGet("api/ticket/{id}")]
     [Authorize]
-    public async Task<Ticket> Retrieve([FromRoute] int id)
+    public async Task<Ticket> Retrieve([FromRoute] int id, [FromQuery] SortDirection sortDirection)
     {
         await AuthorizeAny
         (
@@ -52,7 +52,7 @@ public class TicketController(
             () => TicketService.IsOwnerOrTeamMember(id, Actor.Id)
         );
 
-        return await TicketService.Retrieve(id);
+        return await TicketService.Retrieve(id, sortDirection);
     }
 
 

--- a/src/Gameboard.Api/Features/Ticket/TicketController.cs
+++ b/src/Gameboard.Api/Features/Ticket/TicketController.cs
@@ -18,7 +18,8 @@ using Microsoft.Extensions.Logging;
 namespace Gameboard.Api.Controllers;
 
 [Authorize]
-public class TicketController(
+public class TicketController
+(
     IActingUserService actingUserService,
     ILogger<ChallengeController> logger,
     IDistributedCache cache,
@@ -28,7 +29,7 @@ public class TicketController(
     TicketService ticketService,
     IHubContext<AppHub, IAppHubEvent> hub,
     IMapper mapper
-    ) : GameboardLegacyController(actingUserService, logger, cache, validator)
+) : GameboardLegacyController(actingUserService, logger, cache, validator)
 {
     private readonly IUserRolePermissionsService _permissionsService = permissionsService;
     TicketService TicketService { get; } = ticketService;

--- a/src/Gameboard.Api/Features/Ticket/TicketService.cs
+++ b/src/Gameboard.Api/Features/Ticket/TicketService.cs
@@ -150,13 +150,13 @@ public class TicketService
         return createdTicketModel;
     }
 
-    public IQueryable<Data.Ticket> GetGameOpenTickets(string gameId)
-    {
-        return _store
+    public IQueryable<Data.Ticket> GetGameTicketsQuery(string gameId)
+        => _store
             .WithNoTracking<Data.Ticket>()
-            .Where(t => t.Challenge.GameId == gameId || t.Player.Challenges.Any(c => c.GameId == gameId))
-            .Where(t => t.Status != "Closed");
-    }
+            .Where(t => t.Challenge.GameId == gameId || t.Player.Challenges.Any(c => c.GameId == gameId));
+
+    public IQueryable<Data.Ticket> GetGameOpenTicketsQuery(string gameId)
+        => GetGameTicketsQuery(gameId).Where(t => t.Status != "Closed");
 
     public IQueryable<Data.Ticket> GetTeamTickets(IEnumerable<string> teamIds)
         => _store

--- a/src/Gameboard.Api/Features/User/Permissions/UserRolePermissionsService.cs
+++ b/src/Gameboard.Api/Features/User/Permissions/UserRolePermissionsService.cs
@@ -59,8 +59,8 @@ internal class UserRolePermissionsService(IActingUserService actingUserService, 
         {
             Group = PermissionKeyGroup.Games,
             Key = PermissionKey.Games_ViewUnpublished,
-            Name = "View hidden games",
-            Description = "View games which have been hidden from players by their creator"
+            Name = "View hidden games and practice challenges",
+            Description = "View games and practice challenges which have been hidden from players by their creator"
         },
         new()
         {

--- a/src/Gameboard.Api/Features/User/Permissions/UserRolePermissionsService.cs
+++ b/src/Gameboard.Api/Features/User/Permissions/UserRolePermissionsService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Gameboard.Api.Common.Services;
@@ -107,8 +108,8 @@ internal class UserRolePermissionsService(IActingUserService actingUserService, 
         {
             Group = PermissionKeyGroup.Scoring,
             Key = PermissionKey.Scores_RegradeAndRerank,
-            Name = "Regrade challenges",
-            Description = "Manually initiate regrading of challenges"
+            Name = "Revise scores",
+            Description = "Manually initiate reranking of games and regrading of challenges"
         },
         new()
         {

--- a/src/Gameboard.Api/Features/User/Requests/RequestNameChange/RequestNameChange.cs
+++ b/src/Gameboard.Api/Features/User/Requests/RequestNameChange/RequestNameChange.cs
@@ -61,7 +61,7 @@ internal sealed class RequestNameChangeHandler
         }
         else
         {
-            finalStatus = canRenameWithoutApproval ? string.Empty : "pending";
+            finalStatus = canRenameWithoutApproval ? string.Empty : AppConstants.NameStatusPending;
         }
 
         await _store

--- a/src/Gameboard.Api/Features/User/UserService.cs
+++ b/src/Gameboard.Api/Features/User/UserService.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using AutoMapper;
 using Gameboard.Api.Common.Services;

--- a/src/Gameboard.Api/Features/User/UserService.cs
+++ b/src/Gameboard.Api/Features/User/UserService.cs
@@ -195,7 +195,7 @@ public class UserService
             query = query.Where(u => ((int)u.Role) > 0);
 
         if (model.WantsPending)
-            query = query.Where(u => u.NameStatus.Equals(AppConstants.NameStatusPending) && u.Name != u.ApprovedName);
+            query = query.Where(u => u.Name != u.ApprovedName);
 
         if (model.WantsDisallowed)
             query = query.Where(u => !string.IsNullOrEmpty(u.NameStatus) && !u.NameStatus.Equals(AppConstants.NameStatusPending));

--- a/src/Gameboard.Api/Features/User/UserService.cs
+++ b/src/Gameboard.Api/Features/User/UserService.cs
@@ -4,11 +4,13 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using AutoMapper;
 using Gameboard.Api.Common.Services;
 using Gameboard.Api.Data;
 using Gameboard.Api.Data.Abstractions;
+using Gameboard.Api.Features.Teams;
 using Gameboard.Api.Features.Users;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
@@ -24,6 +26,7 @@ public class UserService
     IMapper mapper,
     IMemoryCache cache,
     INameService namesvc,
+    ITeamService teamService,
     IUserRolePermissionsService permissionsService
 )
 {
@@ -34,6 +37,7 @@ public class UserService
     private readonly IStore<Data.User> _userStore = userStore;
     private readonly IMemoryCache _localcache = cache;
     private readonly INameService _namesvc = namesvc;
+    private readonly ITeamService _teamService = teamService;
     private readonly IUserRolePermissionsService _permissionsService = permissionsService;
 
     /// <summary>

--- a/src/Gameboard.Api/Structure/AppSettings.cs
+++ b/src/Gameboard.Api/Structure/AppSettings.cs
@@ -122,9 +122,9 @@ public class SecurityHeaderOptions
 public class CorsPolicyOptions
 {
     public string Name { get; set; } = "default";
-    public string[] Origins { get; set; } = Array.Empty<string>();
-    public string[] Methods { get; set; } = Array.Empty<string>();
-    public string[] Headers { get; set; } = Array.Empty<string>();
+    public string[] Origins { get; set; } = [];
+    public string[] Methods { get; set; } = [];
+    public string[] Headers { get; set; } = [];
     public bool AllowCredentials { get; set; }
 
     public CorsPolicy Build()
@@ -132,20 +132,20 @@ public class CorsPolicyOptions
         var policy = new CorsPolicyBuilder();
 
         var origins = Origins.Where(x => !string.IsNullOrWhiteSpace(x)).ToArray();
-        if (origins.Any())
+        if (origins.Length > 0)
         {
             if (origins.First() == "*") policy.AllowAnyOrigin(); else policy.WithOrigins(origins);
             if (AllowCredentials && origins.First() != "*") policy.AllowCredentials(); else policy.DisallowCredentials();
         }
 
         var methods = Methods.Where(x => !string.IsNullOrWhiteSpace(x)).ToArray();
-        if (methods.Any())
+        if (methods.Length > 0)
         {
             if (methods.First() == "*") policy.AllowAnyMethod(); else policy.WithMethods(methods);
         }
 
         var headers = Headers.Where(x => !string.IsNullOrWhiteSpace(x)).ToArray();
-        if (headers.Any())
+        if (headers.Length > 0)
         {
             if (headers.First() == "*") policy.AllowAnyHeader(); else policy.WithHeaders(headers);
         }
@@ -220,9 +220,11 @@ public class Defaults
         // Create a new DateTimeOffset representation for every string time given
         for (int i = 0; i < shiftStrings.Length; i++)
         {
-            offsets[i] = new DateTimeOffset[] {
-                    ConvertTime(shiftStrings[i][0], ShiftTimezoneFallback),
-                    ConvertTime(shiftStrings[i][1], ShiftTimezoneFallback) };
+            offsets[i] =
+            [
+                ConvertTime(shiftStrings[i][0], ShiftTimezoneFallback),
+                ConvertTime(shiftStrings[i][1], ShiftTimezoneFallback)
+            ];
         }
         return offsets;
     }


### PR DESCRIPTION
Version 3.25.0 contains bug fixes and stability improvements.

# New features

- People with the `Enroll` permission can now add users to and remove players from teams using the Game Center. 
  - For now, you can only add users who haven't yet registered for the game to a team. (This is messy to do because of #553). We'll consider extending this in the future. In the meantime, if you need to add a user who is already enrolled to a team, unenroll them first, and then add them.

# Enhancements

- The submissions UI for competitive play has been lightly redesigned to improve clarity about the number of remaining submissions (resolves #548)
- The Game Center -> Teams view has a new alert that appears to clarify when filters are being applied. Clicking on the alert removes all filters. (Resolves #546)
- The Game Center -> Tickets tab now includes all tickets in its count (rather than just open ones). (Resolves #549.)
- The Practice Area now properly honors game and challenge-level "hidden" settings. Elevated users still see hidden challenges from hidden games, but a notification icon has been added to clarify that affected challenges are not visible to players.
- The "View Hidden Games" permission has been extended to apply to the Practice Area. Its description has been updated to clarify its function.
- Clicking on a toast notification related to a support ticket now links to the ticket in question (resolves #542)
- Unenrolling a team or player from a game now requires a confirmation click.
- Role-based permissions now have enhanced caching, resulting in less erratic UI behavior in the web client (resolves #505)
- The Practice Area now automatically selects the first unfinished section of the challenge on load if multiple sections are available.

# Bug fixes

- Resolved an issue that caused the web client to display an error after extending a team's session (resolves #544)
- Resolved an issue that prevented player name requests from being displayed in the Game Center -> Teams view (resolves #538)
- The web client once again defaults to a full logout of the identity provider when manually initiated by the user (resolves #534)
- Resolved an issue that caused the Admin -> Users view to fail to refresh after approving a user name change request
- Resolved various issues that affected the availability and functionality of "team up" controls in the web client
- The player name validation process now checks for identical approved names as well as identical pending names when determining uniqueness.
- Fixed a bug that caused the practice page to show VMs as still deployed after undeploy.
- Resolved an issue that could cause tickets to fail to load if their associated team was deleted/unenrolled (resolves #543)
- Fixed an issue that failed to properly limit team gamespace counts until the gamespace finished deploying (resolves #539)
- Added hardening to prevent captain denormalization issues (resolves #545)