### PR TITLE
v3.27.5

### DIFF
--- a/src/Gameboard.Api/Features/Challenge/Services/ChallengeService.cs
+++ b/src/Gameboard.Api/Features/Challenge/Services/ChallengeService.cs
@@ -285,7 +285,13 @@ public partial class ChallengeService
         var practiceChallengesCutoff = _now.Get().AddDays(-7);
         q = q.Include(c => c.Player).Include(c => c.Game);
         // band-aid for #296
-        q = q.Where(c => c.Game.GameEnd > recent || (c.PlayerMode == PlayerMode.Practice && c.StartTime >= practiceChallengesCutoff));
+        q = q.Where
+        (
+            c =>
+                c.EndTime > recent ||
+                c.Game.GameEnd > recent ||
+                (c.PlayerMode == PlayerMode.Practice && c.StartTime >= practiceChallengesCutoff)
+        );
         q = q.OrderByDescending(p => p.StartTime);
 
         return await Mapper.ProjectTo<ChallengeOverview>(q).ToArrayAsync();

--- a/src/Gameboard.Api/Features/Game/Requests/ExportGame/ExportGameModels.cs
+++ b/src/Gameboard.Api/Features/Game/Requests/ExportGame/ExportGameModels.cs
@@ -1,0 +1,78 @@
+using System;
+
+namespace Gameboard.Api.Features.Games;
+
+public sealed class ExportGameResult
+{
+    public required string ExportBatchId { get; set; }
+    public required string GameId { get; set; }
+    public required GameImportExport GameData { get; set; }
+}
+
+public sealed class GameImportExport
+{
+    public required string ExportedGameId { get; set; }
+    public required string Name { get; set; }
+    public required string Competition { get; set; }
+    public required string Season { get; set; }
+    public required string Track { get; set; }
+    public required string Division { get; set; }
+    public required string Logo { get; set; }
+    public required string Sponsor { get; set; }
+    public required string Background { get; set; }
+    public required string TestCode { get; set; }
+    public required DateTimeOffset? GameStart { get; set; }
+    public required DateTimeOffset? GameEnd { get; set; }
+    public required string GameMarkdown { get; set; }
+    public required string FeedbackConfig { get; set; }
+    public required string RegistrationMarkdown { get; set; }
+    public required DateTimeOffset? RegistrationOpen { get; set; }
+    public required DateTimeOffset? RegistrationClose { get; set; }
+    public required GameRegistrationType RegistrationType { get; set; }
+    public required int MinTeamSize { get; set; } = 1;
+    public required int MaxTeamSize { get; set; } = 1;
+    public required int? MaxAttempts { get; set; } = 0;
+    public required bool RequireSponsoredTeam { get; set; }
+    public required int SessionMinutes { get; set; } = 60;
+    public required int? SessionLimit { get; set; } = 0;
+    public required int? SessionAvailabilityWarningThreshold { get; set; }
+    public required int GamespaceLimitPerSession { get; set; } = 1;
+    public required bool IsPublished { get; set; }
+    public required bool AllowLateStart { get; set; }
+    public required bool AllowPreview { get; set; }
+    public required bool AllowPublicScoreboardAccess { get; set; }
+    public required bool AllowReset { get; set; }
+    public required string CardText1 { get; set; }
+    public required string CardText2 { get; set; }
+    public required string CardText3 { get; set; }
+    public required bool IsFeatured { get; set; }
+
+    // mode stuff
+    public string ExternalHostId { get; set; }
+    public GameImportExportExternalHost ExternalHost { get; set; }
+    public string Mode { get; set; }
+    public PlayerMode PlayerMode { get; set; }
+    public bool RequireSynchronizedStart { get; set; } = false;
+    public bool ShowOnHomePageInPracticeMode { get; set; } = false;
+
+    // feedback
+    // public string ChallengesFeedbackTemplateId { get; set; }
+    // public FeedbackTemplate ChallengesFeedbackTemplate { get; set; }
+    // public string FeedbackTemplateId { get; set; }
+    // public FeedbackTemplate FeedbackTemplate { get; set; }
+
+    // public string CertificateTemplateId { get; set; }
+    // public CertificateTemplate CertificateTemplate { get; set; }
+    // public string PracticeCertificateTemplateId { get; set; }
+    // public CertificateTemplate PracticeCertificateTemplate { get; set; }
+}
+
+public sealed class GameImportExportExternalHost
+{
+    public required string ExportedId { get; set; }
+}
+
+public sealed class GameImportExportFeedbackTemplate
+{
+    public required string ExportedFeedbackTemplateId { get; set; }
+}

