### PR TITLE
v3.34.2

### DIFF
--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -1,0 +1,1 @@
+@sei-bstein @sei-tspencer @sei-aschlackman

--- a/src/Gameboard.Api.Tests.Integration/Fixtures/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Gameboard.Api.Tests.Integration/Fixtures/Extensions/ServiceCollectionExtensions.cs
@@ -23,6 +23,13 @@ public static class ServiceCollectionExtensions
         if (existingService != null) services.Remove(existingService);
     }
 
+    public static IServiceCollection ReplaceService<C>(this IServiceCollection services, C replacement) where C : class
+    {
+        RemoveService<C>(services);
+        services.AddSingleton(replacement);
+        return services;
+    }
+
     public static IServiceCollection ReplaceService<I, C>(this IServiceCollection services, bool allowMultipleReplace = false) where I : class where C : class, I
     {
         if (allowMultipleReplace)

--- a/src/Gameboard.Api.Tests.Integration/Fixtures/GameboardTestContext.cs
+++ b/src/Gameboard.Api.Tests.Integration/Fixtures/GameboardTestContext.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Testcontainers.PostgreSql;
 
@@ -20,10 +21,14 @@ public class GameboardTestContext : WebApplicationFactory<Program>, IAsyncLifeti
     {
         builder
             .UseEnvironment("Test")
+            .UseSetting("GameEngine:ClientId", "a-test-client")
+            .UseSetting("GameEngine:ClientSecret", "a-test-client-secret")
             .ConfigureServices(services =>
             {
                 if (_container is null)
+                {
                     throw new GbAutomatedTestSetupException("Couldn't initialize the test context - the database container hasn't been resolved.");
+                }
 
                 // Add DB context with connection to the container
                 // connstring

--- a/src/Gameboard.Api/Extensions/WebApplicationBuilderExtensions.cs
+++ b/src/Gameboard.Api/Extensions/WebApplicationBuilderExtensions.cs
@@ -103,7 +103,7 @@ internal static class WebApplicationBuilderExtensions
         builder.AddGameboardSignalRServices();
 
         // Configure Auth
-        services.AddConfiguredAuthentication(settings.Oidc, settings.ApiKey, builder.Environment, logger);
+        services.AddConfiguredAuthentication(settings.Oidc, settings.ApiKey, builder.Environment);
         services.AddConfiguredAuthorization();
     }
 

--- a/src/Gameboard.Api/Gameboard.Api.csproj
+++ b/src/Gameboard.Api/Gameboard.Api.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="SharpCompress" Version="0.38.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />
-    <PackageReference Include="TopoMojo.Api.Client" Version="2.3.1" />
+    <PackageReference Include="TopoMojo.Api.Client" Version="2.3.11" />
     <PackageReference Include="YamlDotNet" Version="13.1.1" />
   </ItemGroup>
 

--- a/src/Gameboard.Api/Program.cs
+++ b/src/Gameboard.Api/Program.cs
@@ -32,7 +32,7 @@ startupLogger.LogInformation("Starting Gameboard in {envName} configuration.", b
 
 // load settings and configure services
 var settings = builder.BuildAppSettings();
-builder.ConfigureServices(settings);
+builder.ConfigureServices(settings, startupLogger);
 
 // build and configure app
 var app = builder.Build();

--- a/src/Gameboard.Api/Structure/AppSettings.cs
+++ b/src/Gameboard.Api/Structure/AppSettings.cs
@@ -17,6 +17,7 @@ public class AppSettings
     public CrucibleOptions Crucible { get; set; } = new CrucibleOptions();
     public DatabaseOptions Database { get; set; } = new DatabaseOptions();
     public Defaults Defaults { get; set; } = new Defaults();
+    public GameEngineOptions GameEngine { get; set; } = new GameEngineOptions();
     public HeaderOptions Headers { get; set; } = new HeaderOptions();
     public LoggingSettings Logging { get; set; } = new LoggingSettings();
     public OidcOptions Oidc { get; set; } = new OidcOptions();
@@ -28,6 +29,13 @@ public class ApiKeyOptions
 {
     public int BytesOfRandomness { get; set; } = 32;
     public int RandomCharactersLength { get; set; } = 36;
+}
+
+public sealed class GameEngineOptions
+{
+    public string ClientId { get; set; }
+    public string ClientSecret { get; set; }
+    public GameEngineType Type { get; set; } = GameEngineType.TopoMojo;
 }
 
 public class LoggingSettings

--- a/src/Gameboard.Api/Structure/Auth/AuthorizationStartupExtensions.cs
+++ b/src/Gameboard.Api/Structure/Auth/AuthorizationStartupExtensions.cs
@@ -18,47 +18,55 @@ namespace Microsoft.Extensions.DependencyInjection
             JsonWebTokenHandler.DefaultInboundClaimTypeMap.Clear();
 
             services.AddAuthorizationBuilder()
-                .SetDefaultPolicy(new AuthorizationPolicyBuilder()
-                    .RequireAuthenticatedUser()
-                    .AddAuthenticationSchemes
-                    (
-                        JwtBearerDefaults.AuthenticationScheme,
-                        ApiKeyAuthentication.AuthenticationScheme
-                    ).Build())
-
-                .AddPolicy(AppConstants.TicketOnlyPolicy, new AuthorizationPolicyBuilder()
-                    .RequireAuthenticatedUser()
-                    .AddAuthenticationSchemes(
-                        TicketAuthentication.AuthenticationScheme
-                    )
-                    .Build()
-)
-                .AddPolicy(AppConstants.ConsolePolicy, new AuthorizationPolicyBuilder()
-                    .RequireAuthenticatedUser()
-                    .AddAuthenticationSchemes(
-                        AppConstants.MksCookie
-                    )
-                    .Build()
-)
-                .AddPolicy(AppConstants.HubPolicy, new AuthorizationPolicyBuilder()
-                    .RequireAuthenticatedUser()
-                    .AddAuthenticationSchemes(
-                        TicketAuthentication.AuthenticationScheme,
-                        AppConstants.MksCookie
-                    )
-                    .Build()
-)
-                .AddPolicy(AppConstants.GraderPolicy, new AuthorizationPolicyBuilder()
-                    .RequireAuthenticatedUser()
-                    .AddAuthenticationSchemes(
-                        JwtBearerDefaults.AuthenticationScheme,
-                        GraderKeyAuthentication.AuthenticationScheme
-                    ).Build()
-)
-                .AddPolicy(AppConstants.ApiKeyAuthPolicy, new AuthorizationPolicyBuilder()
-                    .RequireAuthenticatedUser()
-                    .AddAuthenticationSchemes(ApiKeyAuthentication.AuthenticationScheme)
-                    .Build());
+                .SetDefaultPolicy
+                (
+                    new AuthorizationPolicyBuilder()
+                        .RequireAuthenticatedUser()
+                        .AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme, ApiKeyAuthentication.AuthenticationScheme)
+                        .Build()
+                )
+                .AddPolicy
+                (
+                    AppConstants.TicketOnlyPolicy,
+                    new AuthorizationPolicyBuilder()
+                        .RequireAuthenticatedUser()
+                        .AddAuthenticationSchemes(TicketAuthentication.AuthenticationScheme)
+                        .Build()
+                )
+                .AddPolicy
+                (
+                    AppConstants.ConsolePolicy,
+                    new AuthorizationPolicyBuilder()
+                        .RequireAuthenticatedUser()
+                        .AddAuthenticationSchemes(AppConstants.MksCookie)
+                        .Build()
+                )
+                .AddPolicy
+                (
+                    AppConstants.HubPolicy,
+                    new AuthorizationPolicyBuilder()
+                        .RequireAuthenticatedUser()
+                        .AddAuthenticationSchemes(TicketAuthentication.AuthenticationScheme, AppConstants.MksCookie)
+                        .Build()
+                )
+                .AddPolicy
+                (
+                    AppConstants.GraderPolicy,
+                    new AuthorizationPolicyBuilder()
+                        .RequireAuthenticatedUser()
+                        .AddAuthenticationSchemes(
+                            JwtBearerDefaults.AuthenticationScheme,
+                            GraderKeyAuthentication.AuthenticationScheme
+                        ).Build()
+                )
+                .AddPolicy
+                (
+                    AppConstants.ApiKeyAuthPolicy,
+                    new AuthorizationPolicyBuilder()
+                        .RequireAuthenticatedUser()
+                        .AddAuthenticationSchemes(ApiKeyAuthentication.AuthenticationScheme)
+                        .Build()
+                );
 
             return services;
         }

--- a/src/Gameboard.Api/Structure/Auth/Crucible/CrucibleHttpClientBuilderExtensions.cs
+++ b/src/Gameboard.Api/Structure/Auth/Crucible/CrucibleHttpClientBuilderExtensions.cs
@@ -1,0 +1,33 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Polly;
+using Polly.Extensions.Http;
+
+namespace Gameboard.Api.Structure.Auth.Crucible;
+
+public static class CrucibleHttpClientBuilderExtensions
+{
+    private static IHttpClientBuilder AddCrucibleAsyncRetryPolicy(this IHttpClientBuilder builder, int maxRetries)
+    {
+        return builder
+            .AddPolicyHandler
+            (
+                HttpPolicyExtensions
+                    .HandleTransientHttpError()
+                    .OrResult(msg => msg.StatusCode == System.Net.HttpStatusCode.NotFound)
+                    .WaitAndRetryAsync(maxRetries, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)))
+            );
+    }
+
+    public static IHttpClientBuilder ConfigureCrucibleServiceAccountClient(this IHttpClientBuilder builder, Uri baseAddress, int maxRetries = 10)
+    {
+        return builder
+            .ConfigureHttpClient(client =>
+            {
+                client.BaseAddress = baseAddress;
+                client.Timeout = TimeSpan.FromSeconds(300);
+            })
+            .AddHttpMessageHandler<CrucibleServiceAccountBearerTokenHandler>()
+            .AddCrucibleAsyncRetryPolicy(maxRetries);
+    }
+}

