### PR TITLE
v3.32.1

### DIFF
--- a/src/Gameboard.Api.Tests.Integration/Tests/Features/Games/GameControllerTests.cs
+++ b/src/Gameboard.Api.Tests.Integration/Tests/Features/Games/GameControllerTests.cs
@@ -11,7 +11,7 @@ public class GameControllerTests(GameboardTestContext testContext) : IClassFixtu
     {
         // arrange
 
-        var game = new NewGame()
+        var game = new GameDetail()
         {
             Name = "Test game",
             Competition = "Test competition",

--- a/src/Gameboard.Api/Common/Services/SlugService.cs
+++ b/src/Gameboard.Api/Common/Services/SlugService.cs
@@ -15,6 +15,6 @@ internal partial class SlugService : ISlugService
             .ToLower()
             .Trim('-');
 
-    [GeneratedRegex("\\s+")]
+    [GeneratedRegex("[^a-zA-Z0-9]+")]
     private static partial Regex WhitespaceRegex();
 }

--- a/src/Gameboard.Api/Features/ChallengeSpec/ChallengeSpecController.cs
+++ b/src/Gameboard.Api/Features/ChallengeSpec/ChallengeSpecController.cs
@@ -2,6 +2,7 @@
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Gameboard.Api.Common.Services;
 using Gameboard.Api.Features.ChallengeSpecs;
@@ -99,8 +100,8 @@ public class ChallengeSpecController
     /// Load solve performance for the challenge spec
     /// </summary>
     [HttpGet("/api/challengespecs/{challengeSpecId}/question-performance")]
-    public Task<GetChallengeSpecQuestionPerformanceResult> GetQuestionPerformance([FromRoute] string challengeSpecId)
-        => _mediator.Send(new GetChallengeSpecQuestionPerformanceQuery(challengeSpecId));
+    public Task<GetChallengeSpecQuestionPerformanceResult> GetQuestionPerformance([FromRoute] string challengeSpecId, CancellationToken cancellationToken)
+        => _mediator.Send(new GetChallengeSpecQuestionPerformanceQuery(challengeSpecId), cancellationToken);
 
     /// <summary>
     /// Sync challengespec name/description with external source

--- a/src/Gameboard.Api/Features/ChallengeSpec/ChallengeSpecService.cs
+++ b/src/Gameboard.Api/Features/ChallengeSpec/ChallengeSpecService.cs
@@ -194,7 +194,6 @@ public class ChallengeSpecService
                 CountSubmitted = allQuestions[q.Text].Count(answeredQ => answeredQ.IsGraded)
             }).OrderBy(q => q.QuestionRank);
 
-            // GB will need special topo access anyway if we want to show support people the answers
             questionPerformance.Add(challengeSpecId, questions);
         }
 

--- a/src/Gameboard.Api/Features/Feedback/Requests/ListFeedbackTemplates/ListFeedbackTemplates.cs
+++ b/src/Gameboard.Api/Features/Feedback/Requests/ListFeedbackTemplates/ListFeedbackTemplates.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using AutoMapper;
@@ -25,7 +26,12 @@ internal sealed class ListFeedbackTemplatesHandler(IMapper mapper, IStore store,
             .Validate(cancellationToken);
 
         var templates = await _mapper
-            .ProjectTo<FeedbackTemplateView>(_store.WithNoTracking<FeedbackTemplate>())
+            .ProjectTo<FeedbackTemplateView>
+            (
+                _store
+                    .WithNoTracking<FeedbackTemplate>()
+                    .OrderBy(t => t.Name)
+            )
             .ToArrayAsync(cancellationToken);
 
         return new ListFeedbackTemplatesResponse { Templates = templates };

--- a/src/Gameboard.Api/Features/Game/Game.cs
+++ b/src/Gameboard.Api/Features/Game/Game.cs
@@ -72,11 +72,6 @@ public class Game : GameDetail
     public bool IsPracticeMode { get; set; }
 }
 
-public class NewGame : GameDetail
-{
-    public bool IsClone { get; set; } = false;
-}
-
 public class ChangedGame : Game { }
 
 public class GameSearchFilter : SearchFilter

--- a/src/Gameboard.Api/Features/Game/GameController.cs
+++ b/src/Gameboard.Api/Features/Game/GameController.cs
@@ -56,7 +56,7 @@ public class GameController
     /// <param name="model"></param>
     /// <returns></returns>
     [HttpPost("api/game")]
-    public async Task<Game> Create([FromBody] NewGame model)
+    public async Task<Game> Create([FromBody] GameDetail model)
     {
         await Authorize(_permissionsService.Can(PermissionKey.Games_CreateEditDelete));
         return await GameService.Create(model);

--- a/src/Gameboard.Api/Features/Game/GameController.cs
+++ b/src/Gameboard.Api/Features/Game/GameController.cs
@@ -62,6 +62,11 @@ public class GameController
         return await GameService.Create(model);
     }
 