--- a/src/Gameboard.Api/Features/Player/Services/PlayerService.cs
+++ b/src/Gameboard.Api/Features/Player/Services/PlayerService.cs
@@ -134,12 +134,22 @@ public class PlayerService
         );
     }
 
-    public Expression<Func<Data.Player, bool>> GetWhereHasPendingNamePredicate()
+    public Func<Data.Player, bool> GetHasActiveSessionFunc(DateTimeOffset now)
+    {
+        return p => p.SessionBegin != DateTimeOffset.MinValue && p.SessionBegin < now && p.SessionEnd > now;
+    }
+
+    public Expression<Func<Data.Player, bool>> GetHasActiveSessionPredicate(DateTimeOffset now)
+    {
+        return p => p.SessionBegin != DateTimeOffset.MinValue && p.SessionBegin < now && p.SessionEnd > now;
+    }
+
+    public Expression<Func<Data.Player, bool>> GetHasPendingNamePredicate()
     {
         return p => p.Name != p.ApprovedName && p.Name != null && p.Name != string.Empty && (p.NameStatus == null || p.NameStatus == string.Empty || p.NameStatus == AppConstants.NameStatusPending);
     }
 
-    public Expression<Func<Data.Player, bool>> GetWhereDoesntHavePendingNamePredicate()
+    public Expression<Func<Data.Player, bool>> GetDoesntHavePendingNamePredicate()
     {
         return p => !(p.Name != p.ApprovedName && p.Name != null && p.Name != string.Empty && (p.NameStatus == null || p.NameStatus == string.Empty || p.NameStatus == AppConstants.NameStatusPending));
     }
@@ -322,7 +332,7 @@ public class PlayerService
 
         if (model.WantsPending)
         {
-            var pendingNamePredicate = GetWhereHasPendingNamePredicate();
+            var pendingNamePredicate = GetHasPendingNamePredicate();
             q = q.Where(pendingNamePredicate);
         }
 

--- a/src/Gameboard.Api/Features/Practice/PracticeController.cs
+++ b/src/Gameboard.Api/Features/Practice/PracticeController.cs
@@ -9,10 +9,7 @@ namespace Gameboard.Api.Features.Practice;
 [ApiController]
 [Authorize]
 [Route("/api/practice")]
