### PR TITLE
v3.26.2

### DIFF
--- a/src/Gameboard.Api/Features/Feedback/FeedbackController.cs
+++ b/src/Gameboard.Api/Features/Feedback/FeedbackController.cs
@@ -50,6 +50,7 @@ public class FeedbackController
     /// </summary>
     /// <param name="model"></param>
     /// <returns></returns>
+    [HttpGet]
     public async Task<Feedback> Retrieve([FromQuery] FeedbackSearchParams model)
     {
         await Authorize(FeedbackService.UserIsEnrolled(model.GameId, Actor.Id));

--- a/src/Gameboard.Api/Features/Feedback/FeedbackController.cs
+++ b/src/Gameboard.Api/Features/Feedback/FeedbackController.cs
@@ -114,6 +114,10 @@ public class FeedbackController
     public Task<ListFeedbackTemplatesResponse> ListTemplates()
         => _mediator.Send(new ListFeedbackTemplatesQuery());
 
+    [HttpPut("template/{templateId}")]
+    public Task<FeedbackTemplateView> UpdateTemplate([FromQuery] string templateId, [FromBody] UpdateFeedbackTemplateRequest request)
+        => _mediator.Send(new UpdateFeedbackTemplateCommand(request));
+
     /// <summary>
     /// Create a new feedback response.
     /// </summary>

--- a/src/Gameboard.Api/Features/Feedback/Requests/UpdateFeedbackTemplate/UpdateFeedbackTemplate.cs
+++ b/src/Gameboard.Api/Features/Feedback/Requests/UpdateFeedbackTemplate/UpdateFeedbackTemplate.cs
@@ -1,0 +1,58 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoMapper;
+using Gameboard.Api.Data;
+using Gameboard.Api.Services;
+using Gameboard.Api.Structure.MediatR;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Gameboard.Api.Features.Feedback;
+
+public record UpdateFeedbackTemplateCommand(UpdateFeedbackTemplateRequest Request) : IRequest<FeedbackTemplateView>;
+
+internal sealed class UpdateFeedbackTemplateHandler
+(
+    IMapper mapper,
+    IStore store,
+    IValidatorService validator
+) : IRequestHandler<UpdateFeedbackTemplateCommand, FeedbackTemplateView>
+{
+    private readonly IMapper _mapper = mapper;
+    private readonly IStore _store = store;
+    private readonly IValidatorService _validator = validator;
+
+    public async Task<FeedbackTemplateView> Handle(UpdateFeedbackTemplateCommand request, CancellationToken cancellationToken)
+    {
+        await _validator
+            .Auth(c => c.RequirePermissions(Users.PermissionKey.Games_CreateEditDelete))
+            .AddEntityExistsValidator<FeedbackTemplate>(request.Request.Id)
+            .AddValidator(request.Request.Name.IsEmpty(), new MissingRequiredInput<string>(nameof(request.Request.Name)))
+            .AddValidator(request.Request.Content.IsEmpty(), new MissingRequiredInput<string>(nameof(request.Request.Content)))
+            .AddValidator(async ctx =>
+            {
+                if (await _store.WithNoTracking<FeedbackTemplate>().AnyAsync(t => t.Name == request.Request.Name && t.Id != request.Request.Id))
+                {
+                    ctx.AddValidationException(new DuplicateFeedbackTemplateNameException(request.Request.Name));
+                }
+            })
+            .Validate(cancellationToken);
+
+        await _store
+            .WithNoTracking<FeedbackTemplate>()
+            .Where(t => t.Id == request.Request.Id)
+            .ExecuteUpdateAsync
+            (
+                up => up
+                    .SetProperty(t => t.HelpText, request.Request.HelpText)
+                    .SetProperty(t => t.Content, request.Request.Content)
+                    .SetProperty(t => t.Name, request.Request.Name),
+                cancellationToken
+            );
+
+        return await _mapper
+            .ProjectTo<FeedbackTemplateView>(_store.WithNoTracking<FeedbackTemplate>().Where(t => t.Id == request.Request.Id))
+            .SingleAsync(cancellationToken);
+    }
+}

--- a/src/Gameboard.Api/Features/Feedback/Requests/UpdateFeedbackTemplate/UpdateFeedbackTemplateModels.cs
+++ b/src/Gameboard.Api/Features/Feedback/Requests/UpdateFeedbackTemplate/UpdateFeedbackTemplateModels.cs
@@ -1,0 +1,9 @@
+namespace Gameboard.Api.Features.Feedback;
+
+public sealed class UpdateFeedbackTemplateRequest
+{
+    public required string Id { get; set; }
+    public required string Content { get; set; }
+    public string HelpText { get; set; }
+    public required string Name { get; set; }
+}

--- a/src/Gameboard.Api/Features/Feedback/Requests/UpsertFeedbackSubmission/UpsertFeedbackSubmissionModels.cs
+++ b/src/Gameboard.Api/Features/Feedback/Requests/UpsertFeedbackSubmission/UpsertFeedbackSubmissionModels.cs
@@ -16,9 +16,16 @@ public sealed class UpsertFeedbackSubmissionRequest
     public required string FeedbackTemplateId { get; set; }
     public required bool IsFinalized { get; set; }
     public IEnumerable<QuestionSubmission> Responses { get; set; }
+    public string UserId { get; set; }
 }
 
 public sealed class UpsertFeedbackSubmissionResponse
 {
     public required FeedbackSubmissionView Submission { get; set; }
+}
+
+public sealed class CantUpdateOtherUserFeedback : GameboardValidationException
+{
+    public CantUpdateOtherUserFeedback(string otherUserId)
+        : base($"Can't update feedback for other user {otherUserId}") { }
 }