--- a/src/Gameboard.Api/Structure/Auth/Crucible/CrucibleServiceAccountBearerTokenHandler.cs
+++ b/src/Gameboard.Api/Structure/Auth/Crucible/CrucibleServiceAccountBearerTokenHandler.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Polly;
+using Polly.Retry;
+
+namespace Gameboard.Api.Structure.Auth.Crucible;
+
+public class CrucibleServiceAccountBearerTokenHandler
+(
+    ILogger<CrucibleServiceAccountBearerTokenHandler> logger,
+    ICrucibleServiceAccountTokenService tokenService
+) : DelegatingHandler
+{
+    private readonly AsyncRetryPolicy<HttpResponseMessage> _retryPolicy = Policy
+        .HandleResult<HttpResponseMessage>(r => r.StatusCode == HttpStatusCode.Unauthorized)
+        .WaitAndRetryForeverAsync(attempt =>
+        {
+            logger.LogError("Retrying crucible service account authorization after a 401");
+            tokenService.InvalidateToken();
+            return TimeSpan.FromSeconds(Math.Min(Math.Pow(2, attempt), 120));
+        });
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var result = await _retryPolicy.ExecuteAndCaptureAsync(async () =>
+        {
+            var token = await tokenService.GetTokenAsync(cancellationToken);
+            request.Headers.Authorization = new AuthenticationHeaderValue(token.TokenType, token.AccessToken);
+            return await base.SendAsync(request, cancellationToken);
+        });
+
+        // result.Result is null/default if the policy fails
+        return result.Result ?? result.FinalHandledResult;
+    }
+}

