### PR TITLE
v3.28.4

### DIFF
--- a/src/Gameboard.Api/Data/Entities/Game.cs
+++ b/src/Gameboard.Api/Data/Entities/Game.cs
@@ -78,7 +78,19 @@ public class Game : IEntity
     public ICollection<Feedback> Feedback { get; set; } = [];
     public ICollection<ChallengeGate> Prerequisites { get; set; } = [];
 
+    [NotMapped] public bool RequireSession => SessionMinutes > 0;
+    [NotMapped] public bool RequireTeam => MinTeamSize > 1;
     [NotMapped] public bool AllowTeam => MaxTeamSize > 1;
+
+    [NotMapped]
+    public bool IsLive =>
+        GameStart != DateTimeOffset.MinValue &&
+        GameStart.CompareTo(DateTimeOffset.UtcNow) < 0 &&
+        GameEnd.CompareTo(DateTimeOffset.UtcNow) > 0;
+
+    [NotMapped]
+    public bool HasEnded =>
+        GameEnd.CompareTo(DateTimeOffset.UtcNow) < 0;
 
     [NotMapped]
     public bool RegistrationActive =>
@@ -86,5 +98,6 @@ public class Game : IEntity
         RegistrationOpen.CompareTo(DateTimeOffset.UtcNow) < 0 &&
         RegistrationClose.CompareTo(DateTimeOffset.UtcNow) > 0;
 
+    [NotMapped] public bool IsCompetitionMode => PlayerMode == PlayerMode.Competition;
     [NotMapped] public bool IsPracticeMode => PlayerMode == PlayerMode.Practice;
 }

--- a/src/Gameboard.Api/Features/Game/ImportExport/GameImportExportService.cs
+++ b/src/Gameboard.Api/Features/Game/ImportExport/GameImportExportService.cs
@@ -318,7 +318,7 @@ internal sealed class GameImportExportService
 
         var batch = new GameImportExportBatch
         {
-            DownloadUrl = GetExportBatchPackageName(exportBatchId),
+            DownloadUrl = Path.Combine(_coreOptions.AppUrl, GetExportBatchPackagePath(exportBatchId)),
             ExportBatchId = exportBatchId,
             Games = [.. gamesExported],
             CertificateTemplates = certificateTemplates,

--- a/src/Gameboard.Api/Features/Game/ImportExport/GameImportExportService.cs
+++ b/src/Gameboard.Api/Features/Game/ImportExport/GameImportExportService.cs
@@ -318,7 +318,7 @@ internal sealed class GameImportExportService
 
         var batch = new GameImportExportBatch
         {
-            DownloadUrl = Path.Combine(_coreOptions.AppUrl, GetExportBatchPackagePath(exportBatchId)),
+            DownloadUrl = Path.Combine(_coreOptions.AppUrl, "games", "export", exportBatchId),
             ExportBatchId = exportBatchId,
             Games = [.. gamesExported],
             CertificateTemplates = certificateTemplates,

--- a/src/Gameboard.Api/Features/Reports/Queries/FeedbackReport/FeedbackReportService.cs
+++ b/src/Gameboard.Api/Features/Reports/Queries/FeedbackReport/FeedbackReportService.cs
@@ -128,17 +128,17 @@ internal sealed class FeedbackReportService(IReportsService reportsService, ISto
 
         if (seasonsCriteria.Any())
         {
-            records = records.Where(s => seasonsCriteria.Contains(s.LogicalGame.Season));
+            records = records.Where(s => seasonsCriteria.Contains(s.LogicalGame.Season.ToLower()));
         }
 
         if (seriesCriteria.Any())
         {
-            records = records.Where(s => seriesCriteria.Contains(s.LogicalGame.Series));
+            records = records.Where(s => seriesCriteria.Contains(s.LogicalGame.Series.ToLower()));
         }
 
         if (tracksCriteria.Any())
         {
-            records = records.Where(s => tracksCriteria.Contains(s.LogicalGame.Track));
+            records = records.Where(s => tracksCriteria.Contains(s.LogicalGame.Track.ToLower()));
         }
 
         var orderedQuery = records.OrderBy(r => r.User.Name);


### PR DESCRIPTION
Version 3.28.4 of Gameboard fixes a few bugs and adds a minor enhancement.

# Enhancements

- Admins can now view certificates issued to players and teams to ensure template quality and accuracy. 
  - The same criteria still apply - the player must have a nonzero score, be finished with their session, and the game must be over.
  - To do this, visit Game Center -> Teams and use the new context menu entry "View Certificate"


# Bug fixes

- Fixed an issue that caused some of the filters for the Feedback Report to fail to apply correctly.
- Fixed an issue that prevented players from accessing old certificates.