+    [HttpPost("api/game/clone")]
+    [Authorize]
+    public Task<Game> Clone([FromBody] CloneGameCommand request, CancellationToken cancellationToken)
+        => _mediator.Send(request, cancellationToken);
+
     /// <summary>
     /// Retrieve game
     /// </summary>
@@ -218,56 +223,34 @@ public class GameController
     public Task<TeamGamespaceLimitState> GetTeamGamespaceLimitState([FromRoute] string gameId, [FromRoute] string teamId)
         => _mediator.Send(new GetTeamGamespaceLimitStateQuery(gameId, teamId, Actor));
 
-    [HttpPost("api/game/{id}/card")]
-    public async Task<ActionResult<UploadedFile>> UploadGameCard(string id, IFormFile file)
+    [HttpPost("api/game/{id}/image/card")]
+    public async Task<ActionResult<UploadedFile>> UploadCardImage(string id, IFormFile file, CancellationToken cancellationToken)
     {
         await Authorize(_permissionsService.Can(PermissionKey.Games_CreateEditDelete));
-        return Ok(await GameService.SaveGameCardImage(id, file));
+        return Ok(await GameService.SaveCardImage(id, file, cancellationToken));
     }
 
-    [HttpPost("api/game/{id}/{type}")]
-    public async Task<ActionResult<UploadedFile>> UploadMapImage(string id, string type, IFormFile file)
+    [HttpPost("api/game/{id}/image/map")]
+    public async Task<UploadedFile> UploadMapImage(string id, IFormFile file, CancellationToken cancellationToken)
     {
         await Authorize(_permissionsService.Can(PermissionKey.Games_CreateEditDelete));
-        await Validate(new Entity { Id = id });
-
-        string filename = $"{type}_{new Random().Next().ToString("x8")}{Path.GetExtension(file.FileName)}".ToLower();
-        string path = Path.Combine(Options.ImageFolder, filename);
-
-        using (var stream = new FileStream(path, FileMode.Create))
-        {
-            await file.CopyToAsync(stream);
-        }
-
-        await GameService.UpdateImage(id, type, filename);
-
-        return Ok(new UploadedFile { Filename = filename });
+        return await GameService.SaveMapImage(id, file, cancellationToken);
     }
 
-    [HttpDelete("api/game/{id}/card")]
-    public async Task DeleteGameCard([FromRoute] string id)
-    {
-        await Authorize(_permissionsService.Can(PermissionKey.Games_CreateEditDelete));
-        await GameService.DeleteGameCardImage(id);
-    }
-
-    [HttpDelete("api/game/{id}/{type}")]
+    [HttpDelete("api/game/{id}/image/card")]
     [Authorize]
-    public async Task<ActionResult<UploadedFile>> DeleteImage([FromRoute] string id, [FromRoute] string type)
+    public async Task DeleteGameCard([FromRoute] string id, CancellationToken cancellationToken)
     {
         await Authorize(_permissionsService.Can(PermissionKey.Games_CreateEditDelete));
-        await Validate(new Entity { Id = id });
+        await GameService.DeleteCardImage(id, cancellationToken);
+    }
 
-        string target = $"{id}_{type}.*".ToLower();
-        var file = Directory.GetFiles(Options.ImageFolder, target).FirstOrDefault();
-
-        if (file.NotEmpty())
-        {
-            System.IO.File.Delete(file);
-            await GameService.UpdateImage(id, type, "");
-        }
-
-        return Ok(new UploadedFile { Filename = "" });
+    [HttpDelete("api/game/{gameId}/image/map")]
+    [Authorize]
+    public async Task DeleteGameMapImage([FromRoute] string gameId, CancellationToken cancellationToken)
+    {
+        await Authorize(_permissionsService.Can(PermissionKey.Games_CreateEditDelete));
+        await GameService.DeleteMapImage(gameId, cancellationToken);
     }
 
     /// <summary>

--- a/src/Gameboard.Api/Features/Game/GameMapper.cs
+++ b/src/Gameboard.Api/Features/Game/GameMapper.cs
@@ -3,9 +3,6 @@
 
 using System.Linq;
 using AutoMapper;
-using Gameboard.Api.Features.Feedback;
-using YamlDotNet.Serialization;
-using YamlDotNet.Serialization.NamingConventions;
 
 namespace Gameboard.Api.Services;
 
