### PR TITLE
Sync appsettings.conf keys to helm chart on release

### DIFF
--- a/.github/workflows/update-helm-chart.yml
+++ b/.github/workflows/update-helm-chart.yml
@@ -16,3 +16,5 @@ jobs:
           github_app_private_key: ${{ secrets.CRUCIBLE_HELM_UPDATE_PRIVATE_KEY }}
           chart_file: charts/gameboard/charts/gameboard-api/Chart.yaml
           parent_chart_file: charts/gameboard/Chart.yaml
+          settings_file: src/Gameboard.Api/appsettings.conf
+          settings_file_kind: dotnet-conf


### PR DESCRIPTION
Adds settings_file and settings_file_kind inputs so the update-helm-chart action propagates added/removed keys from src/Gameboard.Api/appsettings.conf into the helm chart's env: block.