### PR TITLE
v3.33.0

### DIFF
--- a/src/Gameboard.Api.Tests.Integration/Fixtures/Services/TestGameEngineService.cs
+++ b/src/Gameboard.Api.Tests.Integration/Fixtures/Services/TestGameEngineService.cs
@@ -89,7 +89,17 @@ public class TestGameEngineService : IGameEngineService
             Url = "https://sei.cmu.edu"
         });
 
-    public IEnumerable<GameEngineGamespaceVm> GetGamespaceVms(GameEngineGameState state)
+    public Task<ConsoleState[]> GetConsoles(GameEngineType gameEngine, ConsoleId[] consoleIds, CancellationToken cancellationToken)
+    {
+        return Task.FromResult<ConsoleState[]>([.. consoleIds.Select(c => new ConsoleState
+        {
+            Id = c,
+            AccessTicket = string.Empty,
+            IsRunning = false,
+            Url = "https://sei.cmu.edu"
+        })]);
+    }
+    public IEnumerable<GameEngineGamespaceVm> GetVmsFromState(GameEngineGameState state)
         => [];
 
     public Task<GameEngineGameState> GetPreview(Data.ChallengeSpec spec)

--- a/src/Gameboard.Api.Tests.Integration/Fixtures/Services/TestGameEngineService.cs
+++ b/src/Gameboard.Api.Tests.Integration/Fixtures/Services/TestGameEngineService.cs
@@ -2,6 +2,7 @@ using AutoMapper;
 using Gameboard.Api.Common;
 using Gameboard.Api.Common.Services;
 using Gameboard.Api.Data;
+using Gameboard.Api.Features.Consoles;
 using Gameboard.Api.Features.GameEngine;
 
 namespace Gameboard.Api.Tests.Integration.Fixtures;
@@ -68,10 +69,25 @@ public class TestGameEngineService : IGameEngineService
         return Task.FromResult(new GameEngineGameState());
     }
 
-    public Task<ConsoleSummary> GetConsole(Data.Challenge entity, ConsoleRequest model, bool observer)
+    public Task<ConsoleState> GetConsole(Data.Challenge entity, ConsoleRequest model, bool observer)
     {
-        return Task.FromResult(new ConsoleSummary { });
+        return Task.FromResult(new ConsoleState
+        {
+            Id = new ConsoleId { ChallengeId = entity.Id, Name = model.Name },
+            AccessTicket = string.Empty,
+            IsRunning = false,
+            Url = "https://sei.cmu.edu"
+        });
     }
+
+    public Task<ConsoleState> GetConsole(GameEngineType gameEngine, ConsoleId consoleId, CancellationToken cancellationToken)
+        => Task.FromResult(new ConsoleState
+        {
+            Id = consoleId,
+            AccessTicket = string.Empty,
+            IsRunning = false,
+            Url = "https://sei.cmu.edu"
+        });
 
     public IEnumerable<GameEngineGamespaceVm> GetGamespaceVms(GameEngineGameState state)
         => [];

--- a/src/Gameboard.Api/Features/Challenge/Challenge.cs
+++ b/src/Gameboard.Api/Features/Challenge/Challenge.cs
@@ -174,23 +174,18 @@ public class ObserveVM
     public bool IsVisible { get; set; }
 }
 
+public class GetConsoleStateRequest
+{
+    public string ChallengeId { get; set; }
+    public string Name { get; set; }
+}
+
 public class ConsoleRequest
 {
     public string Name { get; set; }
     public string SessionId { get; set; }
     public ConsoleAction Action { get; set; }
-    public string Id => $"{Name}#{SessionId}";
-}
-
-public class ConsoleSummary
-{
-    public string Id { get; set; }
-    public string Name { get; set; }
-    public string SessionId { get; set; }
-    public string Url { get; set; }
-    public bool IsRunning { get; set; }
-    public bool IsObserver { get; set; }
-    public string Ticket { get; set; }
+    public string Id { get => $"{Name}#{SessionId}"; }
 }
 
 public enum ConsoleAction

--- a/src/Gameboard.Api/Features/Challenge/Challenge.cs
+++ b/src/Gameboard.Api/Features/Challenge/Challenge.cs
@@ -83,6 +83,8 @@ public class UserActiveChallengeVm
 {
     public required string Id { get; set; }
     public required string Name { get; set; }
+    public required string AccessTicket { get; set; }
+    public required string Url { get; set; }
 }
 
 public class UserActiveChallengeScoreAndAttemptsState

--- a/src/Gameboard.Api/Features/Challenge/ChallengeMapper.cs
+++ b/src/Gameboard.Api/Features/Challenge/ChallengeMapper.cs
@@ -127,11 +127,6 @@ namespace Gameboard.Api.Services
             CreateMap<TopoMojo.Api.Client.VmState, ObserveVM>()
                  .ForMember(d => d.ChallengeId, opt => opt.MapFrom(s => s.IsolationId))
             ;
-
-            CreateMap<TopoMojo.Api.Client.VmConsole, ConsoleSummary>()
-                .ForMember(d => d.SessionId, opt => opt.MapFrom(s => s.IsolationId))
-            ;
-
             CreateMap<Data.ChallengeEvent, ChallengeEventSummary>();
         }
     }

--- a/src/Gameboard.Api/Features/Challenge/ConsoleActorMap.cs
+++ b/src/Gameboard.Api/Features/Challenge/ConsoleActorMap.cs
@@ -51,7 +51,7 @@ namespace Gameboard.Api.Services
                 : _cache.Values
             ;
 
-            return q.ToArray();
+            return [.. q];
         }
 
         public ConsoleActor FindActor(string uid)