--- a/src/Gameboard.Api/Structure/Auth/Crucible/CrucibleServiceAccountTokenService.cs
+++ b/src/Gameboard.Api/Structure/Auth/Crucible/CrucibleServiceAccountTokenService.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using IdentityModel.Client;
+using Microsoft.Extensions.Logging;
+
+namespace Gameboard.Api.Structure.Auth.Crucible;
+
+public interface ICrucibleServiceAccountTokenService
+{
+    public Task<TokenResponse> GetTokenAsync(CancellationToken cancellationToken);
+    void InvalidateToken();
+}
+
+internal sealed class CrucibleServiceAccountTokenService
+(
+    CrucibleServiceAccountAuthenticationConfig crucibleServiceAccountAuthConfig,
+    HttpClient httpClient,
+    ILogger<CrucibleServiceAccountTokenService> logger
+) : ICrucibleServiceAccountTokenService
+{
+    private TokenResponse _currentToken = null;
+    private readonly SemaphoreSlim _semaphore = new(1);
+
+    public async Task<TokenResponse> GetTokenAsync(CancellationToken cancellationToken)
+    {
+        if (_currentToken is null || _currentToken.ExpiresIn <= crucibleServiceAccountAuthConfig.RenewTokenThreshold)
+        {
+            try
+            {
+                await _semaphore.WaitAsync(cancellationToken);
+                logger.LogInformation("Renewing auth token...");
+                _currentToken = await RenewToken(cancellationToken);
+                logger.LogInformation("Auth token renewed.");
+            }
+            finally
+            {
+                _semaphore.Release();
+            }
+        }
+
+        return _currentToken;
+    }
+
+    public void InvalidateToken()
+    {
+        _currentToken = null;
+    }
+
+    private async Task<TokenResponse> RenewToken(CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Renewing auth token...");
+
+        var discoDoc = await httpClient.GetDiscoveryDocumentAsync(crucibleServiceAccountAuthConfig.OidcAuthority, cancellationToken);
+        var tokenResponse = await httpClient.RequestClientCredentialsTokenAsync(new ClientCredentialsTokenRequest
+        {
+            Address = discoDoc.TokenEndpoint,
+            ClientId = crucibleServiceAccountAuthConfig.ClientId,
+            ClientSecret = crucibleServiceAccountAuthConfig.ClientSecret
+        }, cancellationToken);
+
+        if (tokenResponse.IsError)
+        {
+            logger.LogError("Exception renewing auth token. {exMessage} {exDescription}", tokenResponse.Error, tokenResponse.ErrorDescription);
+            throw new Exception(tokenResponse.Error);
+        }
+
+        logger.LogInformation("Auth token renewed.");
+        return tokenResponse;
+    }
+}

