### PR TITLE
v3.27.6

### DIFF
--- a/src/Gameboard.Api/Features/Game/Requests/GetGamePlayState/GetGamePlayState.cs
+++ b/src/Gameboard.Api/Features/Game/Requests/GetGamePlayState/GetGamePlayState.cs
@@ -66,8 +66,10 @@ internal class GetGamePlayStateHandler(
             })
             .ToArrayAsync(cancellationToken);
 
-        var begin = teamSession.Select(p => p.SessionBegin).Distinct().Single();
-        var end = teamSession.Select(p => p.SessionEnd).Distinct().Single();
+        // max is a kludge here - there should only be one, but 
+        // becaues of denormalized structure, bugs could cause more than one
+        var begin = teamSession.Select(p => p.SessionBegin).Max();
+        var end = teamSession.Select(p => p.SessionEnd).Max();
 
         if (begin.IsEmpty())
             return GamePlayState.NotStarted;


### PR DESCRIPTION
Version 3.27.6 of Gameboard fixes an edge case bug where if members of a team ends up with different start times, they're unable to access challenges.