--- a/src/Gameboard.Api/Features/Challenge/Services/ChallengeService.cs
+++ b/src/Gameboard.Api/Features/Challenge/Services/ChallengeService.cs
@@ -633,21 +633,6 @@ public partial class ChallengeService
         }, CancellationToken.None);
     }
 
-    // public async Task<ConsoleState> GetConsole(ConsoleRequest model, bool observer)
-    // {
-    //     var entity = await _challengeStore.Retrieve(model.SessionId);
-    //     var challenge = Mapper.Map<Challenge>(entity);
-
-    //     if (!challenge.State.Vms.Any(v => v.Name == model.Name))
-    //     {
-    //         var vmNames = string.Join(", ", challenge.State.Vms.Select(vm => vm.Name));
-    //         throw new ResourceNotFound<GameEngineVmState>("n/a", $"VMS for challenge {model.Name} - searching for {model.Name}, found these names: {vmNames}");
-    //     }
-
-    //     var console = await _gameEngine.GetConsole(entity, model, observer);
-    //     return console ?? throw new InvalidConsoleAction();
-    // }
-
     public async Task<List<ObserveChallenge>> GetChallengeConsoles(string gameId)
     {
         // retrieve challenges to list

--- a/src/Gameboard.Api/Features/ChallengeSpec/ChallengeSpecController.cs
+++ b/src/Gameboard.Api/Features/ChallengeSpec/ChallengeSpecController.cs
@@ -93,8 +93,8 @@ public class ChallengeSpecController
     }
 
     [HttpGet("/api/challengespecs/by-game")]
-    public Task<IEnumerable<GameChallengeSpecs>> ListByGame()
-        => _challengeSpecService.ListByGame();
+    public Task<GameChallengeSpecs[]> ListByGame([FromQuery] string gameId)
+        => _challengeSpecService.ListByGame(gameId.IsEmpty() ? null : gameId);
 
     /// <summary>
     /// Load solve performance for the challenge spec

--- a/src/Gameboard.Api/Features/ChallengeSpec/ChallengeSpecService.cs
+++ b/src/Gameboard.Api/Features/ChallengeSpec/ChallengeSpecService.cs
@@ -98,21 +98,24 @@ public class ChallengeSpecService
         return Mapper.Map<ChallengeSpec>(entity);
     }
 