@@ -13,45 +10,9 @@ public class GameMapper : Profile
 {
     public GameMapper()
     {
-        var yaml = new DeserializerBuilder()
-            .WithNamingConvention(CamelCaseNamingConvention.Instance)
-            .IgnoreUnmatchedProperties()
-            .Build();
-
         CreateMap<string, string>().ConvertUsing(str => str == null ? null : str.Trim());
-
-        // Use BeforeMap for custom mapping since Deserialize() could error and prevent Game from loading
-        // Need to not throw error if format is invalid. If Deserialize() could default to null on error, that would be ideal
-        CreateMap<Data.Game, Game>()
-            .BeforeMap((src, dest) =>
-            {
-                try
-                {
-                    dest.FeedbackTemplate = yaml.Deserialize<GameFeedbackTemplate>(src.FeedbackConfig ?? "");
-                }
-                catch
-                {
-                    dest.FeedbackTemplate = null;
-                }
-            })
-            .ForMember(d => d.CountPlayers, o => o.MapFrom(s => s.Players.Select(p => p.UserId).Distinct().Count()))
-            .ForMember(d => d.CountTeams, o => o.MapFrom(s => s.Players.Select(p => p.TeamId).Distinct().Count()));
-
-        CreateMap<Data.Game, BoardGame>()
-            .BeforeMap((src, dest) =>
-            {
-                try
-                {
-                    dest.FeedbackTemplate = yaml.Deserialize<GameFeedbackTemplate>(src.FeedbackConfig ?? "");
-                }
-                catch
-                {
-                    dest.FeedbackTemplate = null;
-                }
-            });
-
         CreateMap<Game, Data.Game>();
-        CreateMap<NewGame, Data.Game>();
+        CreateMap<GameDetail, Data.Game>();
         CreateMap<ChangedGame, Data.Game>()
             .ForMember(d => d.FeedbackTemplateId, opt => opt.MapFrom(s => s.FeedbackTemplateId))
             .ForMember(d => d.ChallengesFeedbackTemplateId, opt => opt.MapFrom(s => s.ChallengesFeedbackTemplateId))
@@ -59,6 +20,10 @@ public class GameMapper : Profile
             .ForMember(d => d.ChallengesFeedbackTemplate, opt => opt.Ignore());
 
         // FROM Data.Game
+        CreateMap<Data.Game, BoardGame>();
+        CreateMap<Data.Game, Game>()
+            .ForMember(d => d.CountPlayers, o => o.MapFrom(s => s.Players.Select(p => p.UserId).Distinct().Count()))
+            .ForMember(d => d.CountTeams, o => o.MapFrom(s => s.Players.Select(p => p.TeamId).Distinct().Count()));
         CreateMap<Data.Game, SimpleEntity>();
     }
 }

--- a/src/Gameboard.Api/Features/Game/GameService.cs
+++ b/src/Gameboard.Api/Features/Game/GameService.cs
@@ -13,13 +13,12 @@ using Microsoft.Extensions.Logging;
 using AutoMapper;
 using Gameboard.Api.Common.Services;
 using Gameboard.Api.Data;