--- a/src/Gameboard.Api/Features/Reports/Queries/FeedbackReport/FeedbackReport.cs
+++ b/src/Gameboard.Api/Features/Reports/Queries/FeedbackReport/FeedbackReport.cs
@@ -52,7 +52,6 @@ internal sealed class FeedbackReportHandler
             },
             Paging = paged.Paging,
             Records = paged.Items,
-
         };
     }
 }

--- a/src/Gameboard.Api/Features/Reports/Queries/FeedbackReport/FeedbackReportService.cs
+++ b/src/Gameboard.Api/Features/Reports/Queries/FeedbackReport/FeedbackReportService.cs
@@ -34,6 +34,8 @@ internal sealed class FeedbackReportService(IReportsService reportsService, ISto
             .Include(s => s.User)
             .Where(s => s.FeedbackTemplateId == parameters.TemplateId);
 
+        // we need to load the feedback template to ensure that everyone in the report has an entry for all questions (even ones they didn't answer)
+
         if (submissionDateStart.IsNotEmpty())
         {
             matchingSubmissions = matchingSubmissions.Where(s => s.WhenCreated >= submissionDateStart.Value);
@@ -111,7 +113,7 @@ internal sealed class FeedbackReportService(IReportsService reportsService, ISto
                         LogoFileName = s.User.Sponsor.Logo,
                         Name = s.User.Sponsor.Name
                     },
-                    Responses = s.Responses,
+                    Responses = s.Responses.OrderBy(r => r.Id).ToArray(),
                     User = new SimpleEntity { Id = s.UserId, Name = s.User.ApprovedName },
                     WhenCreated = s.WhenCreated,
                     WhenEdited = s.WhenEdited,


### PR DESCRIPTION
Version 3.26.2 of Gameboard contains a few bug fixes:

- Fixed an issue that caused the API's swagger page to fail to load.
- Fixed an issue that caused the Feedback Report to render strangely
- Fixed an issue that caused the modal in the FeedbackReport to fail to show data if the response wasn't finalized
- Fixed an issue that made updates to some feedback templates fail
- Users with the `Admin_View` permission can now update feedback from other users (for the purposes of data migration)
- The classic feedback templates are visible in Game Center -> Settings to assist with data migration, but will be removed in a future release.