--- a/src/Gameboard.Api/Structure/Auth/Crucible/CrucibleServiceRegistrationExtensions.cs
+++ b/src/Gameboard.Api/Structure/Auth/Crucible/CrucibleServiceRegistrationExtensions.cs
@@ -11,9 +11,9 @@ public sealed class CrucibleServiceAccountAuthenticationConfig
 
     /// <summary>
     /// An access token that will expire in this amount of time or less (in seconds) will automatically
-    /// be renewed before it's attached to a request. Defaults to 3600 (one hour).
+    /// be renewed before it's attached to a request. Defaults to 300 (5 minutes).
     /// </summary>
-    public int RenewTokenThreshold { get; set; } = 3600;
+    public int RenewTokenThreshold { get; set; } = 300;
 }
 
 public static class CrucibleServiceRegistrationExtensions
@@ -21,8 +21,8 @@ public static class CrucibleServiceRegistrationExtensions
     public static IServiceCollection AddCrucibleServiceAccountAuthentication(this IServiceCollection services, CrucibleServiceAccountAuthenticationConfig config)
     {
         services.AddSingleton(config);
-        services.AddTransient<CrucibleServiceAccountBearerTokenHandler>();
         services.AddSingleton<ICrucibleServiceAccountTokenService, CrucibleServiceAccountTokenService>();
+        services.AddTransient<CrucibleServiceAccountBearerTokenHandler>();
 
         return services;
     }