-using System.Linq.Expressions;
 
 namespace Gameboard.Api.Services;
 
 public interface IGameService
 {
-    Task<Game> Create(NewGame model);
+    Task<Game> Create(GameDetail model);
     Task DeleteCardImage(string gameId, CancellationToken cancellationToken);
     Task DeleteMapImage(string gameId, CancellationToken cancellationToken);
     IQueryable<GameActiveTeam> GetTeamsWithActiveSession(string GameId);
@@ -50,15 +49,8 @@ public class GameService
     private readonly INowService _now = nowService;
     private readonly IStore _store = store;
 
-    public async Task<Game> Create(NewGame model)
+    public async Task<Game> Create(GameDetail model)
     {
-        // for "New Game" only, set global defaults, if defined
-        if (!model.IsClone)
-        {
-            if (_defaults.FeedbackTemplate.NotEmpty())
-                model.FeedbackConfig = _defaults.FeedbackTemplate;
-        }
-
         // defaults: standard, 60 minutes, scoreboard access, etc.
         if (model.Mode.IsEmpty())
             model.Mode = GameEngineMode.Standard;

--- a/src/Gameboard.Api/Features/Game/GameService.cs
+++ b/src/Gameboard.Api/Features/Game/GameService.cs
@@ -13,22 +13,25 @@ using Microsoft.Extensions.Logging;
 using AutoMapper;
 using Gameboard.Api.Common.Services;
 using Gameboard.Api.Data;
+using System.Linq.Expressions;
 
 namespace Gameboard.Api.Services;
 
 public interface IGameService
 {
     Task<Game> Create(NewGame model);
-    Task DeleteGameCardImage(string gameId);
+    Task DeleteCardImage(string gameId, CancellationToken cancellationToken);
+    Task DeleteMapImage(string gameId, CancellationToken cancellationToken);
     IQueryable<GameActiveTeam> GetTeamsWithActiveSession(string GameId);
     Task<bool> IsUserPlaying(string gameId, string userId);
     Task<IEnumerable<Game>> List(GameSearchFilter model = null, bool sudo = false);
     Task<GameGroup[]> ListGrouped(GameSearchFilter model, bool sudo);
     Task<Game> Retrieve(string id, bool accessHidden = true);
     Task<ChallengeSpec[]> RetrieveChallengeSpecs(string id);
+    Task<UploadedFile> SaveCardImage(string gameId, IFormFile file, CancellationToken cancellationToken);
+    Task<UploadedFile> SaveMapImage(string gameId, IFormFile file, CancellationToken cancellationToken);
     Task<SessionForecast[]> SessionForecast(string id);
     Task<Data.Game> Update(ChangedGame account);
-    Task UpdateImage(string id, string type, string filename);
 }
 
 public class GameService
@@ -75,6 +78,50 @@ public class GameService
         var entity = Mapper.Map<Data.Game>(model);
         var created = await _store.Create(entity);
         return Mapper.Map<Game>(created);
+    }
+
+    public async Task DeleteCardImage(string gameId, CancellationToken cancellationToken)
+    {
+        if (!await _store.WithNoTracking<Data.Game>().AnyAsync(g => g.Id == gameId, cancellationToken))
+            throw new ResourceNotFound<Data.Game>(gameId);
+
+        var fileSearchPattern = $"{GetCardFileNameBase(gameId)}.*";
+        var files = Directory.GetFiles(Options.ImageFolder, fileSearchPattern);
+
+        foreach (var cardImageFile in files)
+        {
+            File.Delete(cardImageFile);
+        }
+
+        await _store
+            .WithNoTracking<Data.Game>()
+            .Where(g => g.Id == gameId)
+            .ExecuteUpdateAsync(up => up.SetProperty(g => g.Logo, default(string)), cancellationToken);
+    }
+
+    public async Task DeleteMapImage(string gameId, CancellationToken cancellationToken)
+    {
+        var mapImagePath = await _store
+            .WithNoTracking<Data.Game>()
+            .Where(g => g.Id == gameId)
+            .Select(g => g.Background)
+            .SingleOrDefaultAsync(cancellationToken);
+
+        if (mapImagePath.IsEmpty())
+        {
+            return;
+        }
+
+        await _store
+            .WithNoTracking<Data.Game>()
+            .Where(g => g.Id == gameId)
+            .ExecuteUpdateAsync(up => up.SetProperty(g => g.Background, default(string)), cancellationToken);
+
+        var filePath = Path.Combine(Options.ImageFolder, mapImagePath);
+        if (File.Exists(filePath))
+        {
+            File.Delete(filePath);
+        }
     }
 
     public async Task<Game> Retrieve(string id, bool accessHidden = true)
@@ -218,43 +265,37 @@ public class GameService
     public Task<bool> IsUserPlaying(string gameId, string userId)
         => _store.AnyAsync<Data.Player>(p => p.GameId == gameId && p.UserId == userId, CancellationToken.None);
 
-    public async Task DeleteGameCardImage(string gameId)
+    public async Task<UploadedFile> SaveCardImage(string gameId, IFormFile file, CancellationToken cancellationToken)
     {
-        if (!await _store.WithNoTracking<Data.Game>().AnyAsync(g => g.Id == gameId))
-            throw new ResourceNotFound<Data.Game>(gameId);
+        var fileName = $"{GetCardFileNameBase(gameId)}{Path.GetExtension(file.FileName.ToLower())}";
+        var result = await SaveImage(gameId, fileName, await file.ToBytes(cancellationToken), cancellationToken);
 
-        var fileSearchPattern = $"{GetGameCardFileNameBase(gameId)}.*";
-        var files = Directory.GetFiles(Options.ImageFolder, fileSearchPattern);
+        await _store
+            .WithNoTracking<Data.Game>()
+            .Where(g => g.Id == gameId)
+            .ExecuteUpdateAsync(up => up.SetProperty(g => g.Logo, fileName), cancellationToken);
 
-        foreach (var cardImageFile in files)
-        {
-            File.Delete(cardImageFile);
-        }
-
-        await UpdateImage(gameId, "card", string.Empty);
+        return result;
     }
 
-    public async Task<UploadedFile> SaveGameCardImage(string gameId, IFormFile file)
+    public async Task<UploadedFile> SaveMapImage(string gameId, IFormFile file, CancellationToken cancellationToken)
     {
-        if (!await _store.WithNoTracking<Data.Game>().AnyAsync(g => g.Id == gameId))
-            throw new ResourceNotFound<Data.Game>(gameId);
+        var fileName = $"{GetMapImageFileNameBase(gameId)}{Path.GetExtension(file.FileName.ToLower())}";
+        var result = await SaveImage(gameId, fileName, await file.ToBytes(cancellationToken), cancellationToken);
 
-        // we currently intentionally leave the old image around for quasi-logging purposes,
-        // but we could delete if desired here by getting the path from the Game entity.
-        // We generate a semi-random name for the new file in GetGameCardFileNameBase to bypass
-        // network-level caching.
-        var fileName = $"{GetGameCardFileNameBase(gameId)}{Path.GetExtension(file.FileName.ToLower())}";
-        var path = Path.Combine(Options.ImageFolder, fileName);
+        await _store
+            .WithNoTracking<Data.Game>()
+            .Where(g => g.Id == gameId)
+            .ExecuteUpdateAsync(up => up.SetProperty(g => g.Background, fileName), cancellationToken);
 
-        using var stream = new FileStream(path, FileMode.OpenOrCreate);
-        await file.CopyToAsync(stream);
-        await UpdateImage(gameId, "card", fileName);
-
-        return new UploadedFile { Filename = fileName };
+        return result;
     }
 
-    private string GetGameCardFileNameBase(string gameId)
+    private string GetCardFileNameBase(string gameId)
         => $"{gameId.ToLower()}_card_{_guids.Generate()[..6]}";
+
+    private string GetMapImageFileNameBase(string gameId)
+        => $"{gameId.ToLower()}_map_{_guids.Generate()[..6]}";
 
     private IQueryable<Data.Game> BuildSearchQuery(GameSearchFilter model, bool canViewUnpublished = false)
     {
@@ -333,5 +374,24 @@ public class GameService
             q = q.Take(model.Take);
 
         return q;
+    }
+
+    private async Task<UploadedFile> SaveImage(string gameId, string saveAsFileName, byte[] imageBytes, CancellationToken cancellationToken)
+    {
+        if (!await _store.WithNoTracking<Data.Game>().AnyAsync(g => g.Id == gameId, cancellationToken))
+        {
+            throw new ResourceNotFound<Data.Game>(gameId);
+        }
+
+        // we currently intentionally leave the old image around for quasi-logging purposes,
+        // but we could delete if desired here by getting the path from the Game entity.
+        // We generate a semi-random name for the new file in GetGameCardFileNameBase to bypass
+        // network-level caching.
+        var path = Path.Combine(Options.ImageFolder, saveAsFileName);
+
+        using var stream = new FileStream(path, FileMode.OpenOrCreate);
+        await stream.WriteAsync(imageBytes, cancellationToken);
+
+        return new UploadedFile { Filename = saveAsFileName };
     }
 }

