### PR TITLE
v3.28.2

### DIFF
--- a/src/Gameboard.Api.Tests.Unit/Tests/Features/Games/GameImportExport/GameImportExportModelsMappingTests.cs
+++ b/src/Gameboard.Api.Tests.Unit/Tests/Features/Games/GameImportExport/GameImportExportModelsMappingTests.cs
@@ -26,18 +26,18 @@ public class GameImportExportModelsMappingTests
         .Length.ShouldBe(0);
     }
 
-    // [Fact]
-    // public void GameImportExportExternalHosts_AttributeStrategy_ExportsProperties()
-    // {
-    //     var properties = typeof(GameImportExportExternalHost).GetProperties(BindingFlags.Public | BindingFlags.Instance);
-    //     var propertyNames = properties.Select(p => p.Name).ToArray();
-    //     var gameProperties = typeof(ExternalGameHost)
-    //         .GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
-    //         .Where(p => !p.HasAttribute<NotMappedAttribute>())
-    //         .Where(p => !p.HasAttribute<DontExportAttribute>());
+    [Fact]
+    public void GameImportExportExternalHosts_AttributeStrategy_ExportsProperties()
+    {
+        var properties = typeof(GameImportExportExternalHost).GetProperties(BindingFlags.Public | BindingFlags.Instance);
+        var propertyNames = properties.Select(p => p.Name).ToArray();
+        var gameProperties = typeof(ExternalGameHost)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Where(p => !p.HasAttribute<NotMappedAttribute>())
+            .Where(p => !p.HasAttribute<DontExportAttribute>());
 
-    //     gameProperties.Where(p => !propertyNames.Contains(p.Name))
-    //     .ToArray()
-    //     .Length.ShouldBe(0);
-    // }
+        gameProperties.Where(p => !propertyNames.Contains(p.Name))
+        .ToArray()
+        .Length.ShouldBe(0);
+    }
 }

--- a/src/Gameboard.Api/Data/Entities/ExternalGameHost.cs
+++ b/src/Gameboard.Api/Data/Entities/ExternalGameHost.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Gameboard.Api.Features.Games;
 
 namespace Gameboard.Api.Data;
 
@@ -10,6 +11,7 @@ public sealed class ExternalGameHost : IEntity
     public required bool DestroyResourcesOnDeployFailure { get; set; }
     public int? GamespaceDeployBatchSize { get; set; }
     public int? HttpTimeoutInSeconds { get; set; }
+    [DontExport]
     public string HostApiKey { get; set; }
     public required string HostUrl { get; set; }
     public string PingEndpoint { get; set; }
@@ -17,5 +19,6 @@ public sealed class ExternalGameHost : IEntity
     public string TeamExtendedEndpoint { get; set; }
 
     // nav properties
+    [DontExport]
     public ICollection<Data.Game> UsedByGames { get; set; } = new List<Data.Game>();
 }

--- a/src/Gameboard.Api/Data/Entities/Game.cs
+++ b/src/Gameboard.Api/Data/Entities/Game.cs
@@ -78,19 +78,7 @@ public class Game : IEntity
     public ICollection<Feedback> Feedback { get; set; } = [];
     public ICollection<ChallengeGate> Prerequisites { get; set; } = [];
 
-    [NotMapped] public bool RequireSession => SessionMinutes > 0;
-    [NotMapped] public bool RequireTeam => MinTeamSize > 1;
     [NotMapped] public bool AllowTeam => MaxTeamSize > 1;
-
-    [NotMapped]
-    public bool IsLive =>
-        GameStart != DateTimeOffset.MinValue &&
-        GameStart.CompareTo(DateTimeOffset.UtcNow) < 0 &&
-        GameEnd.CompareTo(DateTimeOffset.UtcNow) > 0;
-
-    [NotMapped]
-    public bool HasEnded =>
-        GameEnd.CompareTo(DateTimeOffset.UtcNow) < 0;
 
     [NotMapped]
     public bool RegistrationActive =>
@@ -98,6 +86,5 @@ public class Game : IEntity
         RegistrationOpen.CompareTo(DateTimeOffset.UtcNow) < 0 &&
         RegistrationClose.CompareTo(DateTimeOffset.UtcNow) > 0;
 