-public class PracticeController(
-    IActingUserService actingUserService,
-    IMediator mediator
-    ) : ControllerBase
+public class PracticeController(IActingUserService actingUserService, IMediator mediator) : ControllerBase
 {
     private readonly IActingUserService _actingUserService = actingUserService;
     private readonly IMediator _mediator = mediator;

--- a/src/Gameboard.Api/Features/Reports/ReportsController.cs
+++ b/src/Gameboard.Api/Features/Reports/ReportsController.cs
@@ -17,77 +17,76 @@ public class ReportsController(IMediator mediator, IReportsService service) : Co
     private readonly IReportsService _service = service;
 
     [HttpGet]
-    public async Task<IEnumerable<ReportViewModel>> List()
-        => await _service.List();
+    public Task<IEnumerable<ReportViewModel>> List()
+        => _service.List();
 
     [HttpGet("challenges")]
-    public Task<ReportResults<ChallengesReportStatSummary, ChallengesReportRecord>> GetChallengesReport([FromQuery] ChallengesReportParameters parameters, [FromQuery] PagingArgs paging)
-        => _mediator.Send(new GetChallengesReportQuery(parameters, paging));
+    public Task<ReportResults<ChallengesReportStatSummary, ChallengesReportRecord>> GetChallengesReport([FromQuery] ChallengesReportParameters parameters, [FromQuery] PagingArgs paging, CancellationToken cancellationToken)
+        => _mediator.Send(new GetChallengesReportQuery(parameters, paging), cancellationToken);
 
     [HttpGet("enrollment")]
-    public Task<ReportResults<EnrollmentReportRecord>> GetEnrollmentReportSummary([FromQuery] EnrollmentReportParameters parameters, [FromQuery] PagingArgs paging)
-        => _mediator.Send(new EnrollmentReportSummaryQuery(parameters, paging));
+    public Task<ReportResults<EnrollmentReportRecord>> GetEnrollmentReportSummary([FromQuery] EnrollmentReportParameters parameters, [FromQuery] PagingArgs paging, CancellationToken cancellationToken)
+        => _mediator.Send(new EnrollmentReportSummaryQuery(parameters, paging), cancellationToken);
 
     [HttpGet("enrollment/stats")]
-    public Task<EnrollmentReportStatSummary> GetEnrollmentReportSummaryStats([FromQuery] EnrollmentReportParameters parameters)
-        => _mediator.Send(new EnrollmentReportSummaryStatsQuery(parameters));
+    public Task<EnrollmentReportStatSummary> GetEnrollmentReportSummaryStats([FromQuery] EnrollmentReportParameters parameters, CancellationToken cancellationToken)
+        => _mediator.Send(new EnrollmentReportSummaryStatsQuery(parameters), cancellationToken);
 
     [HttpGet("enrollment/trend")]
-    public Task<EnrollmentReportLineChartResponse> GetEnrollmentReportLineChart([FromQuery] EnrollmentReportParameters parameters)
-        => _mediator.Send(new EnrollmentReportLineChartQuery(parameters));
+    public Task<EnrollmentReportLineChartResponse> GetEnrollmentReportLineChart([FromQuery] EnrollmentReportParameters parameters, CancellationToken cancellationToken)
+        => _mediator.Send(new EnrollmentReportLineChartQuery(parameters), cancellationToken);
 
     [HttpGet("enrollment/by-game")]
-    public Task<ReportResults<EnrollmentReportByGameRecord>> GetEnrollmentReportByGame([FromQuery] EnrollmentReportParameters parameters, [FromQuery] PagingArgs pagingArgs)
-        => _mediator.Send(new EnrollmentReportByGameQuery(parameters, pagingArgs));
+    public Task<ReportResults<EnrollmentReportByGameRecord>> GetEnrollmentReportByGame([FromQuery] EnrollmentReportParameters parameters, [FromQuery] PagingArgs pagingArgs, CancellationToken cancellationToken)
+        => _mediator.Send(new EnrollmentReportByGameQuery(parameters, pagingArgs), cancellationToken);
 
     [HttpGet("feedback")]
-    public Task<ReportResults<FeedbackReportSummaryData, FeedbackReportRecord>> GetFeedbackReport([FromQuery] FeedbackReportParameters request, [FromQuery] PagingArgs pagingArgs)
-        => _mediator.Send(new FeedbackReportQuery(request, pagingArgs));
+    public Task<ReportResults<FeedbackReportSummaryData, FeedbackReportRecord>> GetFeedbackReport([FromQuery] FeedbackReportParameters request, [FromQuery] PagingArgs pagingArgs, CancellationToken cancellationToken)
+        => _mediator.Send(new FeedbackReportQuery(request, pagingArgs), cancellationToken);
 
     [HttpGet("feedback-legacy")]
-    public Task<FeedbackGameReportResults> GetFeedbackGameReport([FromQuery] GetFeedbackGameReportQuery query)
-        => _mediator.Send(query);
-
+    public Task<FeedbackGameReportResults> GetFeedbackGameReport([FromQuery] GetFeedbackGameReportQuery query, CancellationToken cancellationToken)
+        => _mediator.Send(query, cancellationToken);
 
     [HttpGet("players")]
-    public Task<ReportResults<PlayersReportStatSummary, PlayersReportRecord>> GetPlayersReport([FromQuery] PlayersReportParameters parameters, [FromQuery] PagingArgs pagingArgs)
-        => _mediator.Send(new GetPlayersReportQuery(parameters, pagingArgs));
+    public Task<ReportResults<PlayersReportStatSummary, PlayersReportRecord>> GetPlayersReport([FromQuery] PlayersReportParameters parameters, [FromQuery] PagingArgs pagingArgs, CancellationToken cancellationToken)
+        => _mediator.Send(new GetPlayersReportQuery(parameters, pagingArgs), cancellationToken);
 
     [HttpGet("practice-area")]
-    public async Task<ReportResults<PracticeModeReportOverallStats, IPracticeModeReportRecord>> GetPracticeModeReport([FromQuery] PracticeModeReportParameters parameters, [FromQuery] PagingArgs paging)
-        => await _mediator.Send(new PracticeModeReportQuery(parameters, paging));
+    public async Task<ReportResults<PracticeModeReportOverallStats, IPracticeModeReportRecord>> GetPracticeModeReport([FromQuery] PracticeModeReportParameters parameters, [FromQuery] PagingArgs paging, CancellationToken cancellationToken)
+        => await _mediator.Send(new PracticeModeReportQuery(parameters, paging), cancellationToken);
 
     [HttpGet("practice-area/challenge-spec/{challengeSpecId}")]
-    public Task<PracticeModeReportChallengeDetail> GetChallengeDetail([FromQuery] PracticeModeReportParameters parameters, [FromQuery] PracticeModeReportChallengeDetailParameters challengeDetailParameters, [FromQuery] PagingArgs pagingArgs, [FromRoute] string challengeSpecId)
-        => _mediator.Send(new PracticeModeReportChallengeDetailQuery(challengeSpecId, parameters, challengeDetailParameters, pagingArgs));
+    public Task<PracticeModeReportChallengeDetail> GetChallengeDetail([FromQuery] PracticeModeReportParameters parameters, [FromQuery] PracticeModeReportChallengeDetailParameters challengeDetailParameters, [FromQuery] PagingArgs pagingArgs, [FromRoute] string challengeSpecId, CancellationToken cancellationToken)
+        => _mediator.Send(new PracticeModeReportChallengeDetailQuery(challengeSpecId, parameters, challengeDetailParameters, pagingArgs), cancellationToken);
 
     [HttpGet("practice-area/user/{id}/summary")]
-    public async Task<PracticeModeReportPlayerModeSummary> GetPracticeModeReportPlayerModeSummary([FromRoute] string id, [FromQuery] bool isPractice)
-        => await _mediator.Send(new PracticeModeReportPlayerModeSummaryQuery(id, isPractice));
+    public async Task<PracticeModeReportPlayerModeSummary> GetPracticeModeReportPlayerModeSummary([FromRoute] string id, [FromQuery] bool isPractice, CancellationToken cancellationToken)
+        => await _mediator.Send(new PracticeModeReportPlayerModeSummaryQuery(id, isPractice), cancellationToken);
 
     [HttpGet("site-usage")]
-    public Task<SiteUsageReportRecord> GetSiteUsageReport([FromQuery] SiteUsageReportParameters parameters)
-        => _mediator.Send(new GetSiteUsageReportQuery(parameters));
+    public Task<SiteUsageReportRecord> GetSiteUsageReport([FromQuery] SiteUsageReportParameters parameters, CancellationToken cancellationToken)
+        => _mediator.Send(new GetSiteUsageReportQuery(parameters), cancellationToken);
 
     [HttpGet("site-usage/challenges")]
-    public Task<PagedEnumerable<SiteUsageReportChallenge>> GetSiteUsageREportChallenges([FromQuery] SiteUsageReportParameters reportParameters, [FromQuery] PagingArgs pagingArgs)
-        => _mediator.Send(new GetSiteUsageReportChallengesQuery(reportParameters, pagingArgs));
+    public Task<PagedEnumerable<SiteUsageReportChallenge>> GetSiteUsageREportChallenges([FromQuery] SiteUsageReportParameters reportParameters, [FromQuery] PagingArgs pagingArgs, CancellationToken cancellationToken)
+        => _mediator.Send(new GetSiteUsageReportChallengesQuery(reportParameters, pagingArgs), cancellationToken);
 
     [HttpGet("site-usage/players")]
-    public Task<PagedEnumerable<SiteUsageReportPlayer>> GetSiteUsageReportPlayers([FromQuery] SiteUsageReportParameters reportParameters, [FromQuery] SiteUsageReportPlayersParameters playersParameters, [FromQuery] PagingArgs pagingArgs)
-        => _mediator.Send(new GetSiteUsageReportPlayersQuery(reportParameters, playersParameters, pagingArgs));
+    public Task<PagedEnumerable<SiteUsageReportPlayer>> GetSiteUsageReportPlayers([FromQuery] SiteUsageReportParameters reportParameters, [FromQuery] SiteUsageReportPlayersParameters playersParameters, [FromQuery] PagingArgs pagingArgs, CancellationToken cancellationToken)
+        => _mediator.Send(new GetSiteUsageReportPlayersQuery(reportParameters, playersParameters, pagingArgs), cancellationToken);
 
     [HttpGet("site-usage/sponsors")]
-    public Task<IEnumerable<SiteUsageReportSponsor>> GetSiteUsageReportSponsors([FromQuery] SiteUsageReportParameters reportParameters)
-        => _mediator.Send(new GetSiteUsageReportSponsorsQuery(reportParameters));
+    public Task<IEnumerable<SiteUsageReportSponsor>> GetSiteUsageReportSponsors([FromQuery] SiteUsageReportParameters reportParameters, CancellationToken cancellationToken)
+        => _mediator.Send(new GetSiteUsageReportSponsorsQuery(reportParameters), cancellationToken);
 
     [HttpGet("support")]
-    public Task<ReportResults<SupportReportStatSummary, SupportReportRecord>> GetSupportReport([FromQuery] SupportReportParameters reportParams, [FromQuery] PagingArgs pagingArgs)
-        => _mediator.Send(new SupportReportQuery(reportParams, pagingArgs));
+    public Task<ReportResults<SupportReportStatSummary, SupportReportRecord>> GetSupportReport([FromQuery] SupportReportParameters reportParams, [FromQuery] PagingArgs pagingArgs, CancellationToken cancellationToken)
+        => _mediator.Send(new SupportReportQuery(reportParams, pagingArgs), cancellationToken);
 
     [HttpGet("metaData")]
-    public Task<ReportMetaData> GetReportMetaData([FromQuery] string reportKey)
-        => _mediator.Send(new GetMetaDataQuery(reportKey));
+    public Task<ReportMetaData> GetReportMetaData([FromQuery] string reportKey, CancellationToken cancellationToken)
+        => _mediator.Send(new GetMetaDataQuery(reportKey), cancellationToken);
 
     [HttpGet("parameter/challenge-specs/{gameId?}")]
     public Task<IEnumerable<SimpleEntity>> GetChallengeSpecs(string gameId = null)

--- a/src/Gameboard.Api/Features/Scores/ScoreDenormalizationService.cs
+++ b/src/Gameboard.Api/Features/Scores/ScoreDenormalizationService.cs
@@ -115,7 +115,7 @@ internal class ScoreDenormalizationService
                 SessionStart = (captain?.SessionBegin == null || captain?.SessionBegin == DateTimeOffset.MinValue) ? null : captain.SessionBegin,
                 TeamId = t.TeamId
             };