-    public async Task<IEnumerable<GameChallengeSpecs>> ListByGame()
-    {
-        return await _store
+    public Task<GameChallengeSpecs[]> ListByGame(string gameId = null)
+        => _store
             .WithNoTracking<Data.ChallengeSpec>()
             .Where(s => !s.IsHidden)
+            .Where(s => gameId == null || s.GameId == gameId)
             .Select(s => new
             {
-                ChallengeSpec = new SimpleEntity { Id = s.Id, Name = s.Name },
+                ChallengeSpec = new SimpleEntity
+                {
+                    Id = s.Id,
+                    Name = s.Name
+                },
                 Game = new SimpleEntity { Id = s.GameId, Name = s.Game.Name },
             })
             .GroupBy(s => s.Game)
             .Select(gr => new GameChallengeSpecs { Game = gr.Key, ChallengeSpecs = gr.Select(thing => thing.ChallengeSpec).OrderBy(s => s.Name).ToArray() })
             .OrderBy(v => v.Game.Name)
             .ToArrayAsync();
-    }
 
     public async Task<IOrderedEnumerable<ChallengeSpecQuestionPerformance>> GetQuestionPerformance(string challengeSpecId, CancellationToken cancellationToken)
     {

--- a/src/Gameboard.Api/Features/Consoles/ConsolesController.cs
+++ b/src/Gameboard.Api/Features/Consoles/ConsolesController.cs
@@ -1,6 +1,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Gameboard.Api.Common.Services;
+using Gameboard.Api.Features.Consoles.Requests;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -18,7 +19,18 @@ public class ConsolesController(
     private readonly IActingUserService _actingUserService = actingUserService;
     private readonly IMediator _mediator = mediator;
 
+    [HttpGet]
+    [Authorize(AppConstants.ConsolePolicy)]
+    public Task<ConsoleState> GetConsole([FromQuery] GetConsoleStateRequest request, CancellationToken cancellationToken)
+        => _mediator.Send(new GetConsoleRequest(request.ChallengeId, request.Name), cancellationToken);
+
     [HttpPost("active")]
     public Task<ConsoleActionResponse> RecordUserActive(CancellationToken cancellationToken)
         => _mediator.Send(new RecordUserConsoleActiveCommand(_actingUserService.Get()), cancellationToken);
+
+    // maybe someday, we should unify this (which is designed to tell us who's using which console) with the "user active" endpoint above
+    // (which auto-extends practice sessions)
+    [HttpPost("user")]
+    public Task SetConsoleActiveUser([FromBody] ConsoleId consoleId, CancellationToken cancellationToken)
+        => _mediator.Send(new SetActiveUserCommand(consoleId), cancellationToken);
 }

--- a/src/Gameboard.Api/Features/Consoles/ConsolesController.cs
+++ b/src/Gameboard.Api/Features/Consoles/ConsolesController.cs
@@ -21,12 +21,17 @@ public class ConsolesController(
 
     [HttpGet]
     [Authorize(AppConstants.ConsolePolicy)]
-    public Task<ConsoleState> GetConsole([FromQuery] GetConsoleStateRequest request, CancellationToken cancellationToken)
+    public Task<GetConsoleResponse> GetConsole([FromQuery] GetConsoleStateRequest request, CancellationToken cancellationToken)
         => _mediator.Send(new GetConsoleRequest(request.ChallengeId, request.Name), cancellationToken);
 
+    [HttpGet("list")]
+    [Authorize]
+    public Task<ListConsolesResponse> ListConsoles([FromQuery] ListConsolesQuery query, CancellationToken cancellationToken)
+        => _mediator.Send(query, cancellationToken);
+
     [HttpPost("active")]
-    public Task<ConsoleActionResponse> RecordUserActive(CancellationToken cancellationToken)
-        => _mediator.Send(new RecordUserConsoleActiveCommand(_actingUserService.Get()), cancellationToken);
+    public Task<ConsoleActionResponse> RecordUserActive([FromBody] ConsoleId consoleId, CancellationToken cancellationToken)
+        => _mediator.Send(new RecordUserConsoleActiveCommand(consoleId, _actingUserService.Get()), cancellationToken);
 
     // maybe someday, we should unify this (which is designed to tell us who's using which console) with the "user active" endpoint above
     // (which auto-extends practice sessions)

--- a/src/Gameboard.Api/Features/Consoles/ConsolesExceptions.cs
+++ b/src/Gameboard.Api/Features/Consoles/ConsolesExceptions.cs
@@ -1,0 +1,7 @@
+using Gameboard.Api.Structure;
+
+namespace Gameboard.Api.Features.Consoles;
+
+public sealed class ConsoleTeamNoAccessException(string teamId) : GameboardValidationException($"You can't access consoles owned by team {teamId}.")
+{
+}

--- a/src/Gameboard.Api/Features/Consoles/ConsolesModels.cs
+++ b/src/Gameboard.Api/Features/Consoles/ConsolesModels.cs
@@ -1,6 +1,25 @@
 namespace Gameboard.Api.Features.Consoles;
 
+public sealed class ConsoleId
+{
+    public required string Name { get; set; }
+    public required string ChallengeId { get; set; }
+
+    public override string ToString()
+    {
+        return $"{Name.Trim()}#{ChallengeId.Trim()}";
+    }
+}
+
 public sealed class ConsoleActionResponse
 {
     public required string Message { get; set; }
+}
+
+public sealed class ConsoleState
+{
+    public required ConsoleId Id { get; set; }
+    public required string AccessTicket { get; set; }
+    public required bool IsRunning { get; set; }
+    public required string Url { get; set; }
 }

--- a/src/Gameboard.Api/Features/Consoles/ConsolesModels.cs
+++ b/src/Gameboard.Api/Features/Consoles/ConsolesModels.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Gameboard.Api.Features.Consoles;
 
 public sealed class ConsoleId
@@ -14,6 +16,8 @@ public sealed class ConsoleId
 public sealed class ConsoleActionResponse
 {
     public required string Message { get; set; }
+    public bool SessionAutoExtended { get; set; } = false;
+    public DateTimeOffset SessionExpiresAt { get; set; }
 }
 
 public sealed class ConsoleState

--- a/src/Gameboard.Api/Features/Consoles/RecordUserConsoleActive.cs
+++ b/src/Gameboard.Api/Features/Consoles/RecordUserConsoleActive.cs
@@ -45,7 +45,9 @@ internal class RecordUserConsoleActiveHandler(
         var now = _nowService.Get();
         var player = await _practiceService.GetUserActivePracticeSession(request.ActingUser.Id, cancellationToken);
         if (player is null || !player.IsPractice)
+        {
             return new ConsoleActionResponse { Message = null };
+        }
 
         // if the player's session has less time remaining than the extension threshold, automatically extend 
         if (player.SessionEnd - now >= TimeSpan.FromMinutes(EXTEND_THRESHOLD_MINUTES))

--- a/src/Gameboard.Api/Features/Consoles/RecordUserConsoleActive.cs
+++ b/src/Gameboard.Api/Features/Consoles/RecordUserConsoleActive.cs
@@ -80,6 +80,11 @@ internal class RecordUserConsoleActiveHandler(
         // practice mode session extension when the endpoint is meant to be more generally about
         // user activity.
         var isExtended = extensionResult.SessionEnd != preExtensionSessionEnd;
-        return new ConsoleActionResponse { Message = isExtended ? $"{MESSAGE_EXTENDED}: {postExtensionSessionEnd}" : MESSAGE_NOT_EXTENDED };
+        return new ConsoleActionResponse
+        {
+            Message = isExtended ? $"{MESSAGE_EXTENDED}: {postExtensionSessionEnd}" : MESSAGE_NOT_EXTENDED,
+            SessionAutoExtended = isExtended,
+            SessionExpiresAt = extensionResult.SessionEnd
+        };
     }
 }

--- a/src/Gameboard.Api/Features/Consoles/Requests/GetConsole/GetConsole.cs
+++ b/src/Gameboard.Api/Features/Consoles/Requests/GetConsole/GetConsole.cs
@@ -1,0 +1,50 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Gameboard.Api.Data;
+using Gameboard.Api.Features.Consoles.Validators;
+using Gameboard.Api.Features.GameEngine;
+using Gameboard.Api.Structure.MediatR;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Gameboard.Api.Features.Consoles.Requests;
+
+public record GetConsoleRequest(string ChallengeId, string Name) : IRequest<ConsoleState>;
+
+internal sealed class GetConsoleHandler
+(
+    ICanAccessConsoleValidator canAccessConsoleValidator,
+    IGameEngineService gameEngine,
+    IStore store,
+    IValidatorService validatorService
+) : IRequestHandler<GetConsoleRequest, ConsoleState>
+{
+    public async Task<ConsoleState> Handle(GetConsoleRequest request, CancellationToken cancellationToken)
+    {
+        // configure console access validator
+        canAccessConsoleValidator.ChallengeId = request.ChallengeId;
+
+        // validate
+        await validatorService
+            .AddEntityExistsValidator<Data.Challenge>(request.ChallengeId)
+            .AddValidator(canAccessConsoleValidator)
+            .Validate(cancellationToken);
+
+        // get the console and its state
+        var challenge = await store
+            .WithNoTracking<Data.Challenge>()
+            .Select(c => new { c.Id, c.State, c.GameEngineType })
+            .SingleAsync(c => c.Id == request.ChallengeId, cancellationToken);
+        var state = await gameEngine.GetChallengeState(GameEngineType.TopoMojo, challenge.State);
+
+        if (!state.Vms.Any(v => v.Name == request.Name))
+        {
+            var vmNames = string.Join(", ", state.Vms.Select(vm => vm.Name));
+            throw new ResourceNotFound<GameEngineVmState>("n/a", $"VMS for challenge {request.ChallengeId} - searching for {request.Name}, found these names: {vmNames}");
+        }
+
+        var console = await gameEngine.GetConsole(challenge.GameEngineType, new ConsoleId() { ChallengeId = request.ChallengeId, Name = request.Name }, cancellationToken);
+        return console ?? throw new InvalidConsoleAction();
+    }
+}

--- a/src/Gameboard.Api/Features/Consoles/Requests/GetConsole/GetConsole.cs
+++ b/src/Gameboard.Api/Features/Consoles/Requests/GetConsole/GetConsole.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -38,7 +39,7 @@ internal sealed class GetConsoleHandler
         // get the console and its state
         var challenge = await store
             .WithNoTracking<Data.Challenge>()
-            .Select(c => new { c.Id, c.State, c.GameEngineType })
+            .Select(c => new { c.Id, c.State, c.GameEngineType, c.EndTime, c.Player.SessionEnd })
             .SingleAsync(c => c.Id == request.ChallengeId, cancellationToken);
         var state = await gameEngine.GetChallengeState(GameEngineType.TopoMojo, challenge.State);
 
@@ -53,7 +54,8 @@ internal sealed class GetConsoleHandler
         return new GetConsoleResponse
         {
             ConsoleState = console,
-            IsViewOnly = !isPlayingChallenge
+            IsViewOnly = !isPlayingChallenge,
+            ExpiresAt = challenge.EndTime < challenge.SessionEnd ? challenge.EndTime : challenge.SessionEnd
         };
     }
 }

