### PR TITLE
Fix/aspire dashboard url

### DIFF
--- a/src/Gameboard.Api/Gameboard.Api.csproj
+++ b/src/Gameboard.Api/Gameboard.Api.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <ItemGroup>
     <PackageReference Include="Crucible.Common.Authentication" Version="0.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.7" />
@@ -36,6 +36,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <UserSecretsId>cmu-sei-crucible-gameboard-api</UserSecretsId>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Gameboard.Api/Properties/launchSettings.json
+++ b/src/Gameboard.Api/Properties/launchSettings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "$schema": "http://json.schemastore.org/launchsettings.json",
   "iisSettings": {
     "windowsAuthentication": false,
@@ -20,7 +20,7 @@
     "Project": {
       "commandName": "Project",
       "launchBrowser": false,
-      "launchUrl": "",
+      "launchUrl": "api",
       "applicationUrl": "http://localhost:5002",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                            
  Standardizes launchSettings.json configuration to fix Aspire dashboard URL display and adds UserSecretsId for improved developer experience.
                                                                                                                                                                                                        
  ## Changes                                                                                                                                                                                          

  ### 1. Standardize launchUrl for Aspire Dashboard
  - Updated `launchUrl` property in `launchSettings.json` to `"api"`
  - Fixes Aspire dashboard URL display to show `/api` endpoint instead of root URL
  - Aligns with other Crucible API projects (Player, Caster, Steamfitter, CITE, Gallery, Blueprint, Alloy, TopoMojo)
  - Follows ASP.NET Core conventions for launch profiles

  ### 2. Add UserSecretsId for Development Configuration
  - Added `<UserSecretsId>cmu-sei-crucible-gameboard-api</UserSecretsId>` to project file
  - Enables `dotnet user-secrets` command for local configuration management
  - Allows Crucible AppHost to automatically configure database connection strings for local development
  - Aligns with other Crucible API projects that use user secrets

  ## Impact
  - **No production impact**: launchSettings.json and UserSecretsId are development-only features
  - **Improved developer experience**:
    - Clicking on Gameboard API in Aspire dashboard navigates to correct `/api` endpoint
    - Developers can run Gameboard API standalone with automatic database configuration
    - Consistent configuration approach across all Crucible services
  - **No breaking changes**: All changes are additive or non-functional

  ## Testing
  - Verify Aspire dashboard displays `/api` endpoint for Gameboard API
  - Confirm Gameboard API launches correctly with standard launch profile
  - Test that user secrets are properly configured when running via AppHost

  ## Related
  Part of Crucible-wide effort to standardize API launch configurations across all services.