-        });
+        }));
 
         foreach (var team in teams)
             team.Rank = rankedTeams.TryGetValue(team.TeamId, out var teamRank) ? (teamRank ?? 0) : 0;

--- a/src/Gameboard.Api/Features/Scores/ScoringService.cs
+++ b/src/Gameboard.Api/Features/Scores/ScoringService.cs
@@ -297,10 +297,11 @@ internal class ScoringService(
     public IDictionary<string, int?> GetTeamRanks(IEnumerable<TeamForRanking> teams)
     {
         var scoreRank = 0;
-        TeamForRanking lastScore = null;
+        var lastScore = default(TeamForRanking);
         var retVal = new Dictionary<string, int?>();
         var ranked = teams
-            .OrderByDescending(t => t.OverallScore).ThenBy(t => t.CumulativeTimeMs);
+            .OrderByDescending(t => t.OverallScore)
+                .ThenBy(t => t.CumulativeTimeMs);
 
         foreach (var team in ranked)
         {

--- a/src/Gameboard.Api/Features/Teams/Requests/EndTeamSession.cs
+++ b/src/Gameboard.Api/Features/Teams/Requests/EndTeamSession.cs
@@ -13,14 +13,15 @@ namespace Gameboard.Api.Features.Teams;
 
 public record EndTeamSessionCommand(string TeamId, User Actor) : IRequest<TeamSessionUpdate>;
 
-internal class EndTeamSessionHandler(
+internal class EndTeamSessionHandler
+(
     INowService nowService,
     IUserRolePermissionsService permissionsService,
     IStore store,
     TeamExistsValidator<EndTeamSessionCommand> teamExists,
     ITeamService teamService,
     IValidatorService<EndTeamSessionCommand> validatorService
-    ) : IRequestHandler<EndTeamSessionCommand, TeamSessionUpdate>
+) : IRequestHandler<EndTeamSessionCommand, TeamSessionUpdate>
 {
     private readonly INowService _nowService = nowService;
     private readonly IUserRolePermissionsService _permissionsService = permissionsService;

--- a/src/Gameboard.Api/Features/Teams/TeamController.cs
+++ b/src/Gameboard.Api/Features/Teams/TeamController.cs
@@ -61,7 +61,9 @@ public class TeamController(
     public async Task<TeamSessionUpdate> UpdateSession([FromBody] SessionChangeRequest model, CancellationToken cancellationToken)
     {
         if (model.SessionEnd is null)
+        {
             return await _mediator.Send(new EndTeamSessionCommand(model.TeamId, _actingUserService.Get()), cancellationToken);
+        }
         else
         {
             var player = await _teamService.ExtendSession

--- a/src/Gameboard.Api/Features/Ticket/TicketService.cs
+++ b/src/Gameboard.Api/Features/Ticket/TicketService.cs
@@ -626,6 +626,7 @@ public class TicketService
             .Include(c => c.Activity)
                 .ThenInclude(a => a.Assignee)
             .Include(c => c.Challenge)
+                .ThenInclude(c => c.Game)
             .Include(c => c.Player)
                 .ThenInclude(p => p.Game);
 }


### PR DESCRIPTION
Version 3.27.5 of Gameboard includes minor bug fixes and enhancements.

# Enhancements

- Admins can now use the Practice tab in Game Center to reset a player's practice session (only while the player has an active session)
- Various UI elements have been rethemed to match the current app theme.
- Report API endpoints now support HTTP cancellation for healthier performance of the page.
- A new context menu entry called "View IDs" has been added to Game Center -> Teams. This allows easier copying of specific player, team, and user IDs.

# Bug fixes

- Fixed various cosmetic bugs on the "Live" tab of the Admin area
- Fixed an issue that caused the game name to be `null` when copying ticket markdown
- Fixed an issue that could cause automatic score denormalization to fail to run when a new team scored.
- Fixed an issue that could cause text in some ticket descriptions to wrap strangely
- Improved error handling on the New Ticket form
- Fixed some bugs that could cause Game Center -> Teams to omit players from certain teams when searching