--- a/src/Gameboard.Api/Features/Consoles/Requests/GetConsole/GetConsoleResponse.cs
+++ b/src/Gameboard.Api/Features/Consoles/Requests/GetConsole/GetConsoleResponse.cs
@@ -1,0 +1,7 @@
+namespace Gameboard.Api.Features.Consoles;
+
+public sealed class GetConsoleResponse
+{
+    public required ConsoleState ConsoleState { get; set; }
+    public required bool IsViewOnly { get; set; }
+}

--- a/src/Gameboard.Api/Features/Consoles/Requests/GetConsole/GetConsoleResponse.cs
+++ b/src/Gameboard.Api/Features/Consoles/Requests/GetConsole/GetConsoleResponse.cs
@@ -1,7 +1,10 @@
+using System;
+
 namespace Gameboard.Api.Features.Consoles;
 
 public sealed class GetConsoleResponse
 {
     public required ConsoleState ConsoleState { get; set; }
     public required bool IsViewOnly { get; set; }
+    public required DateTimeOffset ExpiresAt { get; set; }
 }

--- a/src/Gameboard.Api/Features/Consoles/Requests/ListConsoles/ListConsolesModels.cs
+++ b/src/Gameboard.Api/Features/Consoles/Requests/ListConsoles/ListConsolesModels.cs
@@ -18,6 +18,7 @@ public sealed class ListConsolesResponseConsole
 
     public required ConsoleId ConsoleId { get; set; }
     public required string AccessTicket { get; set; }
+    public required SimpleEntity[] ActiveUsers { get; set; }
     public required ListConsolesResponseChallenge Challenge { get; set; }
     public required bool IsViewOnly { get; set; }
     public required ListConsolesResponseTeam Team { get; set; }

--- a/src/Gameboard.Api/Features/Consoles/Requests/ListConsoles/ListConsolesModels.cs
+++ b/src/Gameboard.Api/Features/Consoles/Requests/ListConsoles/ListConsolesModels.cs
@@ -1,0 +1,41 @@
+namespace Gameboard.Api.Features.Consoles;
+
+public enum ListConsolesRequestSort
+{
+    Rank,
+    TeamName
+}
+
+public sealed class ListConsolesResponse
+{
+    public ListConsolesResponseConsole[] Consoles { get; set; }
+}
+
+public sealed class ListConsolesResponseConsole
+{
+    // these are duplicated properties for now, but it's easier to group on the client side with them
+    public required string TeamId { get; set; }
+
+    public required ConsoleId ConsoleId { get; set; }
+    public required string AccessTicket { get; set; }
+    public required ListConsolesResponseChallenge Challenge { get; set; }
+    public required bool IsViewOnly { get; set; }
+    public required ListConsolesResponseTeam Team { get; set; }
+    public required string Url { get; set; }
+}
+
+public sealed class ListConsolesResponseChallenge
+{
+    public required string Id { get; set; }
+    public required bool IsPractice { get; set; }
+    public required string Name { get; set; }
+    public required string SpecId { get; set; }
+}
+
+public sealed class ListConsolesResponseTeam
+{
+    public required string Id { get; set; }
+    public required string Name { get; set; }
+    public required int? Rank { get; set; }
+    public required double? Score { get; set; }
+}

