### PR TITLE
v3.27.1

### DIFF
--- a/src/Gameboard.Api/Features/Scores/ScoreDenormalizationService.cs
+++ b/src/Gameboard.Api/Features/Scores/ScoreDenormalizationService.cs
@@ -108,7 +108,7 @@ internal class ScoreDenormalizationService
         {
             CumulativeTimeMs = t.CumulativeTimeMs,
             OverallScore = t.ScoreOverall,
-            SessionStart = !captains.TryGetValue(t.TeamId, out var captain) || captain.SessionBegin == DateTimeOffset.MinValue ? null : captain.SessionBegin,
+            SessionStart = !captains.TryGetValue(t.TeamId, out var captain) || captain?.SessionBegin == DateTimeOffset.MinValue ? null : captain.SessionBegin,
             TeamId = t.TeamId
         }));
 

--- a/src/Gameboard.Api/Features/Scores/ScoringService.cs
+++ b/src/Gameboard.Api/Features/Scores/ScoringService.cs
@@ -1,4 +1,3 @@
-
 using System;
 using System.Collections.Generic;
 using System.Linq;


### PR DESCRIPTION
Version 3.27.1 of Gameboard fixes a few minor bugs.

# Bug fixes

- Fixed an issue that caused any active system notifications to be included in certificate print previews
- Fixed an issue that could cause grading to display an error in some games
- The game page now links to the certificate print page if the player has earned a certificate (rather than displaying the certificate inline on the game page).
- System Notification modal dialogs are now slightly wider by default.
- Corrected the default "no certificate" option's text in Game Center -> Settings.