--- a/src/Gameboard.Api/Structure/Auth/Crucible/CrucibleServiceRegistrationExtensions.cs
+++ b/src/Gameboard.Api/Structure/Auth/Crucible/CrucibleServiceRegistrationExtensions.cs
@@ -1,0 +1,29 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Gameboard.Api.Structure.Auth.Crucible;
+
+public sealed class CrucibleServiceAccountAuthenticationConfig
+{
+    public required string OidcAudience { get; set; }
+    public required string OidcAuthority { get; set; }
+    public required string ClientId { get; set; }
+    public required string ClientSecret { get; set; }
+
+    /// <summary>
+    /// An access token that will expire in this amount of time or less (in seconds) will automatically
+    /// be renewed before it's attached to a request. Defaults to 3600 (one hour).
+    /// </summary>
+    public int RenewTokenThreshold { get; set; } = 3600;
+}
+
+public static class CrucibleServiceRegistrationExtensions
+{
+    public static IServiceCollection AddCrucibleServiceAccountAuthentication(this IServiceCollection services, CrucibleServiceAccountAuthenticationConfig config)
+    {
+        services.AddSingleton(config);
+        services.AddTransient<CrucibleServiceAccountBearerTokenHandler>();
+        services.AddSingleton<ICrucibleServiceAccountTokenService, CrucibleServiceAccountTokenService>();
+
+        return services;
+    }
+}

--- a/src/Gameboard.Api/Structure/Auth/Crucible/CrucibleServiceRegistrationExtensions.cs
+++ b/src/Gameboard.Api/Structure/Auth/Crucible/CrucibleServiceRegistrationExtensions.cs
@@ -11,9 +11,9 @@ public sealed class CrucibleServiceAccountAuthenticationConfig
 
     /// <summary>
     /// An access token that will expire in this amount of time or less (in seconds) will automatically
-    /// be renewed before it's attached to a request. Defaults to 300 (5 minutes).
+    /// be renewed before it's attached to a request. Defaults to 120 (2 minutes).
     /// </summary>
-    public int RenewTokenThreshold { get; set; } = 300;
+    public int RenewTokenThreshold { get; set; } = 120;
 }
 
 public static class CrucibleServiceRegistrationExtensions

--- a/src/Gameboard.Api/Structure/AuthenticatingHandler.cs
+++ b/src/Gameboard.Api/Structure/AuthenticatingHandler.cs
@@ -68,7 +68,7 @@ namespace Gameboard.Api
             }
             else
             {
-                _logger.LogError($"Error in {nameof(AuthenticatingHandler)}: {_token.Error}");
+                _logger.LogError("Error in {errorTypeName}: {tokenError}", nameof(AuthenticatingHandler), _token.Error);
             }
         }
     }

--- a/src/Gameboard.Api/Structure/HttpClientStartupExtensions.cs
+++ b/src/Gameboard.Api/Structure/HttpClientStartupExtensions.cs
@@ -6,6 +6,8 @@ using System.Net.Http;
 using System.Threading;
 using Alloy.Api.Client;
 using Gameboard.Api;
+using Gameboard.Api.Structure.Auth.Crucible;
+using Microsoft.Extensions.Logging;
 using Polly;
 using Polly.Extensions.Http;
 using TopoMojo.Api.Client;
@@ -14,40 +16,54 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static class StartupExtensions
     {
-        public static IServiceCollection AddConfiguredHttpClients(
-            this IServiceCollection services,
-            CoreOptions config
-        )
+        public static IServiceCollection AddConfiguredHttpClients(this IServiceCollection services, AppSettings settings, ILogger logger)
         {
-            services
-                .AddHttpClient<ITopoMojoApiClient, TopoMojoApiClient>()
-                .ConfigureHttpClient(client =>
-                {
-                    client.BaseAddress = new Uri(config.GameEngineUrl);
-                    client.DefaultRequestHeaders.Add("x-api-key", config.GameEngineClientSecret);
-                    client.DefaultRequestHeaders.Add("x-api-client", config.GameEngineClientName);
-                    client.Timeout = TimeSpan.FromSeconds(300);
-                })
-                .AddPolicyHandler(
-                    HttpPolicyExtensions.HandleTransientHttpError()
-                    .OrResult(msg => msg.StatusCode == System.Net.HttpStatusCode.NotFound)
-                    .WaitAndRetryAsync(config.GameEngineMaxRetries, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)))
-                );
+            logger.LogInformation("Configuring HTTP clients...");
 