-    [NotMapped] public bool IsCompetitionMode => PlayerMode == PlayerMode.Competition;
     [NotMapped] public bool IsPracticeMode => PlayerMode == PlayerMode.Practice;
 }

--- a/src/Gameboard.Api/Features/Certificates/CertificatesService.cs
+++ b/src/Gameboard.Api/Features/Certificates/CertificatesService.cs
@@ -78,11 +78,10 @@ internal class CertificatesService
             .WithNoTracking<Data.Player>()
             .Where
             (
-                p => p.UserId == userId &&
-                p.SessionEnd > DateTimeOffset.MinValue &&
-                p.Game.PlayerMode == PlayerMode.Competition &&
-                (p.Game.GameEnd < now || p.Game.GameEnd == DateTimeOffset.MinValue) &&
-                p.Game.CertificateTemplateId != null
+                p =>
+                    p.UserId == userId
+                    && (p.Game.GameEnd < now || p.Game.GameEnd == DateTimeOffset.MinValue)
+            // && p.Game.CertificateTemplateId != null
             )
             .WhereDateIsNotEmpty(p => p.SessionEnd)
             .Where(p => p.Challenges.All(c => c.PlayerMode == PlayerMode.Competition))
@@ -159,7 +158,7 @@ internal class CertificatesService
                     MaxPossibleScore = t.Game.MaxPossibleScore
                 },
                 Date = t.Game.GameEnd.IsEmpty() ? captain.SessionEnd : t.Game.GameEnd,
-                Rank = score.Rank > 0 ? score.Rank : null,
+                Rank = score?.Rank ?? 0,
                 Score = score is not null ? score.ScoreOverall : 0,
                 Duration = TimeSpan.FromMilliseconds(t.Time),
                 UniquePlayerCount = participationCounts?.UniquePlayerCount,

--- a/src/Gameboard.Api/Features/Certificates/CertificatesService.cs
+++ b/src/Gameboard.Api/Features/Certificates/CertificatesService.cs
@@ -81,7 +81,7 @@ internal class CertificatesService
                 p =>
                     p.UserId == userId
                     && (p.Game.GameEnd < now || p.Game.GameEnd == DateTimeOffset.MinValue)
-            // && p.Game.CertificateTemplateId != null
+                    && p.Game.CertificateTemplateId != null
             )
             .WhereDateIsNotEmpty(p => p.SessionEnd)
             .Where(p => p.Challenges.All(c => c.PlayerMode == PlayerMode.Competition))

--- a/src/Gameboard.Api/Features/Challenge/Services/ChallengeService.cs
+++ b/src/Gameboard.Api/Features/Challenge/Services/ChallengeService.cs
@@ -109,7 +109,7 @@ public partial class ChallengeService
         }
 
         // if we're outside the execution window, we need to be sure the acting person is an admin