--- a/src/Gameboard.Api/Features/Consoles/Requests/ListConsoles/ListConsolesRequest.cs
+++ b/src/Gameboard.Api/Features/Consoles/Requests/ListConsoles/ListConsolesRequest.cs
@@ -1,0 +1,172 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Gameboard.Api.Common.Services;
+using Gameboard.Api.Data;
+using Gameboard.Api.Features.GameEngine;
+using Gameboard.Api.Features.Teams;
+using Gameboard.Api.Features.Users;
+using Gameboard.Api.Structure.MediatR;
+using Gameboard.Api.Structure.MediatR.Validators;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Gameboard.Api.Features.Consoles;
+
+public sealed class ListConsolesQuery : IRequest<ListConsolesResponse>
+{
+    public string? ChallengeSpecId { get; set; }
+    public string? GameId { get; set; }
+    public string? TeamId { get; set; }
+    public PlayerMode? PlayerMode { get; set; }
+    public string? SearchTerm { get; set; }
+    public ListConsolesRequestSort? SortBy { get; set; }
+}
+
+internal sealed class GetConsolesHandler
+(
+    IActingUserService actingUserService,
+    IGameEngineService gameEngine,
+    EntityExistsValidator<Data.Game> gameExists,
+    IStore store,
+    ITeamService teamsService,
+    IUserRolePermissionsService userPermissions,
+    IValidatorService validator
+) : IRequestHandler<ListConsolesQuery, ListConsolesResponse>
+{
+    public async Task<ListConsolesResponse> Handle(ListConsolesQuery request, CancellationToken cancellationToken)
+    {
+        var canObserveTeams = await userPermissions.Can(PermissionKey.Teams_Observe);
+
+        validator
+            .Auth(c => c.RequireAuthentication())
+            .AddValidator(async ctx =>
+            {
+                if (request.TeamId.IsNotEmpty())
+                {
+                    if (canObserveTeams || await teamsService.IsOnTeam(request.TeamId, actingUserService.Get().Id))
+                    {
+                        return;
+                    }
+
+                    ctx.AddValidationException(new ConsoleTeamNoAccessException(request.TeamId));
+                }
+            });
+
+        // validate game existence if supplied
+        if (request.GameId.IsNotEmpty())
+        {
+            validator.AddValidator(gameExists.UseValue(request.GameId));
+        }
+
+        // run validation
+        await validator.Validate(cancellationToken);
+
+        // enforce team rank sort by default
+        request.SortBy ??= ListConsolesRequestSort.Rank;
+        // sanitize search term
+        if (request.SearchTerm.IsEmpty())
+        {
+            request.SearchTerm = null;
+        }
+        else
+        {
+            request.SearchTerm = request.SearchTerm!.ToLower();
+        }
+
+        // we need to which teams the caller is on to determine which consoles they can access
+        var userTeams = await teamsService.GetUserTeamIds(actingUserService.Get().Id);
+
+        // if you have the Team Observe permission, we just follow your parameters.
+        // if you don't, we use your parameters but restrict results to teams you're on.
+        var queryTeamIds = Array.Empty<string>();
+        if (canObserveTeams)
+        {
+            queryTeamIds = request.TeamId.IsNotEmpty() ? [request.TeamId!] : [];
+        }
+        else
+        {
+            queryTeamIds = userTeams;
+        }
+
+        // load active challenges in the game
+        var challenges = await store
+            .WithNoTracking<Data.Challenge>()
+            .Where(c => c.HasDeployedGamespace)
+            .Where(c => request.GameId == null || c.GameId == request.GameId)
+            .Where(c => request.ChallengeSpecId == null || c.SpecId == request.ChallengeSpecId)
+            .Where(c => queryTeamIds.Length == 0 || queryTeamIds.Contains(c.TeamId))
+            .Where(c => request.PlayerMode == null || request.PlayerMode == c.PlayerMode)
+            .Where(c => request.SearchTerm == null || c.TeamId.ToLower() == request.SearchTerm || c.Id.ToLower() == request.SearchTerm)
+            .Select(c => new
+            {
+                c.Id,
+                c.Name,
+                c.EndTime,
+                c.PlayerMode,
+                c.SpecId,
+                c.State,
+                c.TeamId
+            })
+            .ToDictionaryAsync(c => c.Id, c => c, cancellationToken);
+
+        // constitute teams, captains, and consoles from challenge data
+        var gameEngineType = GameEngineType.TopoMojo;
+        var teamIds = challenges.Values.Select(c => c.TeamId).Distinct().ToArray();
+        var captains = await teamsService.ResolveCaptains(teamIds, cancellationToken);
+
+        // also need scores and ranks for the teams
+        var teamScoreData = await store
+            .WithNoTracking<DenormalizedTeamScore>()
+            .Where(s => teamIds.Contains(s.TeamId))
+            .Select(s => new
+            {
+                s.TeamId,
+                s.Rank,
+                s.ScoreOverall
+            })
+            .ToDictionaryAsync(gr => gr.TeamId, gr => gr, cancellationToken);
+
+        // load console stuff last, because access tickets are time-sensitive
+        var consoleIds = new List<ConsoleId>();
+        foreach (var challenge in challenges.Values)
+        {
+            var state = await gameEngine.GetChallengeState(gameEngineType, challenge.State);
+            var challengeVms = gameEngine.GetVmsFromState(state);
+            consoleIds.AddRange(challengeVms.Select(vm => new ConsoleId { ChallengeId = challenge.Id, Name = vm.Name }));
+        }
+        var consoles = await gameEngine.GetConsoles(gameEngineType, [.. consoleIds], cancellationToken);
+
+        // construct and return the response
+        return new ListConsolesResponse
+        {
+            Consoles = [.. consoles.Where(c => c.Id.ChallengeId.IsNotEmpty()).Select(c => new ListConsolesResponseConsole
+            {
+                ConsoleId = c.Id,
+                AccessTicket = c.AccessTicket,
+                Challenge = new ListConsolesResponseChallenge
+                {
+                    Id = c.Id.ChallengeId,
+                    Name = challenges[c.Id.ChallengeId].Name,
+                    IsPractice = challenges[c.Id.ChallengeId].PlayerMode == PlayerMode.Practice,
+                    SpecId = challenges[c.Id.ChallengeId].SpecId
+                },
+                IsViewOnly = !userTeams.Contains(challenges[c.Id.ChallengeId].TeamId),
+                Team = new ListConsolesResponseTeam
+                {
+                    Id = challenges[c.Id.ChallengeId].TeamId,
+                    Name = captains[challenges[c.Id.ChallengeId].TeamId].ApprovedName,
+                    Rank = teamScoreData.ContainsKey(challenges[c.Id.ChallengeId].TeamId) ? teamScoreData[challenges[c.Id.ChallengeId].TeamId].Rank : null,
+                    Score = teamScoreData.ContainsKey(challenges[c.Id.ChallengeId].TeamId) ? teamScoreData[challenges[c.Id.ChallengeId].TeamId].ScoreOverall : null,
+
+                },
+                TeamId = challenges[c.Id.ChallengeId].TeamId,
+                Url = c.Url
+            }).OrderBy(c => c.Team.Name).ThenBy(c => c.ConsoleId.ChallengeId)]
+        };
+    }
+}