-            services
-                .AddHttpClient("topo", client =>
+            if (settings.Core.GameEngineClientName.IsNotEmpty() && settings.Core.GameEngineClientSecret.IsNotEmpty())
+            {
+                logger.LogInformation("Configuring game engine access via LEGACY API key...");
+
+                // if API credentials are present, attach them to the request.
+                // NOTE: API credentials are a legacy implementation and not preferred. Instead, create a client
+                // using your identity provider and configure Gameboard with its client ID and secret using the
+                // GameEngine__ClientId and GameEngine__ClientSecret settings.
+                services
+                    .AddHttpClient<ITopoMojoApiClient, TopoMojoApiClient>()
+                    .ConfigureHttpClient(client =>
+                    {
+                        client.BaseAddress = new Uri(settings.Core.GameEngineUrl);
+                        client.Timeout = TimeSpan.FromSeconds(300);
+                        client.DefaultRequestHeaders.Add("x-api-client", settings.Core.GameEngineClientName);
+                        client.DefaultRequestHeaders.Add("x-api-key", settings.Core.GameEngineClientSecret);
+                    })
+                    .AddPolicyHandler
+                    (
+                        HttpPolicyExtensions
+                            .HandleTransientHttpError()
+                            .OrResult(msg => msg.StatusCode == System.Net.HttpStatusCode.NotFound)
+                            .WaitAndRetryAsync(settings.Core.GameEngineMaxRetries, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)))
+                    );
+            }
+            else if (settings.GameEngine.ClientId.IsNotEmpty() && settings.GameEngine.ClientSecret.IsNotEmpty())
+            {
+                logger.LogInformation("Configuring game engine access via client credentials...");
+                services.AddCrucibleServiceAccountAuthentication(new CrucibleServiceAccountAuthenticationConfig
                 {
-                    client.BaseAddress = new Uri(config.GameEngineUrl);
-                    client.DefaultRequestHeaders.Add("x-api-key", config.GameEngineClientSecret);
-                    client.DefaultRequestHeaders.Add("x-api-client", config.GameEngineClientName);
-                    client.Timeout = TimeSpan.FromSeconds(300);
-                })
-                .AddPolicyHandler
-                (
-                    HttpPolicyExtensions.HandleTransientHttpError()
-                    .OrResult(msg => msg.StatusCode == System.Net.HttpStatusCode.NotFound)
-                    .WaitAndRetryAsync(config.GameEngineMaxRetries, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)))
-                );
+                    OidcAudience = settings.Oidc.Audience,
+                    OidcAuthority = settings.Oidc.Authority,
+                    ClientId = settings.GameEngine.ClientId,
+                    ClientSecret = settings.GameEngine.ClientSecret
+                });
+
+                services
+                    .AddHttpClient<ITopoMojoApiClient, TopoMojoApiClient>()
+                    .ConfigureCrucibleServiceAccountClient(new Uri(settings.Core.GameEngineUrl), settings.Core.GameEngineMaxRetries);
+            }
+            else
+            {
+                throw new Exception("Gameboard's HTTP access to the game engine has not been configured. Set the GameEngine__ClientId and GameEngine__ClientSecret options to enable client credentials-based access, or (legacy) set Core__GameEngineClientName and Core__GameEngineClientSecret for API-key based access.");
+            }
 
             services
                 .AddHttpClient("identity", client =>
@@ -55,10 +71,12 @@ namespace Microsoft.Extensions.DependencyInjection
                     // Workaround to avoid TaskCanceledException after several retries. TODO: find a better way to handle this.
                     client.Timeout = Timeout.InfiniteTimeSpan;
                 })
-                .AddPolicyHandler(
-                    HttpPolicyExtensions.HandleTransientHttpError()
-                    .OrResult(msg => msg.StatusCode == System.Net.HttpStatusCode.NotFound)
-                    .WaitAndRetryAsync(config.GameEngineMaxRetries, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)))
+                .AddPolicyHandler
+                (
+                    HttpPolicyExtensions
+                        .HandleTransientHttpError()
+                        .OrResult(msg => msg.StatusCode == System.Net.HttpStatusCode.NotFound)
+                        .WaitAndRetryAsync(settings.Core.GameEngineMaxRetries, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)))
                 );
 
             services
@@ -68,10 +86,12 @@ namespace Microsoft.Extensions.DependencyInjection
                     client.Timeout = Timeout.InfiniteTimeSpan;
                 })
                 .AddHttpMessageHandler<AuthenticatingHandler>()