--- a/src/Gameboard.Api/Features/Game/Requests/CloneGame/CloneGame.cs
+++ b/src/Gameboard.Api/Features/Game/Requests/CloneGame/CloneGame.cs
@@ -1,0 +1,51 @@
+using System.Threading;
+using System.Threading.Tasks;
+using AutoMapper;
+using Gameboard.Api.Common.Services;
+using Gameboard.Api.Data;
+using Gameboard.Api.Structure.MediatR;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Gameboard.Api.Features.Games.Requests;
+
+public record CloneGameCommand(string GameId, string Name) : IRequest<Game>;
+
+internal sealed class CloneGameHandler
+(
+    IGuidService guids,
+    IMapper mapper,
+    IStore store,
+    IValidatorService validatorService
+) : IRequestHandler<CloneGameCommand, Game>
+{
+    public async Task<Game> Handle(CloneGameCommand request, CancellationToken cancellationToken)
+    {
+        await validatorService
+            .Auth(c => c.Require(Users.PermissionKey.Games_CreateEditDelete))
+            .AddEntityExistsValidator<Data.Game>(request.GameId)
+            .Validate(cancellationToken);
+
+        var game = await store
+            .WithNoTracking<Data.Game>()
+            .Include(g => g.Prerequisites)
+            .Include(g => g.Specs)
+            .SingleAsync(g => g.Id == request.GameId, cancellationToken);
+
+        await store.DoTransaction(async db =>
+        {
+            // assign new id and name
+            game.Id = guids.Generate();
+            game.Name = request.Name;
+
+            // attach the related entities (so we don't signal to EF that we want to create them)
+            db.AttachRange(game.Prerequisites);
+            db.AttachRange(game.Specs);
+
+            db.Add(game);
+            await db.SaveChangesAsync(cancellationToken);
+        }, cancellationToken);
+
+        return mapper.Map<Game>(game);
+    }
+}

--- a/src/Gameboard.Api/Features/Game/Requests/DeleteGame/DeleteGameCommand.cs
+++ b/src/Gameboard.Api/Features/Game/Requests/DeleteGame/DeleteGameCommand.cs
@@ -68,7 +68,7 @@ internal class DeleteGameHandler
         }
 
         // delete the game and its resources
-        await _gameService.DeleteGameCardImage(request.GameId);
+        await _gameService.DeleteCardImage(request.GameId, cancellationToken);
 
         await _store
             .WithNoTracking<Data.Game>()