--- a/src/Gameboard.Api/Features/Consoles/Requests/ListConsoles/ListConsolesRequest.cs
+++ b/src/Gameboard.Api/Features/Consoles/Requests/ListConsoles/ListConsolesRequest.cs
@@ -133,7 +133,7 @@ internal sealed class GetConsolesHandler
             .ToDictionaryAsync(gr => gr.TeamId, gr => gr, cancellationToken);
 
         // and the map which knows who's using which consoles
-        var gameConsoleUsers = consoleActorMap.Find().GroupBy(a => a.ChallengeId).ToDictionary(gr => gr.Key, gr => gr.ToArray());
+        var gameConsoleUsers = consoleActorMap.Find().GroupBy(a => a.ChallengeId).ToDictionary(gr => gr.Key, gr => gr.DistinctBy(a => a.UserId).ToArray());
 
         // load console stuff last, because access tickets are time-sensitive
         var consoleIds = new List<ConsoleId>();
@@ -143,6 +143,7 @@ internal sealed class GetConsolesHandler
             var challengeVms = gameEngine.GetVmsFromState(state);
             consoleIds.AddRange(challengeVms.Select(vm => new ConsoleId { ChallengeId = challenge.Id, Name = vm.Name }));
         }
+
         var consoles = await gameEngine.GetConsoles(gameEngineType, [.. consoleIds], cancellationToken);
 
         // construct and return the response

--- a/src/Gameboard.Api/Features/Consoles/Requests/SetActiveUser/SetActiveUserCommand.cs
+++ b/src/Gameboard.Api/Features/Consoles/Requests/SetActiveUser/SetActiveUserCommand.cs
@@ -15,6 +15,7 @@ internal sealed class SetActiveUserHandler
     IActingUserService actingUserService,
     ICanAccessConsoleValidator canAccessConsole,
     ChallengeService challengeService,
+    ConsoleActorMap consoleActorMap,
     IValidatorService validator
 ) : IRequestHandler<SetActiveUserCommand>
 {
@@ -29,6 +30,6 @@ internal sealed class SetActiveUserHandler
             .Validate(cancellationToken);
 
         var actingUser = actingUserService.Get();
-        await challengeService.SetConsoleActor(request.Console, actingUser.Id, actingUser.ApprovedName);
+        consoleActorMap.Update(await challengeService.SetConsoleActor(request.Console, actingUser.Id, actingUser.ApprovedName));
     }
 }

--- a/src/Gameboard.Api/Features/Consoles/Requests/SetActiveUser/SetActiveUserCommand.cs
+++ b/src/Gameboard.Api/Features/Consoles/Requests/SetActiveUser/SetActiveUserCommand.cs
@@ -1,0 +1,34 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Gameboard.Api.Common.Services;
+using Gameboard.Api.Features.Consoles.Validators;
+using Gameboard.Api.Services;
+using Gameboard.Api.Structure.MediatR;
+using MediatR;
+
+namespace Gameboard.Api.Features.Consoles.Requests;
+
+public record SetActiveUserCommand(ConsoleId Console) : IRequest;
+
+internal sealed class SetActiveUserHandler
+(
+    IActingUserService actingUserService,
+    ICanAccessConsoleValidator canAccessConsole,
+    ChallengeService challengeService,
+    IValidatorService validator
+) : IRequestHandler<SetActiveUserCommand>
+{
+    public async Task Handle(SetActiveUserCommand request, CancellationToken cancellationToken)
+    {
+        canAccessConsole.ChallengeId = request.Console.ChallengeId;
+
+        await validator
+            .Auth(c => c.RequireAuthentication())
+            .AddEntityExistsValidator<Data.Challenge>(request.Console.ChallengeId)
+            .AddValidator(canAccessConsole)
+            .Validate(cancellationToken);
+
+        var actingUser = actingUserService.Get();
+        await challengeService.SetConsoleActor(request.Console, actingUser.Id, actingUser.ApprovedName);
+    }
+}