-                .AddPolicyHandler(
-                    HttpPolicyExtensions.HandleTransientHttpError()
-                    .OrResult(msg => msg.StatusCode == System.Net.HttpStatusCode.NotFound)
-                    .WaitAndRetryAsync(config.GameEngineMaxRetries, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)))
+                .AddPolicyHandler
+                (
+                    HttpPolicyExtensions
+                        .HandleTransientHttpError()
+                        .OrResult(msg => msg.StatusCode == System.Net.HttpStatusCode.NotFound)
+                        .WaitAndRetryAsync(settings.Core.GameEngineMaxRetries, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)))
                 );
 
             services
@@ -80,10 +100,8 @@ namespace Microsoft.Extensions.DependencyInjection
                     var httpClientFactory = p.GetRequiredService<IHttpClientFactory>();
                     var settings = p.GetRequiredService<CrucibleOptions>();
 
-                    var uri = new Uri(settings.ApiUrl);
-
                     var httpClient = httpClientFactory.CreateClient("alloy");
-                    httpClient.BaseAddress = uri;
+                    httpClient.BaseAddress = new Uri(settings.ApiUrl);
 
                     return new AlloyApiClient(httpClient);
                 });
@@ -92,6 +110,5 @@ namespace Microsoft.Extensions.DependencyInjection
 
             return services;
         }
-
     }
 }

--- a/src/Gameboard.Api/appsettings.conf
+++ b/src/Gameboard.Api/appsettings.conf
@@ -35,6 +35,12 @@
 # Database__Provider = PostgreSQL
 # Database__ConnectionString = Server=localhost;Port=5432;Database=YOUR_DB;User ID=YOUR_DB_USER;Password=YOUR_DB_PASSWORD;
 
+####################################################
+## Game engine settings
+####################################################
+# GameEngine__ClientId = YOUR_OAUTH_CLIENTID
+# GameEngine__ClientSecret = YOUR_OAUTH_CLIENTSECRET
+
 # ####################################################
 # ## Logging settings
 # ####################################################
@@ -50,8 +56,12 @@
 # ####################################################
 # Core__ChallengeDocUrl = http://localhost:5004/api
 # Core__GameEngineUrl = http://localhost:5004/api
+# Core__NameChangeIsEnabled = true
+# Core__NameChangeRequiresApproval = true
+
+# DEPRECATION WARNING
+# this client name/secret setting is actually used for API-key based authentication, which will be deprecated.
+# Instead, set the GameEngine__ClientId and GameEngine__ClientSecret settings to use client credentials auth.
 # Core__GameEngineClientName = 
 # Core__GameEngineClientSecret = 
 # Core__GameEngineDeployBatchSize = 6
-# Core__NameChangeIsEnabled = true
-# Core__NameChangeRequiresApproval = true


### PR DESCRIPTION
Version 3.34.2 allows Gameboard to use the client credentials flow to communicate with its game engine and fixes a few minor bugs.

# Client Credentials Auth

- We previously only supported API key based auth to the game engine. This update adds client credentials, mediated by the identity provider, as the preferred authorization method.
- To use Client Credentials auth with [Topomojo](https://github.com/cmu-sei/topomojo), our most common game engine:
  - Create a client on your OAuth/identity provider that has a compatible audience with Topomojo
  - Set the new Gameboard settings `GameEngine__ClientId` and `GameEngine__ClientSecret`
  - Create a new Topomojo user with "Observer" permission and set its Service Account Client ID to that of the OAuth client
  - Requires Topomojo 2.3.12 or later
- **NOTE**: To make config smoother and clearer, we may rename the following Gameboard variables, which are used to configure API-key-based access, in a future release:
  - `Core__GameEngineClientName`
  - `Core__GameEngineClientSecret`

# Bug fixes

- Fixed a web client error that could occur when a challenge spec with a `null` name was synchronized from the game engine
- Fixed an issue that could cause standard-engine-mode games to appear to be external in the Admin -> Games -> Table view.

# Stability and Health

- Updated to the newest version of the Topomojo API client