-        if (player.Game.IsCompetitionMode)
+        if (player.Game.PlayerMode == PlayerMode.Competition)
         {
             // check gamespace limits for competitive games only
             var teamActiveChallenges = await _teamService.GetChallengesWithActiveGamespace(player.TeamId, player.GameId, cancellationToken);
@@ -156,7 +156,7 @@ public partial class ChallengeService
                 .SingleAsync(s => s.Id == model.SpecId, cancellationToken);
 
             var playerCount = 1;
-            if (player.Game.AllowTeam)
+            if (player.Game.MaxTeamSize > 1)
             {
                 playerCount = await _store
                     .WithNoTracking<Data.Player>()

--- a/src/Gameboard.Api/Features/Game/GameController.cs
+++ b/src/Gameboard.Api/Features/Game/GameController.cs
@@ -244,7 +244,6 @@ namespace Gameboard.Api.Controllers
             await Authorize(_permissionsService.Can(PermissionKey.Scores_RegradeAndRerank));
             await Validate(new Entity { Id = id });
 
-            await GameService.ReRank(id);
             await _scoreDenormalization.DenormalizeGame(id, cancellationToken);
             await _mediator.Publish(new GameCacheInvalidateNotification(id), cancellationToken);
         }

--- a/src/Gameboard.Api/Features/Scores/ScoreDenormalizationService.cs
+++ b/src/Gameboard.Api/Features/Scores/ScoreDenormalizationService.cs
@@ -103,7 +103,6 @@ internal class ScoreDenormalizationService
             .ToArrayAsync();
 
         var captains = await _teamService.ResolveCaptains(teams.Select(t => t.TeamId).ToArray(), cancellationToken: CancellationToken.None);
-
         var rankedTeams = _scoringService.GetTeamRanks(teams.Select(t =>
         {
             captains.TryGetValue(t.TeamId, out var captain);

--- a/src/Gameboard.Api/Features/Support/SupportModels.cs
+++ b/src/Gameboard.Api/Features/Support/SupportModels.cs
@@ -25,3 +25,9 @@ public sealed class UpsertSupportSettingsAutoTagRequest
     public bool? IsEnabled { get; set; }
     public required string Tag { get; set; }
 }
+
+public static class TicketStatus
+{
+    public static readonly string Closed = "Closed";
+    public static readonly string Open = "Open";
+}

--- a/src/Gameboard.Api/Features/Teams/Notifications/TeamSessionResetNotification.cs
+++ b/src/Gameboard.Api/Features/Teams/Notifications/TeamSessionResetNotification.cs
@@ -1,26 +1,18 @@
 using System.Threading;
 using System.Threading.Tasks;
-using Gameboard.Api.Services;
+using Gameboard.Api.Features.Scores;
 using MediatR;
 
 namespace Gameboard.Api.Features.Teams;
 
 public record TeamSessionResetNotification(string GameId, string TeamId) : INotification;
 
-internal class TeamSessionResetHandler : INotificationHandler<TeamSessionResetNotification>
+internal class TeamSessionResetHandler(IScoreDenormalizationService scoreDenorm) : INotificationHandler<TeamSessionResetNotification>
 {
-    private readonly GameService _gameService;
-
-    public TeamSessionResetHandler
-    (
-        GameService gameService
-    )
-    {
-        _gameService = gameService;
-    }
+    private readonly IScoreDenormalizationService _scoreDenorm = scoreDenorm;
 
     public async Task Handle(TeamSessionResetNotification notification, CancellationToken cancellationToken)
     {
-        await _gameService.ReRank(notification.GameId);
+        await _scoreDenorm.DenormalizeGame(notification.GameId, cancellationToken);
     }
 }

--- a/src/Gameboard.Api/Features/Teams/Requests/GetTeamEventHorizon/GetTeamEventHorizon.cs
+++ b/src/Gameboard.Api/Features/Teams/Requests/GetTeamEventHorizon/GetTeamEventHorizon.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Gameboard.Api.Common.Services;
 using Gameboard.Api.Data;
 using Gameboard.Api.Features.Scores;
+using Gameboard.Api.Features.Support;
 using Gameboard.Api.Features.Users;
 using Gameboard.Api.Structure.MediatR;
 using Gameboard.Api.Structure.MediatR.Validators;
@@ -68,7 +69,9 @@ internal class GetTeamEventHorizonHandler
             .ToArrayAsync(cancellationToken);
 
         if (challenges.Length == 0)
+        {
             return null;
+        }
 
         // make sure we have exactly one game
         var games = challenges.Select(c => c.Game).ToArray();
@@ -119,6 +122,9 @@ internal class GetTeamEventHorizonHandler
         var submissionEvents = BuildSubmissionEvents(submissions, challengeMaxScores);
         events.AddRange(submissionEvents);
 
+        // ticket events come from ticket activity
+        events.AddRange(await BuildTicketOpenClosedEvents(request.TeamId, cancellationToken));
+
         // finally, build the event horizon response
         return new EventHorizon
         {
@@ -159,7 +165,7 @@ internal class GetTeamEventHorizonHandler
     /// </summary>
     /// <param name="challenges"></param>
     /// <returns></returns>
-    private IEnumerable<EventHorizonGamespaceOnOffEvent> BuildGamespaceEvents(IEnumerable<Data.Challenge> challenges)
+    private EventHorizonGamespaceOnOffEvent[] BuildGamespaceEvents(IEnumerable<Data.Challenge> challenges)
     {
         var retVal = new List<EventHorizonGamespaceOnOffEvent>();
 
@@ -222,7 +228,7 @@ internal class GetTeamEventHorizonHandler
         return retVal.OrderBy(e => e.Timestamp).ToArray();
     }
 
-    private IEnumerable<IEventHorizonEvent> BuildSubmissionEvents(IEnumerable<ChallengeSubmission> submissions, IDictionary<string, double> challengeSolveScores)
+    private IEventHorizonEvent[] BuildSubmissionEvents(IEnumerable<ChallengeSubmission> submissions, IDictionary<string, double> challengeSolveScores)
     {
         // we'll return a list of submission/solve events
         var retVal = new List<IEventHorizonEvent>();
@@ -287,6 +293,61 @@ internal class GetTeamEventHorizonHandler
             }
         }
 
-        return retVal;
+        return [.. retVal];
+    }
+
+    private async Task<EventHorizonTicketOpenCloseEvent[]> BuildTicketOpenClosedEvents(string teamId, CancellationToken cancellationToken)
+    {
+        // pull the data first, then worry about organizing it "client" side
+        var challengeTickets = await _store
+            .WithNoTracking<Data.Ticket>()
+            .Where(t => t.ChallengeId != null && t.ChallengeId != string.Empty && t.TeamId == teamId)
+            .Select(t => new { t.Id, t.Status, t.Created, t.ChallengeId, Activity = t.Activity.Select(a => new { a.Id, a.Timestamp, a.Status }).Distinct().OrderBy(a => a.Status).ToList() })
+            .GroupBy(a => a.ChallengeId)
+            .ToDictionaryAsync(gr => gr.Key, gr => gr.ToList(), cancellationToken);
+
+        var events = new List<EventHorizonTicketOpenCloseEvent>();
+
+        // for each challenge, find its tickets and build events for them
+        foreach (var challengeId in challengeTickets.Keys)
+        {
+            // we auto-create an open event for each challenge group, because:
+            // - The challenge is guaranteed to have at least one ticket if it comes back from the query
+            // - new tickets don't get an Activity entry just for opening, so we need to simulate that here
+            var tickets = challengeTickets[challengeId];
+
+            foreach (var ticket in tickets)
+            {
+                var lastOpenStamp = ticket.Created;
+                var creatingEvent = new EventHorizonTicketOpenCloseEvent
+                {
+                    Id = challengeId,
+                    ChallengeId = challengeId,
+                    Timestamp = ticket.Created,
+                    Type = EventHorizonEventType.TicketOpenClose,
+                    EventData = new EventHorizonTicketOpenClosedEventData
+                    {
+                        ClosedAt = default
+                    }
+                };
+                events.Add(creatingEvent);
+
+                foreach (var activity in ticket.Activity)
+                {
+                    if (ticket.Status == TicketStatus.Open && lastOpenStamp == default)
+                    {
+                        lastOpenStamp = activity.Timestamp;
+                    }
+                    else if (activity.Status == TicketStatus.Closed && lastOpenStamp != default)
+                    {
+                        creatingEvent.EventData.ClosedAt = activity.Timestamp;
+                        lastOpenStamp = default;
+                    }
+                }
+            }
+
+        }
+
+        return [.. events];
     }
 }

--- a/src/Gameboard.Api/Features/Teams/Requests/GetTeamEventHorizon/GetTeamEventHorizonModels.cs
+++ b/src/Gameboard.Api/Features/Teams/Requests/GetTeamEventHorizon/GetTeamEventHorizonModels.cs
@@ -10,13 +10,15 @@ public enum EventHorizonEventType
     GamespaceOnOff,
     SolveComplete,
     SubmissionRejected,
-    SubmissionScored
+    SubmissionScored,
+    TicketOpenClose
 }
 
 [JsonDerivedType(typeof(EventHorizonEvent))]
 [JsonDerivedType(typeof(EventHorizonGamespaceOnOffEvent))]
 [JsonDerivedType(typeof(EventHorizonSolveCompleteEvent))]
 [JsonDerivedType(typeof(EventHorizonSubmissionScoredEvent))]