--- a/src/Gameboard.Api/Features/Consoles/Validators/CanAccessConsoleValidator.cs
+++ b/src/Gameboard.Api/Features/Consoles/Validators/CanAccessConsoleValidator.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Gameboard.Api.Common.Services;
+using Gameboard.Api.Features.Teams;
+using Gameboard.Api.Features.Users;
+using Gameboard.Api.Services;
+using Gameboard.Api.Structure.MediatR;
+using Gameboard.Api.Structure.MediatR.Validators;
+using Microsoft.Extensions.Logging;
+
+namespace Gameboard.Api.Features.Consoles.Validators;
+
+public interface ICanAccessConsoleValidator : IGameboardValidator
+{
+    string ChallengeId { get; set; }
+}
+
+internal sealed class CanAccessConsoleValidator
+(
+    IActingUserService actingUserService,
+    ChallengeService challengesService,
+    ILogger<CanAccessConsoleValidator> logger,
+    IUserRolePermissionsService permissionsService
+) : ICanAccessConsoleValidator
+{
+    public string ChallengeId { get; set; }
+
+    public Func<RequestValidationContext, Task> GetValidationTask(CancellationToken cancellationToken)
+    {
+        return async ctx =>
+        {
+            var actingUser = actingUserService.Get();
+
+            var isTeamMember = await challengesService.UserIsPlayingChallenge(ChallengeId, actingUser.Id);
+            logger.LogInformation($"Console access attempt ({ChallengeId} / {actingUser.Id}): User {actingUser.Id}, roles {actingUser.Role}, on team = {isTeamMember} .");
+
+            if (!isTeamMember)
+            {
+                var hasObserve = await permissionsService.Can(PermissionKey.Teams_Observe);
+
+                if (!hasObserve)
+                {
+                    var challenge = await challengesService.Get(ChallengeId);
+                    ctx.AddValidationException(new UserIsntOnTeam(actingUser.Id, challenge.TeamId));
+                    return;
+                }
+            }
+
+            logger.LogInformation("Console access attempt ({summary}): Allowed.", $"{ChallengeId} / {actingUser.Id}");
+        };
+    }
+}

--- a/src/Gameboard.Api/Features/FeatureStartupExtensions.cs
+++ b/src/Gameboard.Api/Features/FeatureStartupExtensions.cs
@@ -19,6 +19,7 @@ using Gameboard.Api.Features.Users;
 using Gameboard.Api.Hubs;
 using Gameboard.Api.Structure;
 using Gameboard.Api.Structure.MediatR;
+using Gameboard.Api.Features.Consoles.Validators;
 
 namespace Gameboard.Api;
 
@@ -46,6 +47,7 @@ public static class ServiceStartupExtensions
             .AddImplementationsOf<IGameboardRequestValidator<IReportQuery>>()
             // these aren't picked up right now because they implement multiple interfaces,
             // but allowing multiple-interface classes causes things like IReportQuery implementers to get snagged
+            .AddScoped<ICanAccessConsoleValidator, CanAccessConsoleValidator>()
             .AddScoped<IExtensionsService, ExtensionsService>()
             .AddScoped<IExternalGameService, ExternalGameService>()
             .AddScoped<IExternalGameModeService, ExternalGameModeService>()