--- a/src/Gameboard.Api/Features/Practice/PracticeService.cs
+++ b/src/Gameboard.Api/Features/Practice/PracticeService.cs
@@ -30,8 +30,8 @@ public interface IPracticeService
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     Task<UserPracticeHistoryChallenge[]> GetUserPracticeHistory(string userId, CancellationToken cancellationToken);
-    Task<IEnumerable<string>> GetVisibleChallengeTags(CancellationToken cancellationToken);
-    Task<IEnumerable<string>> GetVisibleChallengeTags(IEnumerable<string> requestedTags, CancellationToken cancellationToken);
+    Task<string[]> GetVisibleChallengeTags(CancellationToken cancellationToken);
+    Task<string[]> GetVisibleChallengeTags(IEnumerable<string> requestedTags, CancellationToken cancellationToken);
     IEnumerable<string> UnescapeSuggestedSearches(string input);
     Task<PracticeModeSettings> UpdateSettings(PracticeModeSettingsApiModel settings, string actingUserId, CancellationToken cancellationToken);
 }
@@ -215,16 +215,16 @@ internal partial class PracticeService
         return apiModel;
     }
 
-    public async Task<IEnumerable<string>> GetVisibleChallengeTags(CancellationToken cancellationToken)
+    public async Task<string[]> GetVisibleChallengeTags(CancellationToken cancellationToken)
     {
         var settings = await GetSettings(cancellationToken);
-        return settings.SuggestedSearches;
+        return [.. settings.SuggestedSearches.OrderBy(s => s)];
     }
 
-    public async Task<IEnumerable<string>> GetVisibleChallengeTags(IEnumerable<string> requestedTags, CancellationToken cancellationToken)
+    public async Task<string[]> GetVisibleChallengeTags(IEnumerable<string> requestedTags, CancellationToken cancellationToken)
     {
         var settings = await GetSettings(cancellationToken);
-        return [.. requestedTags.Select(t => t.ToLower()).Intersect(settings.SuggestedSearches)];
+        return [.. requestedTags.Select(t => t.ToLower()).Intersect(settings.SuggestedSearches).OrderBy(s => s)];
     }
 
     public async Task<PracticeModeSettings> UpdateSettings(PracticeModeSettingsApiModel update, string actingUserId, CancellationToken cancellationToken)

--- a/src/Gameboard.Api/Features/Practice/Requests/GetUserPracticeSummary/GetUserPracticeSummary.cs
+++ b/src/Gameboard.Api/Features/Practice/Requests/GetUserPracticeSummary/GetUserPracticeSummary.cs
@@ -58,6 +58,17 @@ internal sealed class GetUserPracticeSummaryHandler
             // has the user tried this one?
             var userChallengeHistory = userHistory.SingleOrDefault(c => c.ChallengeSpecId == challenge.Id);
 
+            if (userChallengeHistory is not null)
+            {
+                countAttempted += 1;
+                totalPointsScored += userChallengeHistory.BestAttemptScore ?? 0;
+
+                if (userChallengeHistory.IsComplete)
+                {
+                    countCompleted += 1;
+                }
+            }
+
             // update total points scored if played
             totalPointsScored += userChallengeHistory?.BestAttemptScore ?? 0;
 
@@ -89,13 +100,11 @@ internal sealed class GetUserPracticeSummaryHandler
 
                 if (userChallengeHistory is not null)
                 {
-                    countAttempted += 1;
                     engagement.CountAttempted += 1;
                     engagement.PointsScored += userChallengeHistory.BestAttemptScore ?? 0;
 
                     if (userChallengeHistory.IsComplete)
                     {
-                        countCompleted += 1;
                         engagement.CountCompleted += 1;
                     }
                 }
@@ -120,6 +129,7 @@ internal sealed class GetUserPracticeSummaryHandler
                     .SelectMany(c => challengesService.GetTags(c.Tags))
                     .Where(t => practiceSettings.SuggestedSearches.Contains(t))
                     .Where(t => !tagEngagement.ContainsKey(t) || tagEngagement[t].CountAttempted == 0)
+                    .Distinct()
             ]
         };
     }

--- a/src/Gameboard.Api/Features/Reports/Queries/EnrollmentReport/EnrollmentReportService.cs
+++ b/src/Gameboard.Api/Features/Reports/Queries/EnrollmentReport/EnrollmentReportService.cs
@@ -173,7 +173,7 @@ internal class EnrollmentReportService(IReportsService reportsService,
                 ChallengeCount = challenges.Length,
                 ChallengesPartiallySolvedCount = challenges.Where(c => c.Result == ChallengeResult.Partial).Count(),
                 ChallengesCompletelySolvedCount = challenges.Where(c => c.Result == ChallengeResult.Success).Count(),
-                Score = p.Score
+                Score = challenges.Sum(c => c.Score == null ? 0 : c.Score.Value)
             };
         });
 