+[JsonDerivedType(typeof(EventHorizonTicketOpenCloseEvent))]
 public interface IEventHorizonEvent
 {
     public string Id { get; set; }
@@ -64,6 +66,16 @@ public sealed class EventHorizonSubmissionScoredEventData
 public sealed class EventHorizonSubmissionScoredEvent : EventHorizonEvent
 {
     public required EventHorizonSubmissionScoredEventData EventData { get; set; }
+}
+
+public sealed class EventHorizonTicketOpenCloseEvent : EventHorizonEvent, IEventHorizonEvent
+{
+    public required EventHorizonTicketOpenClosedEventData EventData { get; set; }
+}
+
+public sealed class EventHorizonTicketOpenClosedEventData
+{
+    public required DateTimeOffset ClosedAt { get; set; }
 }
 
 public sealed class EventHorizonGame

--- a/src/Gameboard.Api/Features/Teams/Requests/GetTeamEventHorizon/GetTeamEventHorizonModels.cs
+++ b/src/Gameboard.Api/Features/Teams/Requests/GetTeamEventHorizon/GetTeamEventHorizonModels.cs
@@ -76,6 +76,7 @@ public sealed class EventHorizonTicketOpenCloseEvent : EventHorizonEvent, IEvent
 public sealed class EventHorizonTicketOpenClosedEventData
 {
     public required DateTimeOffset ClosedAt { get; set; }
+    public required string TicketKey { get; set; }
 }
 
 public sealed class EventHorizonGame

--- a/src/Gameboard.Api/Features/Ticket/TicketService.cs
+++ b/src/Gameboard.Api/Features/Ticket/TicketService.cs
@@ -33,8 +33,7 @@ public class TicketService
     CoreOptions options,
     IUserRolePermissionsService permissionsService,
     IStore store,
-    ISupportHubBus supportHubBus,
-    ITeamService teamService
+    ISupportHubBus supportHubBus
 ) : _Service(logger, mapper, options)
 {
     private readonly IActingUserService _actingUserService = actingUserService;
@@ -46,9 +45,9 @@ public class TicketService
     private readonly IUserRolePermissionsService _permissionsService = permissionsService;
     private readonly IStore _store = store;
     private readonly ISupportHubBus _supportHubBus = supportHubBus;
-    private readonly ITeamService _teamService = teamService;
 
     internal static char TAGS_DELIMITER = ' ';
+    public static readonly string OpenStatus = "Open";
 
     public string GetFullKey(int key)
         => $"{(Options.KeyPrefix.IsEmpty() ? "GB" : Options.KeyPrefix)}-{key}";

--- a/src/Gameboard.Api/Features/Ticket/TicketService.cs
+++ b/src/Gameboard.Api/Features/Ticket/TicketService.cs
@@ -46,7 +46,6 @@ public class TicketService
     private readonly ISupportHubBus _supportHubBus = supportHubBus;
 
     internal static char TAGS_DELIMITER = ' ';
-    public static readonly string OpenStatus = "Open";
 
     public string GetFullKey(int key)
         => $"{(Options.KeyPrefix.IsEmpty() ? "GB" : Options.KeyPrefix)}-{key}";

--- a/src/Gameboard.Api/Features/Ticket/TicketService.cs
+++ b/src/Gameboard.Api/Features/Ticket/TicketService.cs
@@ -11,7 +11,6 @@ using AutoMapper;
 using Gameboard.Api.Common.Services;
 using Gameboard.Api.Data;
 using Gameboard.Api.Features.Support;
-using Gameboard.Api.Features.Teams;
 using Gameboard.Api.Features.Users;
 using Gameboard.Api.Hubs;
 using MediatR;


### PR DESCRIPTION
Version 3.28.2 contains a minor enhancement and a few bug fixes.

# Enhancements

- The team timeline modal now shows the team's challenge-related tickets as events on the timeline.
- Minor styling updates on the ticket details page

# Bug fixes

- Fixed a bad legacy workaround that caused the scoreboard to deadlock the database if no players had scored yet and multiple people accessed it.
- Fixed a bug that could cause players who played in one or more games in which they didn't score to be unable to retrieve their competitive certificates

# Stability/App health

- Removed some legacy properties from the Game entity