--- a/src/Gameboard.Api/Features/Game/External/Services/ExternalGameHostService.cs
+++ b/src/Gameboard.Api/Features/Game/External/Services/ExternalGameHostService.cs
@@ -199,7 +199,7 @@ internal class ExternalGameHostService : IExternalGameHostService
                 Gamespaces = gamespaces.Select(gs => new ExternalGameStartTeamGamespace
                 {
                     Id = gs.Id,
-                    VmUris = _gameEngine.GetGamespaceVms(gs.State).Select(vm => vm.Url),
+                    VmUris = _gameEngine.GetVmsFromState(gs.State).Select(vm => vm.Url),
                     IsDeployed = gs.State.HasDeployedGamespace
                 }),
                 Players = players.Select(p => new ExternalGameStartMetaDataPlayer

--- a/src/Gameboard.Api/Features/Game/Requests/ListGames/ListGames.cs
+++ b/src/Gameboard.Api/Features/Game/Requests/ListGames/ListGames.cs
@@ -1,7 +1,6 @@
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using AutoMapper;
 using Gameboard.Api.Common.Services;
 using Gameboard.Api.Data;
 using Gameboard.Api.Features.Users;

--- a/src/Gameboard.Api/Features/Game/ResourceDeployment/GameResourcesDeployService.cs
+++ b/src/Gameboard.Api/Features/Game/ResourceDeployment/GameResourcesDeployService.cs
@@ -349,7 +349,7 @@ internal class GameResourcesDeployService : IGameResourcesDeployService
         {
             Id = state.Id,
             IsDeployed = state.IsActive,
-            VmUris = _gameEngineService.GetGamespaceVms(state).Select(vm => vm.Url)
+            VmUris = _gameEngineService.GetVmsFromState(state).Select(vm => vm.Url)
         };
 
     internal Task<string[]> ResolveChallengeSpecIds(string gameId, CancellationToken cancellationToken)

--- a/src/Gameboard.Api/Features/GameEngine/GameEngineExceptions.cs
+++ b/src/Gameboard.Api/Features/GameEngine/GameEngineExceptions.cs
@@ -4,7 +4,11 @@ using Gameboard.Api.Structure;
 
 namespace Gameboard.Api.Features.GameEngine;
 
-internal class GameEngineException(string message, Exception innerEx) : GameboardException(message, innerEx) { }
+internal class GameEngineException : GameboardException
+{
+    public GameEngineException(string message) : base(message) { }
+    public GameEngineException(string message, Exception innerEx) : base(message, innerEx) { }
+}
 
 internal class GradingFailed : GameboardException
 {

--- a/src/Gameboard.Api/Features/GameEngine/Services/GameEngineService.cs
+++ b/src/Gameboard.Api/Features/GameEngine/Services/GameEngineService.cs
@@ -215,8 +215,9 @@ public class GameEngineService
 
         var tasks = consoleIds.Select(id => Mojo.GetVmTicketAsync(id.ToString()));
         var results = await Task.WhenAll(tasks);
+        var runningVms = results.Where(r => r.IsRunning).ToArray();
 
-        return [.. results.Select(vm => new ConsoleState
+        return [.. runningVms.Select(vm => new ConsoleState
         {
             Id = new ConsoleId() { ChallengeId = vm.IsolationId, Name = vm.Name },
             AccessTicket = vm.Ticket,

--- a/src/Gameboard.Api/Structure/AppSettings.cs
+++ b/src/Gameboard.Api/Structure/AppSettings.cs
@@ -167,6 +167,7 @@ public class CoreOptions
     public int GameEngineDeployBatchSize { get; set; } = 2;
     public string GameEngineUrl { get; set; } = "http://localhost:5004";
     public int GameEngineMaxRetries { get; set; } = 2;
+    public GameEngineType GameEngineType { get; set; } = GameEngineType.TopoMojo;
     public string ImageFolder { get; set; } = "wwwroot/img";
     public string KeyPrefix { get; set; } = "GB";
     public bool MojoEnabled { get; set; } = true;

--- a/src/Gameboard.Api/Structure/MediatR/Validators/RequestValidationContext.cs
+++ b/src/Gameboard.Api/Structure/MediatR/Validators/RequestValidationContext.cs
@@ -4,7 +4,7 @@ namespace Gameboard.Api.Structure.MediatR.Validators;
 
 public class RequestValidationContext
 {
-    private List<GameboardValidationException> _exceptions = new List<GameboardValidationException>();
+    private readonly List<GameboardValidationException> _exceptions = [];
     internal IEnumerable<GameboardValidationException> ValidationExceptions { get => _exceptions; }
     internal RequestValidationContext() { }
 

--- a/src/Gameboard.Api/Structure/MediatR/Validators/ValidatorService.cs
+++ b/src/Gameboard.Api/Structure/MediatR/Validators/ValidatorService.cs
@@ -12,6 +12,13 @@ namespace Gameboard.Api.Structure.MediatR;
 
 public interface IValidatorService
 {
+    /// <summary>
+    /// Ensures that an entity of the given type with the provided ID exists. Must be a type registered with EF which
+    /// implements our IEntity interface.
+    /// </summary>
+    /// <typeparam name="TEntity"></typeparam>
+    /// <param name="id"></param>
+    /// <returns></returns>
     IValidatorService AddEntityExistsValidator<TEntity>(string id) where TEntity : class, IEntity;
     IValidatorService AddValidator(IGameboardValidator validator);
     IValidatorService AddValidator(Action<RequestValidationContext> validationAction);
@@ -34,8 +41,10 @@ internal class ValidatorService
     private readonly IStore _store = store;
     private readonly UserRolePermissionsValidator _userRolePermissionsValidator = userRolePermissionsValidator;
 
+
     public IValidatorService AddEntityExistsValidator<TEntity>(string id) where TEntity : class, IEntity
     {
+
         _validationTasks.Add(async ctx =>
         {
             var exists = await _store

--- a/src/Gameboard.Api/Structure/ServiceRegistrationExtensions.cs
+++ b/src/Gameboard.Api/Structure/ServiceRegistrationExtensions.cs
@@ -167,9 +167,7 @@ internal static class ServiceRegistrationExtensions
             .ToArray();
 
     private static Type[] GetRootTypeQuery()
-     => GetRootQuery()
-            .Where(t => t.IsClass && !t.IsAbstract)
-            .ToArray();
+     => [.. GetRootQuery().Where(t => t.IsClass && !t.IsAbstract)];
 
     private class InterfaceTypeMap
     {


### PR DESCRIPTION
Version 3.33.0 of Gameboard contains usability enhancements for VM consoles.

# Enhancements

- Gameboard's consoles are now powered by [ConsoleForge](https://github.com/cmu-sei/console-forge), an open-source Angular library for VM console access.
- Gameboard's built-in console code (and its `gameboard-mks` Angular app) have been removed.
- Game Center -> Observe has been rewritten to take advantage of ConsoleForge's console preview tiles.
- Admin -> Practice has a new Observe tab which allows observation of all active practice challenges.
- The console page (which opens when a console is clicked, either from competitive play, practice, or an admin screen) has been slightly improved:
  - Now shows a countdown until the console expires (typically because the challenge will end).
  - Shows toast notifications when the console disconnects/reconnects
- The Practice Area's challenges now show console previews for all available consoles (unless the sticky panel is in use)

**NOTE:** Because we're using ConsoleForge for consoles now, some minimal configuration updates are required for the web client. Namely, any settings.json files read into the app via Helm or other deployment must now include a ConsoleForge config in the `settings` property. At minimum, the default console client type (e.g. "vmware" or "vnc") is required. A barebones config might look like:

```json
{
  "settings": {
    "consoleForgeConfig": {
      "defaultConsoleClientType": "vnc" // or "vmware" if appropriate
    }
  }
}
```

# For developers

- A reverse proxy is no longer needed to run `gameboard-ui` and `gameboard-mks` from the same origin - you can just `ng serve` as you would in any other app.