@@ -188,7 +188,7 @@ internal class EnrollmentReportService(IReportsService reportsService,
             .Select(p => new
             {
                 Player = p,
-                ChallengesStarted = p.Challenges.Where(c => c.StartTime != DateTimeOffset.MinValue).Count()
+                ChallengesStarted = p.Challenges.Where(c => c.StartTime != DateTimeOffset.MinValue).Select(c => c.Id).Distinct().Count()
             });
 
         var rawResults = await query.ToArrayAsync(cancellationToken);
@@ -239,7 +239,7 @@ internal class EnrollmentReportService(IReportsService reportsService,
             .Select(p => p.TeamId)
             .Distinct()
             .Count();
-        var startedChallengeTeamsCount = distinctTeamIds.Length - rawResults.Where(p => p.ChallengesStarted > 0).Select(r => r.Player.TeamId).Distinct().Count();
+        var startedChallengeTeamsCount = rawResults.Where(p => p.ChallengesStarted > 0).Select(r => r.Player.TeamId).Distinct().Count();
 
         return new EnrollmentReportStatSummary
         {

--- a/src/Gameboard.Api/Features/Reports/Queries/EnrollmentReport/EnrollmentReportSummaryStats.cs
+++ b/src/Gameboard.Api/Features/Reports/Queries/EnrollmentReport/EnrollmentReportSummaryStats.cs
@@ -6,26 +6,17 @@ namespace Gameboard.Api.Features.Reports;
 
 public record EnrollmentReportSummaryStatsQuery(EnrollmentReportParameters Parameters) : IRequest<EnrollmentReportStatSummary>, IReportQuery;
 
-internal class EnrollmentReportSummaryStatsHandler : IRequestHandler<EnrollmentReportSummaryStatsQuery, EnrollmentReportStatSummary>
+internal class EnrollmentReportSummaryStatsHandler
+(
+    IEnrollmentReportService enrollmentReportService,
+    ReportsQueryValidator reportsQueryValidator
+) : IRequestHandler<EnrollmentReportSummaryStatsQuery, EnrollmentReportStatSummary>
 {
-    private readonly IEnrollmentReportService _enrollmentReportService;
-    private readonly ReportsQueryValidator _reportsQueryValidator;
-
-    public EnrollmentReportSummaryStatsHandler
-    (
-        IEnrollmentReportService enrollmentReportService,
-        ReportsQueryValidator reportsQueryValidator
-    )
-    {
-        _enrollmentReportService = enrollmentReportService;
-        _reportsQueryValidator = reportsQueryValidator;
-    }
-
     public async Task<EnrollmentReportStatSummary> Handle(EnrollmentReportSummaryStatsQuery request, CancellationToken cancellationToken)
     {
         // validate
-        await _reportsQueryValidator.Validate(request, cancellationToken);
+        await reportsQueryValidator.Validate(request, cancellationToken);
 
-        return await _enrollmentReportService.GetSummaryStats(request.Parameters, cancellationToken);
+        return await enrollmentReportService.GetSummaryStats(request.Parameters, cancellationToken);
     }
 }

--- a/src/Gameboard.Api/Features/Reports/Queries/FeedbackReport/FeedbackReportService.cs
+++ b/src/Gameboard.Api/Features/Reports/Queries/FeedbackReport/FeedbackReportService.cs
@@ -90,17 +90,17 @@ internal sealed class FeedbackReportService(IReportsService reportsService, ISto
                             s.AttachedEntityType == FeedbackSubmissionAttachedEntityType.ChallengeSpec ?
                             ((FeedbackSubmissionChallengeSpec)s).ChallengeSpec.Game :
                             ((FeedbackSubmissionGame)s).Game
-                        ).Season,
+                        ).Season ?? string.Empty,
                         Series = (
                             s.AttachedEntityType == FeedbackSubmissionAttachedEntityType.ChallengeSpec ?
                             ((FeedbackSubmissionChallengeSpec)s).ChallengeSpec.Game :
                             ((FeedbackSubmissionGame)s).Game
-                        ).Competition,
+                        ).Competition ?? string.Empty,
                         Track = (
                             s.AttachedEntityType == FeedbackSubmissionAttachedEntityType.ChallengeSpec ?
                             ((FeedbackSubmissionChallengeSpec)s).ChallengeSpec.Game :
                             ((FeedbackSubmissionGame)s).Game
-                        ).Track,
+                        ).Track ?? string.Empty,
                         IsTeamGame = (
                             s.AttachedEntityType == FeedbackSubmissionAttachedEntityType.ChallengeSpec ?
                             ((FeedbackSubmissionChallengeSpec)s).ChallengeSpec.Game :

--- a/src/Gameboard.Api/Features/Reports/Queries/SiteUsageReport/GetSiteUsageReportPlayers.cs
+++ b/src/Gameboard.Api/Features/Reports/Queries/SiteUsageReport/GetSiteUsageReportPlayers.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -8,7 +7,6 @@ using Gameboard.Api.Data;
 using Gameboard.Api.Services;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Logging;
 
 namespace Gameboard.Api.Features.Reports;
 
@@ -17,7 +15,6 @@ public record GetSiteUsageReportPlayersQuery(SiteUsageReportParameters ReportPar
 internal sealed class GetSiteUsageReportPlayersHandler
 (
     ChallengeService challengeService,
-    ILogger<GetSiteUsageReportPlayersHandler> logger,
     IPagingService pagingService,
     ISiteUsageReportService reportService,
     IStore store,

--- a/src/Gameboard.Api/Features/Reports/ReportsController.cs
+++ b/src/Gameboard.Api/Features/Reports/ReportsController.cs
@@ -93,7 +93,7 @@ public class ReportsController(IMediator mediator, IReportsService service) : Co
         => _service.ListChallengeSpecs(gameId);
 
     [HttpGet("parameter/challenge-tags")]
-    public Task<IEnumerable<string>> GetChallengeTags(CancellationToken cancellationToken)
+    public Task<string[]> GetChallengeTags(CancellationToken cancellationToken)
         => _service.ListChallengeTags(cancellationToken);
 
     [HttpGet("parameter/games")]

--- a/src/Gameboard.Api/Features/Reports/ReportsService.cs
+++ b/src/Gameboard.Api/Features/Reports/ReportsService.cs
@@ -20,7 +20,7 @@ public interface IReportsService
     Task<IDictionary<string, ReportTeamViewModel>> GetTeamsByPlayerIds(IEnumerable<string> playerIds, CancellationToken cancellationToken);
     Task<IEnumerable<ReportViewModel>> List();
     Task<IEnumerable<SimpleEntity>> ListChallengeSpecs(string gameId = null);
-    Task<IEnumerable<string>> ListChallengeTags(CancellationToken cancellationToken);
+    Task<string[]> ListChallengeTags(CancellationToken cancellationToken);
     Task<IEnumerable<SimpleEntity>> ListGames();
     Task<IEnumerable<string>> ListSeasons();
     Task<IEnumerable<string>> ListSeries();
@@ -30,13 +30,14 @@ public interface IReportsService
     IEnumerable<string> ParseMultiSelectCriteria(string criteria);
 }
 
-public class ReportsService(
+public class ReportsService
+(
     INowService now,
     IPagingService paging,
     IPracticeService practiceService,
     IStore store,
     ITeamService teamService
-    ) : IReportsService
+) : IReportsService
 {
     private static readonly string MULTI_SELECT_DELIMITER = ",";
 
@@ -283,7 +284,7 @@ public class ReportsService(
             .ToArrayAsync();
     }
 
-    public Task<IEnumerable<string>> ListChallengeTags(CancellationToken cancellationToken)
+    public Task<string[]> ListChallengeTags(CancellationToken cancellationToken)
         => _practiceService.GetVisibleChallengeTags(cancellationToken);
 
     public Task<IEnumerable<string>> ListSeasons()

--- a/src/Gameboard.Api/Structure/AppSettings.cs
+++ b/src/Gameboard.Api/Structure/AppSettings.cs
@@ -46,6 +46,7 @@ public class OidcOptions
     public string Authority { get; set; } = "http://localhost:5000";
     public string Audience { get; set; } = "gameboard-api";
     public string DefaultUserNameClaimType { get; set; } = null;
+    public bool DefaultUserNameInferFromEmail { get; set; } = false;
     public int MksCookieMinutes { get; set; } = 60;
     public bool RequireHttpsMetadata { get; set; } = true;
     public bool StoreUserEmails { get; set; } = false;


### PR DESCRIPTION
Version 3.32.1 contains minor enhancements and bug fixes.

# Enhancements

- Added a new Helm chart setting (`Oidc__DefaultUserNameInferFromEmail`) which causes Gameboard to use the pre `@` portion of a user's email address as their default username.
  - Defaults to `false`
  - Requires that the `Oidc__StoreUserEmails` setting be `true` (if `false`, this new setting has no effect)
  - Is overridden by the behavior of `Oidc__DefaultUserNameClaimType` if that value is `true`

# Bug fixes

- Feedback templates are now listed in alphabetical order in the Reports and Admin areas.
- Fixed a bug that caused Clone Game to fail in many game configurations (resolves #446)
- Fixed a bug that caused the unstarted team count on the Enrollment Report to be artificially high in some cases
- Challenge tags displayed on the landing page of the Practice Area now display in alphabetical order
- Fixed a few bugs in the calculation of total points and values in the new Practice Area summary info

# Platform health and stability

- The clone process now has its own endpoint (`POST /api/game/clone` rather than repurposing the `POST /api/game` endpoint)
- In order to minimize computation that isn't useful to the user, reports no longer automatically run upon navigation or manipulation of filters.
  - To see changes reflected, users will need to hit the new large **Generate Report** button.
  - It's not necessary to hit this button before exporting to CSV (CSV exports always use the current filter values when generating)
  - Fixed a number of minor report display bugs that could occur when rapidly manipulating filters.
  - Reports still auto-run when linked from outside the app (for example, when you click on a bookmarked report with a filter configuration)